### PR TITLE
BCDA-341: Automate tag/release process

### DIFF
--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -1,7 +1,8 @@
 FROM python:3.7-alpine3.8
 
+ARG GITHUB_ACCESS_TOKEN
 RUN apk update
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash git openssh openssl
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .

--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -7,9 +7,6 @@ RUN apk add --no-cache bash git gnupg
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
 
-RUN git config user.email "bcda-ci@adhocteam.us"
-RUN git config user.name "BCDA CI"
-
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app

--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -4,11 +4,11 @@ ARG GITHUB_ACCESS_TOKEN
 RUN apk update
 RUN apk add --no-cache bash git gnupg
 
-git config user.email "bcda-ci@adhocteam.us"
-git config user.name "BCDA CI"
-
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
+
+RUN git config user.email "bcda-ci@adhocteam.us"
+RUN git config user.name "BCDA CI"
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 

--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -1,14 +1,17 @@
 FROM python:3.7-alpine3.8
 
 ARG GITHUB_ACCESS_TOKEN
+ARG GITHUB_USER
+ARG GITHUB_EMAIL
+ARG GITHUB_GPG_KEY_FILE
+
 RUN apk update
 RUN apk add --no-cache bash git gnupg
-
-WORKDIR /go/src/github.com/CMSgov/bcda-app
-COPY . .
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
+COPY . .
+
 ENTRYPOINT ["bash", "ops/release.sh"]
 CMD []

--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -4,6 +4,9 @@ ARG GITHUB_ACCESS_TOKEN
 RUN apk update
 RUN apk add --no-cache bash git gnupg
 
+git config user.email "bcda-ci@adhocteam.us"
+git config user.name "BCDA CI"
+
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
 

--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -1,0 +1,13 @@
+FROM python:3.7-alpine3.8
+
+RUN apk update
+RUN apk add --no-cache bash
+
+WORKDIR /go/src/github.com/CMSgov/bcda-app
+COPY . .
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+WORKDIR /go/src/github.com/CMSgov/bcda-app
+ENTRYPOINT ["bash", "ops/release.sh", "-t"]
+CMD []

--- a/Dockerfiles/Dockerfile.release
+++ b/Dockerfiles/Dockerfile.release
@@ -2,7 +2,7 @@ FROM python:3.7-alpine3.8
 
 ARG GITHUB_ACCESS_TOKEN
 RUN apk update
-RUN apk add --no-cache bash git openssh openssl
+RUN apk add --no-cache bash git gnupg
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
@@ -10,5 +10,5 @@ COPY . .
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
-ENTRYPOINT ["bash", "ops/release.sh", "-t"]
+ENTRYPOINT ["bash", "ops/release.sh"]
 CMD []

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ debug-worker:
 	@-bash -c "trap 'docker-compose stop' EXIT; \
 		docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --no-deps -T --rm -v $(shell pwd):/go/src/github.com/CMSgov/bcda-app worker dlv debug"
 
-.PHONY: docker-build docker-bootstrap load-fixtures test debug-api debug-worker api-shell worker-shell package
+.PHONY: docker-build docker-bootstrap load-fixtures test debug-api debug-worker api-shell worker-shell package release

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ release:
 	# This target should be executed by passing in an argument representing the name of the tag for the release
         # For example: make package previous_tag=r1 new_tag=r2
 	docker build -t release -f Dockerfiles/Dockerfile.release .
-	docker run -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release $(previous_tag) $(new_tag)
+	docker run -e GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN} -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release $(previous_tag) $(new_tag)
 
 package:
 	# This target should be executed by passing in an argument reprsenting the version of the artifacts we are packaging

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 release:
 	docker build -t release -f Dockerfiles/Dockerfile.release .
-	docker run -e GITHUB_ACCESS_TOKEN='${GITHUB_ACCESS_TOKEN}' -e GITHUB_USER='${GITHUB_USER}' -e GITHUB_EMAIL='${GITHUB_EMAIL}' -e GITHUB_GPG_KEY_FILE='${GITHUB_GPG_KEY_FILE}' -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release
+	docker run --rm -e GITHUB_ACCESS_TOKEN='${GITHUB_ACCESS_TOKEN}' -e GITHUB_USER='${GITHUB_USER}' -e GITHUB_EMAIL='${GITHUB_EMAIL}' -e GITHUB_GPG_KEY_FILE='${GITHUB_GPG_KEY_FILE}' -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release
 
 package:
 	# This target should be executed by passing in an argument reprsenting the version of the artifacts we are packaging

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 release:
-	# This target should be executed by passing in an argument representing the name of the tag for the release
-        # For example: make package previous_tag=r1 new_tag=r2
 	docker build -t release -f Dockerfiles/Dockerfile.release .
-	docker run -e GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN} -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release $(previous_tag) $(new_tag)
+	docker run -e GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN} -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release
 
 package:
 	# This target should be executed by passing in an argument reprsenting the version of the artifacts we are packaging

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+release:
+	# This target should be executed by passing in an argument representing the name of the tag for the release
+        # For example: make package previous_tag=r1 new_tag=r2
+	docker build -t release -f Dockerfiles/Dockerfile.release .
+	docker run -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release $(previous_tag) $(new_tag)
+
 package:
 	# This target should be executed by passing in an argument reprsenting the version of the artifacts we are packaging
 	# For example: make package version=r1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 release:
 	docker build -t release -f Dockerfiles/Dockerfile.release .
