### PR TITLE
BCDA-195 Feature: returning FHIR bulk responses for errors

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -123,18 +123,55 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 
 		jsonData, err := json.Marshal(rb)
 		if err != nil {
+			errorStatus := createOperationOutcome("marshalling error")
+			_, err = w.Write([]byte(errorStatus))
+			if err != nil {
+				http.Error(w, http.StatusText(500), 500)
+				return
+			}
 			http.Error(w, http.StatusText(500), 500)
 			return
 		}
 
 		_, err = w.Write([]byte(jsonData))
 		if err != nil {
+			errorStatus := createOperationOutcome("writing error")
+			_, err = w.Write([]byte(errorStatus))
+			if err != nil {
+				http.Error(w, http.StatusText(500), 500)
+				return
+			}
 			http.Error(w, http.StatusText(500), 500)
 			return
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}
 	}
+}
+
+func createOperationOutcome(outcome string) []byte {
+	is := issue {
+		Severity: "",
+		Code: "",
+		Details: codeableConcept{nil,""},
+		Diagnostics: "",
+		Location: nil,
+		Expression: nil,
+	}
+
+	oo := operationOutcomeBody{
+		ResourceType: "OperationOutcome",
+		Id: outcome,
+		Text: "",
+		Issue: []issue{is},
+	}
+
+	jsonData, err := json.Marshal(oo)
+	if err != nil {
+		log.Fatal(err)
+		return nil
+	}
+	return jsonData
 }
 
 func serveData(w http.ResponseWriter, r *http.Request) {

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -40,6 +40,28 @@ type bulkResponseBody struct {
 	Errors              []fileItem `json:"error"`
 }
 
+type codeableConcept struct {
+	Coding  []string `json:"coding"`
+	Text    string   `json:"text"`
+}
+
+type issue struct {
+	Severity    string           `json:"severity"`
+	Code        string           `json:"code"`
+	Details     codeableConcept  `json:"details"`
+	Diagnostics string           `json:"diagnostics"`
+	Location    []string         `json:"location"`
+	Expression  []string         `json:"expression"`
+}
+
+type operationOutcomeBody struct {
+    ResourceType  string     `json:"resourceType"`
+    Id            string     `json:"id"`
+    Text          string     `json:"text"`
+    Issue         []issue    `json:"issue"`
+}
+
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "bcda"


### PR DESCRIPTION
When a user request a job status response the state of that job should be accurate and represented in a format that meets the FHIR Bulk guidelines.

Proposed changes:
Added error response handling for the Failed status to match the output format in the spec. Taken directly from the spec. "The body MUST be a FHIR OperationOutcome in JSON format". All of the other responses were already handled (Pending, In Progress, Completed) (I think Emily did them, but I could be wrong). For expired status see ticket: (https://jira.cms.gov/browse/BCDA-294)

Change Details:
* Added a struct to match the operation outcome response to the bcda api classes. (main.go)
* Also added the error handling for request being made during the job status generation. Once we actually start processing jobs (anything that's more than serving up a static file), then the job "Failed" status can be added during processing. Added the creation of the operation outcome response in this class as well. (api.go)

Security Implications:
Currently there are no security implications but a conversation about how much data we're willing to output in our error responses should take place. see ticket (https://jira.cms.gov/browse/BCDA-293)

Acceptance Validation:
I was able to test the changes by manipulating a status to "Failed" in the db, then added some code to see the operation outcome response. Currently it's hard to test a failed status because nothing is really setting a status to "Failed" yet. But this will obviously change once we start file/data processing.

Feedback Requested
Anything