### PR TITLE
BCDA-235: Generate test coverage metrics/reports 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.DS_Store
 bcda/bcda
 bcdaworker/bcdaworker
+test_results/*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ models:
 
 test:
 	docker-compose up -d db
-	docker-compose -f docker-compose.test.yml up
+	docker-compose -f docker-compose.test.yml up --force-recreate
 
 load-fixtures:
 	docker-compose up -d db

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Build the images and start the containers:
 1. Build the images
 ```sh
 make docker-bootstrap
+```
 2. Start the containers
 ```sh
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -2,27 +2,43 @@
 
 [![Build Status](https://travis-ci.org/CMSgov/bcda-app.svg?branch=master)](https://travis-ci.org/CMSgov/bcda-app)
 
-### Local development
 
-To get started:
+### Dependencies
+
+To get started, install some dependencies:
 
 1. Install [Go](https://golang.org/doc/install)
 2. Install [Docker](https://docs.docker.com/install/)
 3. Install [Docker Compose](https://docs.docker.com/compose/install/)
 4. Install [xo](https://github.com/xo/xo)
 5. Ensure all dependencies installed above are on PATH and can be executed directly from command line.
-6. Build and start the app by running the following:
+
+
+### Build / Start
+
+Build the images and start the containers:
+
+1. Build the images
 ```sh
 make docker-bootstrap
+2. Start the containers
+```sh
 docker-compose up
 ```
 
-To interact with the app:
-1) Get a token: `http://localhost:3000/api/v1/token`
-2) POST to `http://localhost:3000/api/v1/claims` with `Authorization: Bearer <token>`
+### Test
 
+Run tests and produce test metrics:
 
-To run tests:
-```
+1. Run tests (this places results and a coverage report in test_results/<timestamp>):
+```sh
 make test
 ```
+
+
+### Use the application
+
+To interact with the app:
+
+1) Get a token: `http://localhost:3000/api/v1/token`
+2) POST to `http://localhost:3000/api/v1/claims` with `Authorization: Bearer <token>`

--- a/bcda/database/connection_test.go
+++ b/bcda/database/connection_test.go
@@ -1,0 +1,3 @@
+package database_test
+
+// TODO: placeholder for tests

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -1,0 +1,3 @@
+package logging_test
+
+// TODO: placeholder for logging tests

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -1,0 +1,3 @@
+package main_test
+
+// TODO: placeholder for tests

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,7 +6,6 @@ services:
       context: .
       dockerfile: Dockerfiles/Dockerfile.unit_test
     environment:
-      - DB_HOST_URL=postgresql://postgres:toor@db:5432?sslmode=disable
-      - TEST_DB_URL=postgresql://postgres:toor@db:5432/bcda_test?sslmode=disable
+      - DB=postgresql://postgres:toor@db:5432
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-
 #
 # This script is intended to be run from within the Docker "unit_test" container
-# The docker-compose file brings forward the env vars: DB_HOST_URL and TEST_DB_URL
+# The docker-compose file brings forward the env vars: DB
 #
 
 echo "Running linter..."
 golangci-lint run
 
 echo "Setting up test DB (bcda_test)..."
+DB_HOST_URL=${DB}?sslmode=disable
+TEST_DB_URL=${DB}/bcda_test?sslmode=disable
 echo "DB_HOST_URL is $DB_HOST_URL"
 echo "TEST_DB_URL is $TEST_DB_URL"
 usql $DB_HOST_URL -c 'drop database if exists bcda_test;'
@@ -16,8 +17,14 @@ usql $DB_HOST_URL -c 'create database bcda_test;'
 usql $TEST_DB_URL -f db/api.sql
 usql $TEST_DB_URL -f db/fixtures.sql
 
-echo "Running unit tests..."
-DATABASE_URL=$TEST_DB_URL go test -v -race ./...
+timestamp=`date +%Y-%m-%d_%H-%M-%S`
+echo "Running unit tests and placing results/coverage in test_results/${timestamp} on host..."
+mkdir -p test_results/${timestamp}
+DATABASE_URL=$TEST_DB_URL go test -v -race ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
+echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
+go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html
+
 
 echo "Cleaning up test DB (bcda_test)..."
 usql $DB_HOST_URL -c 'drop database bcda_test;'


### PR DESCRIPTION
Test coverage metrics and reports are generated as part of `make test`, and the resulting reports are output in the `test_results` folder on the host (individual timestamped folders are created in `test_results` in order to separate the metrics by test run).  

The files that are generated are:
1) `testresults.out` -- Results of test case execution
2) `testcoverage.out` -- Generic test coverage file generated by `-coverprofile`
3) `testcov_byfunc.out` -- Test coverage metrics by function
4) `testcoverage.html` -- Highlighted test coverage analysis for each go file

See attached to see examples of the outputs.

[testcovfiles.zip](https://github.com/CMSgov/bcda-app/files/2371227/testcovfiles.zip)

Two additional things to note:
1) Empty test files were created in some of our packages which did not have test cases, to be used as placeholders so coverage could be generated for those particular go files.  We will need to create test cases for these packages (examples: logging, database).
2) Test metrics are reported at the unit level.  That means that if a test is executed and calls a function in another package under the covers, test coverage is not reported for that as we have gone outside of the unit level.
