### PR TITLE
BCDA-293: Error Persistence - Connection Error

### DIFF
--- a/Dockerfiles/Dockerfile.bcdaworker
+++ b/Dockerfiles/Dockerfile.bcdaworker
@@ -14,6 +14,7 @@ ENV BB_CLIENT_CERT_FILE ../bcda/client/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE ../bcda/client/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us
 ENV FHIR_PAYLOAD_DIR data
+ENV BB_TIMEOUT_MS 500
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcdaworker
 CMD ["fresh"]

--- a/Dockerfiles/Dockerfile.bcdaworker
+++ b/Dockerfiles/Dockerfile.bcdaworker
@@ -8,6 +8,7 @@ WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
 RUN dep ensure
 
+ENV BCDA_WORKER_ERROR_LOG /var/log/bcda-worker-error.log
 ENV BCDA_BB_LOG /var/log/bcda-bb-request.log
 ENV BB_CLIENT_CERT_FILE ../bcda/client/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE ../bcda/client/bb-dev-test-key.pem

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -234,6 +234,15 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			Errors:              []fileItem{},
 		}
 
+		errFilePath := fmt.Sprintf("%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), job.AcoID)
+		if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
+			errFI := fileItem{
+				Type: "OperationOutcome",
+				URL:  fmt.Sprintf("%s://%s/data/%s-error.ndjson", scheme, r.Host, job.AcoID),
+			}
+			rb.Errors = append(rb.Errors, errFI)
+		}
+
 		jsonData, err := json.Marshal(rb)
 		if err != nil {
 			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -93,7 +93,7 @@ func RequireTokenACOMatch(next http.Handler) http.Handler {
 
 			aco, _ := claims["aco"].(string)
 
-			re := regexp.MustCompile("/([a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}).ndjson")
+			re := regexp.MustCompile("/([a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12})(?:-error)?.ndjson")
 			urlUUID := re.FindStringSubmatch(r.URL.String())[1]
 
 			if uuid.Equal(uuid.Parse(aco), uuid.Parse(string(urlUUID))) {

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -62,7 +63,12 @@ func NewBlueButtonClient() (*BlueButtonClient, error) {
 
 	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	client := &http.Client{Transport: transport, Timeout: 500 * time.Millisecond}
+	var timeout int
+	if timeout, err = strconv.Atoi(os.Getenv("BB_TIMEOUT_MS")); err != nil {
+		logger.Info("Could not get Blue Button timeout from environment variable; using default value of 500.")
+		timeout = 500
+	}
+	client := &http.Client{Transport: transport, Timeout: time.Duration(timeout) * time.Millisecond}
 
 	return &BlueButtonClient{*client}, nil
 }

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -62,7 +62,7 @@ func NewBlueButtonClient() (*BlueButtonClient, error) {
 
 	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	client := &http.Client{Transport: transport}
+	client := &http.Client{Transport: transport, Timeout: 500 * time.Millisecond}
 
 	return &BlueButtonClient{*client}, nil
 }

--- a/bcda/responseutils/issuedetail.go
+++ b/bcda/responseutils/issuedetail.go
@@ -5,4 +5,5 @@ const (
 	TokenErr  = "Invalid Token"
 	DbErr     = "Database Error"
 	FormatErr = "Formatting Error"
+	BbErr     = "Blue Button Error"
 )

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -115,10 +115,12 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 
 	w := bufio.NewWriter(f)
 
-	pData, err := bb.GetExplanationOfBenefitData(beneficiaryIDs[0])
+	// TODO: Multiple beneficiaries
+	beneficiaryID := beneficiaryIDs[0]
+	pData, err := bb.GetExplanationOfBenefitData(beneficiaryID)
 	if err != nil {
 		log.Error(err)
-		appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, "Error retrieving ExplanationOfBenefit")
+		appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving ExplanationOfBenefit for beneficiary %s in ACO %s", beneficiaryID, acoID))
 	} else {
 		// Append newline because we'll be writing multiple entries per file later
 		_, err := w.WriteString(pData + "\n")

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/CMSgov/bcda-app/bcda/responseutils"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/client"
@@ -29,6 +31,17 @@ type jobEnqueueArgs struct {
 	AcoID          string
 	UserID         string
 	BeneficiaryIDs []string
+}
+
+func init() {
+	log.SetFormatter(&log.JSONFormatter{})
+	filePath := os.Getenv("BCDA_WORKER_ERROR_LOG")
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err == nil {
+		log.SetOutput(file)
+	} else {
+		log.Info("Failed to log to file; using default stderr")
+	}
 }
 
 func processJob(j *que.Job) error {
@@ -104,8 +117,8 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 
 	pData, err := bb.GetExplanationOfBenefitData(beneficiaryIDs[0])
 	if err != nil {
-		// TODO: Store errors in NDJSON file of OperationOutcomes
 		log.Error(err)
+		appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, "Error retrieving ExplanationOfBenefit")
 	} else {
 		// Append newline because we'll be writing multiple entries per file later
 		_, err := w.WriteString(pData + "\n")
@@ -117,6 +130,28 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 	w.Flush()
 
 	return nil
+}
+
+func appendErrorToFile(acoID, code, detailsCode, detailsDisplay string) {
+	oo := responseutils.CreateOpOutcome(responseutils.Error, code, detailsCode, detailsDisplay)
+
+	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")
+	fileName := fmt.Sprintf("%s/%s-error.ndjson", dataDir, acoID)
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		log.Error(err)
+	}
+
+	defer f.Close()
+
+	ooBytes, err := json.Marshal(oo)
+	if err != nil {
+		log.Error(err)
+	}
+
+	if _, err = f.WriteString(string(ooBytes) + "\n"); err != nil {
+		log.Error(err)
+	}
 }
 
 func waitForSig() {

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -62,6 +62,25 @@ func TestWriteEOBDataToFileInvalidACO(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestAppendErrorToFile(t *testing.T) {
+	os.Setenv("FHIR_PAYLOAD_DIR", "data/test")
+	acoID := "9c05c1f8-349d-400f-9b69-7963f2262b07"
+
+	appendErrorToFile(acoID, "", "", "")
+
+	filePath := fmt.Sprintf("%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), acoID)
+	fData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fail()
+	}
+
+	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error"}]}`
+
+	assert.Equal(t, ooResp+"\n", string(fData))
+
+	os.Remove(filePath)
+}
+
 func (bbc *MockBlueButtonClient) GetExplanationOfBenefitData(patientID string) (string, error) {
 	return eobData, nil
 }

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -84,7 +84,7 @@ func TestWriteEOBDataToFileWithError(t *testing.T) {
 		t.Fail()
 	}
 
-	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit"}],"text":"Error retrieving ExplanationOfBenefit"}}]}`
+	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}}]}`
 	assert.Equal(t, ooResp+"\n", string(fData))
 
 	os.Remove(filePath)


### PR DESCRIPTION
### Fixes [BCDA-293](https://jira.cms.gov/browse/BCDA-293)
To comply with FHIR bulk spec, when errors occur in generating export files, they must be compiled into an NDJSON file of OperationOutcome resources.

### Proposed changes:
* Write OperationOutcome resources to file if errors occur while ExplanationOfBenefit data is being retrieved and written to a file


### Change Details
* Add configurable (env var `BB_TIMEOUT_MS`) timeout to Blue Button requests
* Add `appendErrorToFile()` function in bcdaworker/main.go
   * Called when an error is returned from `BlueButtonClient.GetExplanationOfBenefitData()`
* Include error NDJSON file in `jobStatus()` response
* Tests in bcdaworker/main_test.go


### Security Implications
Beneficiary ID and ACO ID included in the OperationOutcome text.


### Acceptance Validation
![screen shot 2018-10-08 at 2 06 20 pm](https://user-images.githubusercontent.com/1923441/46625814-608d1800-cb03-11e8-90d9-509518721a5a.png)


### Feedback Requested
Does the approach of checking for the existence of an error file make sense, or should we store something (e.g., error count per job) in the database? Any other feedback appreciated too.
