### PR TITLE
BCDA-231 Feature: Implemented metadata endpoint for capability statement

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -307,3 +307,8 @@ func blueButtonMetadata(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 }
+
+func metadata(w http.ResponseWriter, r *http.Request) {
+	statement := responseutils.CreateCapabilityStatement()
+	responseutils.WriteCapabilityStatement(statement, w)
+}

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -40,6 +40,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/client"
@@ -309,6 +310,7 @@ func blueButtonMetadata(w http.ResponseWriter, r *http.Request) {
 }
 
 func metadata(w http.ResponseWriter, r *http.Request) {
-	statement := responseutils.CreateCapabilityStatement()
+	dt := time.Now()
+	statement := responseutils.CreateCapabilityStatement(dt, "0.1")
 	responseutils.WriteCapabilityStatement(statement, w)
 }

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -311,6 +311,12 @@ func blueButtonMetadata(w http.ResponseWriter, r *http.Request) {
 
 func metadata(w http.ResponseWriter, r *http.Request) {
 	dt := time.Now()
-	statement := responseutils.CreateCapabilityStatement(dt, "0.1")
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	host := fmt.Sprintf("%s://%s", scheme, r.Host)
+	statement := responseutils.CreateCapabilityStatement(dt, "0.1", host)
 	responseutils.WriteCapabilityStatement(statement, w)
 }

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	fhirmodels "github.com/eug48/fhir/models"
 	"net/http"
+	"time"
 )
 
 func CreateOpOutcome(severity, code, detailsCode, detailsDisplay string) *fhirmodels.OperationOutcome {
@@ -22,4 +23,99 @@ func WriteError(outcome *fhirmodels.OperationOutcome, w http.ResponseWriter, cod
 	}
 }
 