-	docker run -e GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN} -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release
+	docker run -e GITHUB_ACCESS_TOKEN='${GITHUB_ACCESS_TOKEN}' -e GITHUB_USER='${GITHUB_USER}' -e GITHUB_EMAIL='${GITHUB_EMAIL}' -e GITHUB_GPG_KEY_FILE='${GITHUB_GPG_KEY_FILE}' -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release
 
 package:
 	# This target should be executed by passing in an argument reprsenting the version of the artifacts we are packaging

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -63,12 +63,13 @@ fi
 
 # fetch tags before any tag lookups so we have the most up-to-date list
 # and generate the correct next release number
-git fetch --tags
+git fetch https://${GITHUB_ACCESS_TOKEN}@github.com/CMSgov/bcda-app --tags
 
 if [ -n "$MANUAL_TAGS" ]; then
   PREVTAG="$1"
   NEWTAG="$2"
   PREVRELEASENUM=${PREVTAG//^r/}
+  echo ${PREVRELEASENUM}
   NEWRELEASENUM=${NEWTAG//^r/}
 else
   PREVTAG=$(git tag | sort -n | tail -1)
@@ -96,7 +97,6 @@ echo "================" >> $TMPFILE
 echo "" >> $TMPFILE
 echo "$commits" >> $TMPFILE
 echo "" >> $TMPFILE
-
 git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
 
 python ./ops/github_release.py --release $NEWTAG --release-file $TMPFILE

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -61,6 +61,14 @@ then
   exit 1
 fi
 
+# initialize git configuration if env vars are set
+if [ ! -z "$GITHUB_USER" ] && [ ! -z "$GITHUB_EMAIL" ] && [ ! -z "$GITHUB_GPG_KEY_FILE" ]
+then
+  git config user.name "$GITHUB_USER"
+  git config user.email "$GITHUB_EMAIL"
+  gpg --import $GITHUB_GPG_KEY_FILE
+fi
+
 # fetch tags before any tag lookups so we have the most up-to-date list
 # and generate the correct next release number
 git fetch https://${GITHUB_ACCESS_TOKEN}@github.com/CMSgov/bcda-app --tags
@@ -97,6 +105,7 @@ echo "================" >> $TMPFILE
 echo "" >> $TMPFILE
 echo "$commits" >> $TMPFILE
 echo "" >> $TMPFILE
+
 git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
 
 python ./ops/github_release.py --release $NEWTAG --release-file $TMPFILE

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -12,6 +12,8 @@ Start a new $PROJECT_NAME release.
 
 Usage: GITHUB_ACCESS_TOKEN=<gh_access_token> $(basename "$0") [-ch] [-t previous-tag new-tag]
 
+Optionally, GITHUB_USER, GITHUB_EMAIL, and GITHUB_GPG_KEY_FILE environment variables can be set prior to running this script, to identify and verify who is creating the release.  This is primarily necessary when the release process is run from a Docker container (i.e., from Jenkins).
+
 Options:
   -h    print this help text and exit
   -t    manually specify tags

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -79,7 +79,6 @@ if [ -n "$MANUAL_TAGS" ]; then
   PREVTAG="$1"
   NEWTAG="$2"
   PREVRELEASENUM=${PREVTAG//^r/}
-  echo ${PREVRELEASENUM}
   NEWRELEASENUM=${NEWTAG//^r/}
 else
   PREVTAG=$(git tag | sort -n | tail -1)


### PR DESCRIPTION
### Fixes [BCDA-341](https://jira.cms.gov/browse/BCDA-341)

Allow tag/release process to be executed from Jenkins job in an automated fashion, which can optionally deploy the release to specified environment by calling the relevant downstream jobs.

### Proposed changes:

App-related changes are in this PR.  Another PR is open for the ops-related changes.

In app, we will be creating a `Dockerfile` so that the release process can run in a containerized fashion.


### Change Details

- Created a `Dockerfile` so that the release process can be run from a container
- Updated `Makefile` so that release process can be run by executing a `make` command
- Update `release.sh` to accomodate the security validation required when creating tags from within a container.


### Security Implications

I have create a GPG key and added it to my Github account, which allows user "BCDA CI" to create tags.  When environment variables are appropriately configured (see `release.sh`), then those variables are used to configure the user creating the tag (required for use in a container).


### Acceptance Validation

Jenkins job: **https://bcda-ci.adhocteam.us/job/BCDA%20-%20Tag%20and%20Release/**

Several releases created.  See screenshots below.  (Note: all temporary tags and releases have since been removed).

<img width="739" alt="screen shot 2018-10-08 at 1 01 21 pm" src="https://user-images.githubusercontent.com/37818548/46623726-8e229300-cafc-11e8-8379-f82247ab753b.png">

<img width="524" alt="screen shot 2018-10-08 at 1 01 41 pm" src="https://user-images.githubusercontent.com/37818548/46623728-911d8380-cafc-11e8-99c2-c8362bba8ae9.png">



### Feedback Requested

