### PR TITLE
BCDA-256 Feature: Unit test for db connections

### DIFF
--- a/bcda/database/connection.go
+++ b/bcda/database/connection.go
@@ -4,26 +4,30 @@ import (
 	"database/sql"
 	"log"
 	"os"
-
 	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/postgres"
-	_ "github.com/lib/pq"
+        _ "github.com/jinzhu/gorm/dialects/postgres"
+        _ "github.com/lib/pq"
 )
+
+// Variable substitution to support testing.
+var logFatal = log.Fatal
 
 func GetDbConnection() *sql.DB {
 	databaseURL := os.Getenv("DATABASE_URL")
-	db, err := sql.Open("postgres", databaseURL)
-	if err != nil {
-		log.Fatal(err)
+	db, _ := sql.Open("postgres", databaseURL)
+	pingErr := db.Ping()
+	if pingErr != nil {
+		logFatal(pingErr)
 	}
 	return db
 }
 
 func GetGORMDbConnection() *gorm.DB {
 	databaseURL := os.Getenv("DATABASE_URL")
-	db, err := gorm.Open("postgres", databaseURL)
-	if err != nil {
-		log.Fatal(err)
+	db, _ := gorm.Open("postgres", databaseURL)
+	pingErr := db.DB().Ping()
+	if pingErr != nil {
+		logFatal(pingErr)
 	}
 	return db
 }

--- a/bcda/database/connection.go
+++ b/bcda/database/connection.go
@@ -2,11 +2,11 @@ package database
 
 import (
 	"database/sql"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+	_ "github.com/lib/pq"
 	"log"
 	"os"
-	"github.com/jinzhu/gorm"
-        _ "github.com/jinzhu/gorm/dialects/postgres"
-        _ "github.com/lib/pq"
 )
 
 // Variable substitution to support testing.

--- a/bcda/database/connection_test.go
+++ b/bcda/database/connection_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"os"
 	"testing"
-    	"os"
-)	
+)
 
 type ConnectionTestSuite struct {
 	suite.Suite
-	db *sql.DB
+	db     *sql.DB
 	gormdb *gorm.DB
 }
 
@@ -20,47 +20,46 @@ func (suite *ConnectionTestSuite) TestDbConnections() {
 
 	// after this test, replace the original log.Fatal() function
 	origLogFatal := logFatal
-    	defer func() { logFatal = origLogFatal } ()       
-	
+	defer func() { logFatal = origLogFatal }()
+
 	// create the mock version of log.Fatal()
 	logFatal = func(args ...interface{}) {
-		fmt.Println("FATAL (NO-OP)")	
+		fmt.Println("FATAL (NO-OP)")
 	}
 
 	// get the real database URL
 	actualDatabaseURL := os.Getenv("DATABASE_URL")
-       
-    	// set the database URL to a bogus value to test negative scenarios
-    	os.Setenv("DATABASE_URL", "fake_db_url")
-      
+
+	// set the database URL to a bogus value to test negative scenarios
+	os.Setenv("DATABASE_URL", "fake_db_url")
+
 	// attempt to open DB connection swith the bogus DB string
-    	suite.db = GetDbConnection()
+	suite.db = GetDbConnection()
 	suite.gormdb = GetGORMDbConnection()
-	
+
 	// asert that Ping returns an error
 	assert.NotNil(suite.T(), suite.db.Ping(), fmt.Sprint("Database should fail to connect (negative scenario)"))
 	assert.NotNil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Gorm database should fail to connect (negative scenario)"))
-	
+
 	// close DBs to reset the test
 	suite.db.Close()
 	suite.gormdb.Close()
 
-    	// set the database URL back to the real value to test the positive scenarios
-    	os.Setenv("DATABASE_URL", actualDatabaseURL)
-        
+	// set the database URL back to the real value to test the positive scenarios
+	os.Setenv("DATABASE_URL", actualDatabaseURL)
+
 	suite.db = GetDbConnection()
 	defer suite.db.Close()
 
-    	suite.gormdb = GetGORMDbConnection()
-    	defer suite.gormdb.Close()
+	suite.gormdb = GetGORMDbConnection()
+	defer suite.gormdb.Close()
 
 	// assert that Ping() does not return an error
-    	assert.Nil(suite.T(), suite.db.Ping(), fmt.Sprint("Error connecting to sql database"))
-    	assert.Nil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Error connecting to gorm database "))
+	assert.Nil(suite.T(), suite.db.Ping(), fmt.Sprint("Error connecting to sql database"))
+	assert.Nil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Error connecting to gorm database "))
 
 }
 
 func TestConnectionTestSuite(t *testing.T) {
 	suite.Run(t, new(ConnectionTestSuite))
 }
