### PR TITLE
GORM bug fixes, style changes

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -3,12 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/bcdaModels"
 	"net/http"
 	"strconv"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	que "github.com/bgentry/que-go"
 	jwt "github.com/dgrijalva/jwt-go"
 	fhirmodels "github.com/eug48/fhir/models"
@@ -47,7 +47,7 @@ func bulkRequest(w http.ResponseWriter, r *http.Request) {
 		scheme = "https"
 	}
 
-	newJob := bcdaModels.Job{
+	newJob := models.Job{
 		AcoID:      uuid.Parse(acoId),
 		UserID:     uuid.Parse(userId),
 		RequestURL: fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL),
@@ -95,7 +95,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(400), 400)
 		return
 	}
-	var job bcdaModels.Job
+	var job models.Job
 	err = db.First(&job, i).Error
 	if err != nil {
 		log.Print(err)

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -53,7 +53,7 @@ func bulkRequest(w http.ResponseWriter, r *http.Request) {
 		RequestURL: fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL),
 		Status:     "Pending",
 	}
-	if err := db.Save(newJob); err != nil {
+	if result := db.Save(&newJob); result.Error != nil {
 		log.Error(err)
 		writeError(fhirmodels.OperationOutcome{}, w)
 		return

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/CMSgov/bcda-app/bcda/bcdaModels"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/go-chi/chi"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
@@ -24,7 +24,7 @@ type APITestSuite struct {
 }
 
 func (s *APITestSuite) SetupTest() {
-	bcdaModels.InitializeGormModels()
+	models.InitializeGormModels()
 	s.db = database.GetGORMDbConnection()
 
 	s.rr = httptest.NewRecorder()
@@ -43,7 +43,7 @@ func (s *APITestSuite) TestBulkRequestMissingToken() {
 }
 
 func (s *APITestSuite) TestJobStatusPending() {
-	j := bcdaModels.Job{
+	j := models.Job{
 		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
@@ -70,7 +70,7 @@ func (s *APITestSuite) TestJobStatusPending() {
 }
 
 func (s *APITestSuite) TestJobStatusInProgress() {
-	j := bcdaModels.Job{
+	j := models.Job{
 		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
@@ -97,7 +97,7 @@ func (s *APITestSuite) TestJobStatusInProgress() {
 }
 
 func (s *APITestSuite) TestJobStatusFailed() {
-	j := bcdaModels.Job{
+	j := models.Job{
 		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
@@ -124,7 +124,7 @@ func (s *APITestSuite) TestJobStatusFailed() {
 }
 
 func (s *APITestSuite) TestJobStatusCompleted() {
-	j := bcdaModels.Job{
+	j := models.Job{
 		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -10,7 +10,6 @@ import (
 
 func InitializeGormModels() *gorm.DB {
 	db := database.GetGORMDbConnection()
-
 	defer db.Close()
 
 	// Migrate the schema
@@ -30,16 +29,6 @@ type ACO struct {
 	Name string    `json:"name"`                                   // name
 }
 
-type Job struct {
-	gorm.Model
-	Aco        ACO       `gorm:"foreignkey:AcoID;association_foreignkey:UUID"` // aco
-	AcoID      uuid.UUID `gorm:"primary_key; type:char(36)" json:"aco_id"`
-	User       User      `gorm:"foreignkey:UserID;association_foreignkey:UUID"` // user
-	UserID     uuid.UUID `gorm:"type:char(36)"`
-	RequestURL string    `json:"request_url"` // request_url
-	Status     string    `json:"status"`      // status
-}
-
 type Token struct {
 	gorm.Model
 	UUID   uuid.UUID `gorm:"primary_key" json:"uuid"` // uuid
@@ -47,7 +36,6 @@ type Token struct {
 	UserID uuid.UUID `json:"user_id"`                                // user_id
 	Value  string    `gorm:"type:varchar(511); unique" json:"value"` // value
 	Active bool      `json:"active"`                                 // active
-
 }
 
 func (token *Token) BeforeSave() error {

--- a/bcda/database/connection.go
+++ b/bcda/database/connection.go
@@ -20,7 +20,6 @@ func GetDbConnection() *sql.DB {
 }
 
 func GetGORMDbConnection() *gorm.DB {
-
 	databaseURL := os.Getenv("DATABASE_URL")
 	db, err := gorm.Open("postgres", databaseURL)
 	if err != nil {

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/bcdaModels"
 	"net/http"
 	"os"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/urfave/cli"
 
 	"github.com/bgentry/que-go"
@@ -82,10 +82,15 @@ func main() {
 				qc = que.NewClient(pgxpool)
 
 				fmt.Println("Starting bcda...")
+				if os.Getenv("DEBUG") == "true" {
+					autoMigrate()
+				}
+
 				err = http.ListenAndServe(":3000", NewRouter())
 				if err != nil {
 					return err
 				}
+
 				return nil
 			},
 		},
@@ -185,15 +190,11 @@ func main() {
 			},
 		},
 		{
-			Name:     "sqlMigrate",
+			Name:     "sql-migrate",
 			Category: "Database tools",
 			Usage:    "Migrate GORM schema changes to the DB",
 			Action: func(c *cli.Context) error {
-				fmt.Println("Initializing Database")
-				// Initialize models to get the database in the right spot
-				bcdaModels.InitializeGormModels()
-				auth.InitializeGormModels()
-				fmt.Println("Completed Database Initialization")
+				autoMigrate()
 				return nil
 			},
 		},
@@ -203,6 +204,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func autoMigrate() {
+	fmt.Println("Initializing Database")
+	models.InitializeGormModels()
+	auth.InitializeGormModels()
+	fmt.Println("Completed Database Initialization")
 }
 
 func createACO(name string) (string, error) {

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -1,4 +1,4 @@
-package bcdaModels
+package models
 
 import (
 	"github.com/CMSgov/bcda-app/bcda/auth"
@@ -9,7 +9,6 @@ import (
 
 func InitializeGormModels() *gorm.DB {
 	db := database.GetGORMDbConnection()
-
 	defer db.Close()
 
 	// Migrate the schema

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/bcdaModels"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/bgentry/que-go"
 	"github.com/jackc/pgx"
 	"log"
@@ -37,7 +37,7 @@ func processJob(j *que.Job) error {
 		return err
 	}
 
-	var exportJob bcdaModels.Job
+	var exportJob models.Job
 	err = db.First(&exportJob, "ID = ?", jobArgs.ID).Error
 	if err != nil {
 		return err


### PR DESCRIPTION
A couple bug fixes and code style/naming changes.

### Proposed changes:

- Fixes error checking when creating a new job record
- Removes redundant bcda from name of models package
- Removes duplicate `Job` definition from `auth/models.go`
- Auto runs gorm migrations when env var `DEBUG=true` (e.g., local dev env)
- Changes `bcda sqlMigrate` to `bcda sql-migrate` to match the rest of the cli commands