### PR TITLE
BCDA-96: Add a license doc

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+## This project is in the worldwide public domain
+
+As a work of the United States government, this project is in the public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+### CC0 1.0 Universal Summary
+
+This is a human-readable summary of the
+[Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+#### No copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+#### Other information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+### Contributions to this project
+
+This project is not accepting contributions at this time. However, feedback and questions are welcome and may be submitted via the [Beneficiary Claims Data API Google Group](https://groups.google.com/forum/#!forum/bc-api).


### PR DESCRIPTION
### Fixes [BCDA-96](https://jira.cms.gov/browse/BCDA-96)

- Adds a license doc indicating the project is public domain in the United States and worldwide under CC0 1.0
- Points would-be contributors to the BCDA Google Group for feedback and questions