-

--- a/bcda/database/connection_test.go
+++ b/bcda/database/connection_test.go
@@ -1,3 +1,32 @@
 package database_test
 
-// TODO: placeholder for tests
+import (
+	"database/sql"
+	"fmt"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type ConnectionTestSuite struct {
+	suite.Suite
+	db *sql.DB
+	gormdb *gorm.DB
+}
+
+func (suite *ConnectionTestSuite) TestDbConnections() {
+	suite.db = database.GetDbConnection()
+	defer suite.db.Close()
+
+	suite.gormdb = database.GetGORMDbConnection()
+	defer suite.gormdb.Close()
+
+	assert.NotNil(suite.T(), suite.db, fmt.Sprint("Error connecting to sql database"))
+	assert.NotNil(suite.T(), suite.gormdb, fmt.Sprint("Error connecting to gorm database "))
+}
+
+func TestConnectionTestSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionTestSuite))
+}

--- a/bcda/database/connection_test.go
+++ b/bcda/database/connection_test.go
@@ -1,14 +1,14 @@
-package database_test
+package database
 
 import (
 	"database/sql"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
-)
+    	"os"
+)	
 
 type ConnectionTestSuite struct {
 	suite.Suite
@@ -17,16 +17,50 @@ type ConnectionTestSuite struct {
 }
 
 func (suite *ConnectionTestSuite) TestDbConnections() {
-	suite.db = database.GetDbConnection()
+
+	// after this test, replace the original log.Fatal() function
+	origLogFatal := logFatal
+    	defer func() { logFatal = origLogFatal } ()       
+	
+	// create the mock version of log.Fatal()
+	logFatal = func(args ...interface{}) {
+		fmt.Println("FATAL (NO-OP)")	
+	}
+
+	// get the real database URL
+	actualDatabaseURL := os.Getenv("DATABASE_URL")
+       
+    	// set the database URL to a bogus value to test negative scenarios
+    	os.Setenv("DATABASE_URL", "fake_db_url")
+      
+	// attempt to open DB connection swith the bogus DB string
+    	suite.db = GetDbConnection()
+	suite.gormdb = GetGORMDbConnection()
+	
+	// asert that Ping returns an error
+	assert.NotNil(suite.T(), suite.db.Ping(), fmt.Sprint("Database should fail to connect (negative scenario)"))
+	assert.NotNil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Gorm database should fail to connect (negative scenario)"))
+	
+	// close DBs to reset the test
+	suite.db.Close()
+	suite.gormdb.Close()
+
+    	// set the database URL back to the real value to test the positive scenarios
+    	os.Setenv("DATABASE_URL", actualDatabaseURL)
+        
+	suite.db = GetDbConnection()
 	defer suite.db.Close()
 
-	suite.gormdb = database.GetGORMDbConnection()
-	defer suite.gormdb.Close()
+    	suite.gormdb = GetGORMDbConnection()
+    	defer suite.gormdb.Close()
 
-	assert.NotNil(suite.T(), suite.db, fmt.Sprint("Error connecting to sql database"))
-	assert.NotNil(suite.T(), suite.gormdb, fmt.Sprint("Error connecting to gorm database "))
+	// assert that Ping() does not return an error
+    	assert.Nil(suite.T(), suite.db.Ping(), fmt.Sprint("Error connecting to sql database"))
+    	assert.Nil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Error connecting to gorm database "))
+
 }
 
 func TestConnectionTestSuite(t *testing.T) {
 	suite.Run(t, new(ConnectionTestSuite))
 }
+


### PR DESCRIPTION
Fixes [BCDA-256](https://jira.cms.gov/browse/BCDA-256)

Problem:
Created unit test for our database connectivity. Previously there were none.

Proposed changes:
Added a test suite to connection_test.go (bcda/database/connection_test.go)

Security Implications:
None.

Acceptance Validation:
I wasn't able to fully get the unit test coverage to 100% due to the inability to properly test log statements. Not sure how to do that other than writing unit test for our logger itself which seems kinda excessive.
Take a look at this screenshot:
<img width="546" alt="screen shot 2018-09-24 at 9 12 04 am" src="https://user-images.githubusercontent.com/42976557/45954164-479c4700-bfda-11e8-981d-cf15a2b2cf2f.png">



Feedback Requested:
Any feedback. How can we get our test coverage to 100% with this problem? It's not just this test but for all of our test.