### PR TITLE
BCDA-147: Add UUID to access token claims

### DIFF
--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -172,10 +172,10 @@ func (backend *JWTAuthenticationBackend) IsBlacklisted(token *jwt.Token) bool {
 
 	const sqlstr = `SELECT value ` +
 		`FROM public.tokens ` +
-		`WHERE user_id = $1 ` +
+		`WHERE uuid = $1 ` +
 		`AND active = false`
 
-	rows, err := db.Query(sqlstr, claims["sub"])
+	rows, err := db.Query(sqlstr, claims["id"])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -107,6 +107,7 @@ func (backend *JWTAuthenticationBackend) GenerateToken(userID string, acoID stri
 		"iat": time.Now().Unix(),
 		"sub": userID,
 		"aco": acoID,
+		"id":  uuid.NewUUID(),
 	}
 	tokenString, err := token.SignedString(backend.PrivateKey)
 	if err != nil {
@@ -122,11 +123,13 @@ func (backend *JWTAuthenticationBackend) RevokeToken(tokenString string) error {
 		return errors.New("Could not read token claims")
 	}
 
+	tokenID := claims["id"].(string)
 	userID := claims["sub"].(string)
 
 	hash := Hash{}
 
 	token := models.Token{
+		UUID:   uuid.Parse(tokenID),
 		UserID: uuid.Parse(userID),
 		Value:  hash.Generate(tokenString),
 		Active: false,
@@ -135,11 +138,24 @@ func (backend *JWTAuthenticationBackend) RevokeToken(tokenString string) error {
 	db := database.GetDbConnection()
 	defer db.Close()
 
-	err := token.Insert(db)
+	var err error
+
+	if token.Exists() {
+		err = token.Update(db)
+	} else {
+
+		const sqlstr = `INSERT INTO public.tokens (` +
+			`uuid, user_id, value, active` +
+			`) VALUES (` +
+			`$1, $2, $3, $4` +
+			`)`
+
+		_, err = db.Exec(sqlstr, token.UUID, token.UserID, token.Value, false)
+	}
+
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/db/api.sql
+++ b/db/api.sql
@@ -25,7 +25,7 @@ create table jobs (
 );
 
 create table tokens (
-  id serial not null primary key,
+  uuid uuid not null primary key,
   user_id uuid not null references users,
   value text not null,
   active boolean not null default false


### PR DESCRIPTION
<!-- Replace xxx with the JIRA ticket number: -->
### Fixes [BCDA-147](https://jira.cms.gov/browse/BCDA-147)
Our current process of finding tokens by user ID when checking to see if they've been blacklisted could be slow if many tokens exist for a user.

### Proposed changes:
Add a UUID to the token claims and replace serial ID with application-generated UUID in the tokens table. Search on UUID when checking to see if a token is active.


### Change Details
* `GenerateToken()` adds a UUID to the JWT claims
* `RevokeToken()` saves the UUID to the database
* `IsBlacklisted()` queries by token UUID


### Security Implications
This impacts the way we revoke token access.


### Acceptance Validation
All auth backend tests still passing.


### Feedback Requested
General review - any improvements to be made?