-func WriteCapabilityStatement() {}
+func CreateCapabilityStatement() *fhirmodels.CapabilityStatement {
+	usecoors := true
+	dt := time.Now()
+	baseurl := "<host>"
+	statement := &fhirmodels.CapabilityStatement{
+		Status:       "active",
+		Date:         &fhirmodels.FHIRDateTime{Time: dt, Precision: fhirmodels.Date},
+		Publisher:    "Centers for Medicare & Medicaid Services",
+		Kind:         "capability",
+		Instantiates: []string{"https://api.bluebutton.cms.gov/v1/fhir/metadata"},
+		Software: &fhirmodels.CapabilityStatementSoftwareComponent{
+			Name:        "Beneficiary Claims Data API",
+			Version:     "0.1",
+			ReleaseDate: &fhirmodels.FHIRDateTime{Time: dt, Precision: fhirmodels.Date},
+		},
+		Implementation: &fhirmodels.CapabilityStatementImplementationComponent{
+			Description: "",
+			Url:         baseurl,
+		},
+		FhirVersion:   "3.0.1",
+		AcceptUnknown: "extensions",
+		Format:        []string{"application/json", "application/fhir+json"},
+		Rest: []fhirmodels.CapabilityStatementRestComponent{
+			{
+				Mode: "server",
+				Security: &fhirmodels.CapabilityStatementRestSecurityComponent{
+					Cors: &usecoors,
+					Service: []fhirmodels.CodeableConcept{
+						{
+							Coding: []fhirmodels.Coding{
+								{Display: "OAuth", Code: "OAuth", System: "http://hl7.org/fhir/ValueSet/restful-security-service"},
+							},
+							Text: "OAuth",
+						},
+						{
+							Coding: []fhirmodels.Coding{
+								{Display: "SMART-on-FHIR", Code: "SMART-on-FHIR", System: "http://hl7.org/fhir/ValueSet/restful-security-service"},
+							},
+							Text: "SMART-on-FHIR",
+						},
+					},
+				},
+				Interaction: []fhirmodels.CapabilityStatementSystemInteractionComponent{
+					{
+						Code: "batch",
+					},
+					{
+						Code: "search-system",
+					},
+				},
+				Operation: []fhirmodels.CapabilityStatementRestOperationComponent{
+					{
+						Name: "export",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/Patient/$export",
+							Type:      "Endpoint",
+						},
+					},
+					{
+						Name: "jobs",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/jobs/{jobId}",
+							Type:      "Endpoint",
+						},
+					},
+					{
+						Name: "token",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/token",
+							Type:      "Endpoint",
+						},
+					},
+					{
+						Name: "bb_metadata",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/bb_metadata",
+							Type:      "Endpoint",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return statement
+}
+
+func WriteCapabilityStatement(statement *fhirmodels.CapabilityStatement, w http.ResponseWriter) {
+	statementJSON, _ := json.Marshal(statement)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write(statementJSON)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -23,20 +23,19 @@ func WriteError(outcome *fhirmodels.OperationOutcome, w http.ResponseWriter, cod
 	}
 }
 
-func CreateCapabilityStatement() *fhirmodels.CapabilityStatement {
+func CreateCapabilityStatement(reldate time.Time, relversion string) *fhirmodels.CapabilityStatement {
 	usecoors := true
-	dt := time.Now()
 	baseurl := "<host>"
 	statement := &fhirmodels.CapabilityStatement{
 		Status:       "active",
-		Date:         &fhirmodels.FHIRDateTime{Time: dt, Precision: fhirmodels.Date},
+		Date:         &fhirmodels.FHIRDateTime{Time: reldate, Precision: fhirmodels.Date},
 		Publisher:    "Centers for Medicare & Medicaid Services",
 		Kind:         "capability",
 		Instantiates: []string{"https://api.bluebutton.cms.gov/v1/fhir/metadata"},
 		Software: &fhirmodels.CapabilityStatementSoftwareComponent{
 			Name:        "Beneficiary Claims Data API",
-			Version:     "0.1",
-			ReleaseDate: &fhirmodels.FHIRDateTime{Time: dt, Precision: fhirmodels.Date},
+			Version:     relversion,
+			ReleaseDate: &fhirmodels.FHIRDateTime{Time: reldate, Precision: fhirmodels.Date},
 		},
 		Implementation: &fhirmodels.CapabilityStatementImplementationComponent{
 			Description: "",
@@ -99,6 +98,13 @@ func CreateCapabilityStatement() *fhirmodels.CapabilityStatement {
 						Name: "bb_metadata",
 						Definition: &fhirmodels.Reference{
 							Reference: baseurl + "/api/v1/bb_metadata",
+							Type:      "Endpoint",
+						},
+					},
+					{
+						Name: "metadata",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/metadata",
 							Type:      "Endpoint",
 						},
 					},

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	fhirmodels "github.com/eug48/fhir/models"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -23,15 +24,15 @@ func WriteError(outcome *fhirmodels.OperationOutcome, w http.ResponseWriter, cod
 	}
 }
 
-func CreateCapabilityStatement(reldate time.Time, relversion string) *fhirmodels.CapabilityStatement {
+func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *fhirmodels.CapabilityStatement {
 	usecors := true
-	baseurl := "<host>"
+	bbServer := os.Getenv("BB_SERVER_LOCATION")
 	statement := &fhirmodels.CapabilityStatement{
 		Status:       "active",
 		Date:         &fhirmodels.FHIRDateTime{Time: reldate, Precision: fhirmodels.Date},
 		Publisher:    "Centers for Medicare & Medicaid Services",
 		Kind:         "capability",
-		Instantiates: []string{"https://api.bluebutton.cms.gov/v1/fhir/metadata"},
+		Instantiates: []string{bbServer + "/baseDstu3/metadata/"},
 		Software: &fhirmodels.CapabilityStatementSoftwareComponent{
 			Name:        "Beneficiary Claims Data API",
 			Version:     relversion,
@@ -84,20 +85,6 @@ func CreateCapabilityStatement(reldate time.Time, relversion string) *fhirmodels
 						Name: "jobs",
 						Definition: &fhirmodels.Reference{
 							Reference: baseurl + "/api/v1/jobs/{jobId}",
-							Type:      "Endpoint",
-						},
-					},
-					{
-						Name: "token",
-						Definition: &fhirmodels.Reference{
-							Reference: baseurl + "/api/v1/token",
-							Type:      "Endpoint",
-						},
-					},
-					{
-						Name: "bb_metadata",
-						Definition: &fhirmodels.Reference{
-							Reference: baseurl + "/api/v1/bb_metadata",
 							Type:      "Endpoint",
 						},
 					},

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -24,7 +24,7 @@ func WriteError(outcome *fhirmodels.OperationOutcome, w http.ResponseWriter, cod
 }
 
 func CreateCapabilityStatement(reldate time.Time, relversion string) *fhirmodels.CapabilityStatement {
-	usecoors := true
+	usecors := true
 	baseurl := "<host>"
 	statement := &fhirmodels.CapabilityStatement{
 		Status:       "active",
@@ -48,7 +48,7 @@ func CreateCapabilityStatement(reldate time.Time, relversion string) *fhirmodels
 			{
 				Mode: "server",
 				Security: &fhirmodels.CapabilityStatementRestSecurityComponent{
-					Cors: &usecoors,
+					Cors: &usecors,
 					Service: []fhirmodels.CodeableConcept{
 						{
 							Coding: []fhirmodels.Coding{

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -29,10 +29,10 @@ func NewRouter() http.Handler {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(auth.RequireTokenAuth).With(ValidateBulkRequestHeaders).Get("/Patient/$export", bulkRequest)
 		r.With(auth.RequireTokenAuth).Get("/jobs/{jobId}", jobStatus)
+		r.Get("/metadata", metadata)
 		if os.Getenv("DEBUG") == "true" {
 			r.Get("/token", getToken)
 			r.Get("/bb_metadata", blueButtonMetadata)
-			r.Get("/metadata", metadata)
 		}
 	})
 	r.With(auth.RequireTokenAuth).With(auth.RequireTokenACOMatch).Get("/data/{acoID}.ndjson", serveData)

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -32,6 +32,7 @@ func NewRouter() http.Handler {
 		if os.Getenv("DEBUG") == "true" {
 			r.Get("/token", getToken)
 			r.Get("/bb_metadata", blueButtonMetadata)
+			r.Get("/metadata", metadata)
 		}
 	})
 	r.With(auth.RequireTokenAuth).With(auth.RequireTokenACOMatch).Get("/data/{acoID}.ndjson", serveData)


### PR DESCRIPTION
Fixes [BCDA-231](https://jira.cms.gov/browse/BCDA-231)

Problem:
We needed a capability statement (FHIR compliant) as to what our API can do. And now we have one!!

Proposed changes:
router.go - added metadata endpoint
api.go - added http handler function to call for the creation of the capability statement
writer.go - added function for creating a capability statement and for writing the response.

Security Implications
None

Acceptance Validation
Try to hit the "/api/v1/metadata" and see if a capability statement is generated.

Feedback Requested
Any