### PR TITLE
BCDA-234: Containerize Unit Tests

### DIFF
--- a/Dockerfiles/Dockerfile.unit_test
+++ b/Dockerfiles/Dockerfile.unit_test
@@ -1,0 +1,16 @@
+FROM golang:1.10.3
+
+RUN openssl genrsa -out /var/local/private.pem 2048
+RUN openssl rsa -in /var/local/private.pem -outform PEM -pubout -out /var/local/public.pem
+
+RUN go get github.com/tools/godep
+RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN go get -u github.com/xo/usql
+
+WORKDIR /go/src/github.com/CMSgov/bcda-app
+COPY . .
+
+RUN godep restore ./...
+
+WORKDIR /go/src/github.com/CMSgov/bcda-app
+CMD ["sh", "unit_test.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,22 @@
 models:
+	docker-compose up -d db
+	echo "Waiting for db to be ready..."
+	sleep 5	
 	PGSSLMODE=disable xo postgresql://postgres:toor@localhost:5432/bcda -o models
 
 test:
-	golangci-lint run
-	docker-compose up -d db && sleep 5
-	PGPASSWORD=toor psql -U postgres -h localhost -p 5432 -q -c 'drop database if exists bcda_test;'
-	PGPASSWORD=toor psql -U postgres -h localhost -p 5432 -q -c 'create database bcda_test;'
-	PGPASSWORD=toor psql -U postgres -h localhost -p 5432 -q -f db/api.sql bcda_test
-	PGPASSWORD=toor psql -U postgres -h localhost -p 5432 -q -f db/fixtures.sql bcda_test
-	DATABASE_URL="postgresql://postgres:toor@localhost:5432/bcda_test?sslmode=disable" go test -v -race ./...
-	PGPASSWORD=toor psql -U postgres -h localhost -p 5432 -q -c 'drop database bcda_test;'
+	docker-compose up -d db
+	docker-compose -f docker-compose.test.yml up
 
 load-fixtures:
 	docker-compose up -d db
 	echo "Wait for db to be ready..."
 	sleep 5
-	psql "postgresql://postgres:toor@localhost:5432/bcda" -f db/fixtures.sql
-	docker-compose stop db
+	usql "postgres://postgres:toor@localhost:5432/bcda?sslmode=disable" -f db/fixtures.sql
 
 docker-build:
 	docker-compose build
+	docker-compose -f docker-compose.test.yml build
 
 docker-bootstrap: docker-build load-fixtures
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ load-fixtures:
 	docker-compose up -d db
 	echo "Wait for db to be ready..."
 	sleep 5
-	usql "postgres://postgres:toor@localhost:5432/bcda?sslmode=disable" -f db/fixtures.sql
+	docker-compose run -v $(shell pwd)/db:/tmp/db db psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /tmp/db/fixtures.sql
 
 docker-build:
 	docker-compose build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ load-fixtures:
 	docker-compose up -d db
 	echo "Wait for db to be ready..."
 	sleep 5
-	docker-compose run -v $(shell pwd)/db:/tmp/db db psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /tmp/db/fixtures.sql
+	docker-compose exec db psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /var/db/fixtures.sql
 
 docker-build:
 	docker-compose build

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ To get started:
 2. Install [Docker](https://docs.docker.com/install/)
 3. Install [Docker Compose](https://docs.docker.com/compose/install/)
 4. Install [xo](https://github.com/xo/xo)
-5. Install [usql](https://github.com/xo/usql) by running command ``` go get -u github.com/xo/usql ```
-6. From the root of the project repository run:
+5. Install [usql](https://github.com/xo/usql)
+6. Ensure all dependencies installed above are on PATH and can be executed directly from command line.
 
 ```sh
 make docker-bootstrap

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ To get started:
 2. Install [Docker](https://docs.docker.com/install/)
 3. Install [Docker Compose](https://docs.docker.com/compose/install/)
 4. Install [xo](https://github.com/xo/xo)
-5. Install [usql](https://github.com/xo/usql)
-6. Ensure all dependencies installed above are on PATH and can be executed directly from command line.
-
+5. Ensure all dependencies installed above are on PATH and can be executed directly from command line.
+6. Build and start the app by running the following:
 ```sh
 make docker-bootstrap
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -6,10 +6,24 @@
 
 To get started:
 
-1. Install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
-1. From the root of the project repository run:
+1. Install [Go](https://golang.org/doc/install)
+2. Install [Docker](https://docs.docker.com/install/)
+3. Install [Docker Compose](https://docs.docker.com/compose/install/)
+4. Install [xo](https://github.com/xo/xo)
+5. Install [usql](https://github.com/xo/usql) by running command ``` go get -u github.com/xo/usql ```
+6. From the root of the project repository run:
 
 ```sh
 make docker-bootstrap
 docker-compose up
+```
+
+To interact with the app:
+1) Get a token: `http://localhost:3000/api/v1/token`
+2) POST to `http://localhost:3000/api/v1/claims` with `Authorization: Bearer <token>`
+
+
+To run tests:
+```
+make test
 ```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  unit_test:
+    build:
+      context: .
+      dockerfile: Dockerfiles/Dockerfile.unit_test
+    environment:
+      - DB_HOST_URL=postgresql://postgres:toor@db:5432?sslmode=disable
+      - TEST_DB_URL=postgresql://postgres:toor@db:5432/bcda_test?sslmode=disable
+    volumes:
+      - .:/go/src/github.com/CMSgov/bcda-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - "5432:5432"
     volumes:
       - ./db/api.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./db:/var/db
   api:
     build:
       context: .

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# This script is intended to be run from within the Docker "unit_test" container
+# The docker-compose file brings forward the env vars: DB_HOST_URL and TEST_DB_URL
+#
+
+echo "Running linter..."
+golangci-lint run
+
+echo "Setting up test DB (bcda_test)..."
+echo "DB_HOST_URL is $DB_HOST_URL"
+echo "TEST_DB_URL is $TEST_DB_URL"
+usql $DB_HOST_URL -c 'drop database if exists bcda_test;'
+usql $DB_HOST_URL -c 'create database bcda_test;'
+usql $TEST_DB_URL -f db/api.sql
+usql $TEST_DB_URL -f db/fixtures.sql
+
+echo "Running unit tests..."
+DATABASE_URL=$TEST_DB_URL go test -v -race ./...
+
+echo "Cleaning up test DB (bcda_test)..."
+usql $DB_HOST_URL -c 'drop database bcda_test;'


### PR DESCRIPTION
The intent of BCDA-234 is to:
1) Containerize the unit tests to ensure they are run in an environment that we know is stable through automation.  This removes the need to install extraneous dependencies on host machine.
2) Remove local dependency on `psql` (which is bloated) and replace with `usql` (which is lean)
3) Beef up README with more details on how to set up environment, how to run tests, and how to interact with the app