### PR TITLE
BCDA-30: Scripts to generate release tags and create github release 

### DIFF
--- a/ops/github_release.py
+++ b/ops/github_release.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+
+def main(release, release_file):
+    access_token = os.environ['GITHUB_ACCESS_TOKEN']
+
+    with open(release_file, 'r') as f:
+        data = {
+            "tag_name": release,
+            "name": release,
+            "body": f.read(),
+            "draft": False,
+            "prerelease": False
+        }
+
+        base_url = "https://api.github.com"
+        path = "/repos/CMSgov/bcda-app/releases"
+        headers = {
+            "Authorization": "token %s" % access_token
+        }
+
+        req = urllib.request.Request(
+            base_url + path, data=json.dumps(data).encode('utf-8'),
+            headers=headers,
+            method='POST'
+        )
+        resp = urllib.request.urlopen(req)
+
+    if resp.status != 201:
+        print("Could not create release: %s" % release)
+        sys.exit(1)
+    else:
+        print("Successfully created release: %s" % release)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--release', dest='release', type=str,
+        help='The version tag/identifier for the release'
+    )
+
+    parser.add_argument(
+        '--release-file', dest='release_file', type=str,
+        help='Path to file with body of release notes'
+    )
+
+    args = parser.parse_args()
+
+    main(args.release, args.release_file)

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+PROJECT_NAME="Beneficiary Claims Data API"
+GITHUB_REPO="CMSgov/bcda-app"
+ORIGIN="${BCDA_GIT_ORIGIN:-"origin"}"
+
+usage() {
+    cat <<EOF >&2
+Start a new $PROJECT_NAME release.
+
+Usage: GITHUB_ACCESS_TOKEN=<gh_access_token> $(basename "$0") [-ch] [-t previous-tag new-tag]
+
+Options:
+  -h    print this help text and exit
+  -t    manually specify tags
+  -p    automatically push new tags to $ORIGIN.
+EOF
+}
+
+MANUAL_TAGS=
+while getopts ":chtp" opt; do
+    case "$opt" in
+        t)
+            MANUAL_TAGS=1
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [ $# -lt 2 ] && [ -n "$MANUAL_TAGS" ]
+then
+  usage
+  exit 1
+fi
+
+if [ -z "$(echo $(python -V) | grep "Python 3")" ]
+then
+  echo "Python 3+ is required"
+  exit 1
+fi
+
+if [ -z "$GITHUB_ACCESS_TOKEN" ]
+then
+  echo "Please export GITHUB_ACCESS_TOKEN to continue">&2
+  exit 1
+fi
+
+if [ ! -f ".travis.yml" ]
+then
+  echo "Must run script in top-level project directory.">&2
+  exit 1
+fi
+
+# fetch tags before any tag lookups so we have the most up-to-date list
+# and generate the correct next release number
+git fetch --tags
+
+if [ -n "$MANUAL_TAGS" ]; then
+  PREVTAG="$1"
+  NEWTAG="$2"
+  PREVRELEASENUM=${PREVTAG//^r/}
+  NEWRELEASENUM=${NEWTAG//^r/}
+else
+  PREVTAG=$(git tag | sort -n | tail -1)
+  if [ ! -n "$PREVTAG" ]; then
+      PREVTAG="r0"
+      PREVRELEASENUM=0
+  else
+      PREVRELEASENUM=$(git tag | grep '^r[0-9]' | sed 's/^r//' | sort -n | tail -1)
+  fi
+  NEWRELEASENUM=$(($PREVRELEASENUM + 1))
+  PREVTAG="r$PREVRELEASENUM"
+  NEWTAG="r$NEWRELEASENUM"
+fi
+
+TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
+
+commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
+
+echo "$NEWTAG - $(date +%Y-%m-%d)" > $TMPFILE
+echo "================" >> $TMPFILE
+echo "" >> $TMPFILE
+echo "$commits" >> $TMPFILE
+echo "" >> $TMPFILE
+
+git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
+
+python ./ops/github_release.py --release $NEWTAG --release-file $TMPFILE
+
+rm $TMPFILE
+
+echo "Release $NEWTAG created."
+echo

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -74,7 +74,6 @@ if [ -n "$MANUAL_TAGS" ]; then
 else
   PREVTAG=$(git tag | sort -n | tail -1)
   if [ ! -n "$PREVTAG" ]; then
-      PREVTAG="r0"
       PREVRELEASENUM=0
   else
       PREVRELEASENUM=$(git tag | grep '^r[0-9]' | sed 's/^r//' | sort -n | tail -1)
@@ -86,7 +85,12 @@ fi
 
 TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
 
-commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
+if [ $PREVRELEASENUM -gt 0 ]
+then
+  commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
+else
+  commits=$(git log --pretty=format:"- %s" HEAD)
+fi
 
 echo "$NEWTAG - $(date +%Y-%m-%d)" > $TMPFILE
 echo "================" >> $TMPFILE

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -15,7 +15,6 @@ Usage: GITHUB_ACCESS_TOKEN=<gh_access_token> $(basename "$0") [-ch] [-t previous
 Options:
   -h    print this help text and exit
   -t    manually specify tags
-  -p    automatically push new tags to $ORIGIN.
 EOF
 }
 


### PR DESCRIPTION
### Fixes [BCDA-30](https://jira.cms.gov/browse/BCDA-30)

Adds `ops/release.sh` and `ops/github_release.py`. Used together, these scripts create a release tag and github release complete with release notes based on git commit history.

The `release.sh` script inspects git tags to determine the previous release tag/number, increments by 1 and creates a new tag and release based on the updated number. 

This script also calls `github_release.py`. The github release script requires python 3+ to work properly.

Usage:

```sh
GITHUB_ACCESS_TOKEN=<gh_access_token> ./ops/release.sh
```