### PR TITLE
BCDA-355: Fetch data for more than one beneficiary from the BB backend sandbox

### DIFF
--- a/bcda/responseutils/issuedetail.go
+++ b/bcda/responseutils/issuedetail.go
@@ -2,8 +2,9 @@ package responseutils
 
 // Internal codes: These will be modified over time
 const (
-	TokenErr  = "Invalid Token"
-	DbErr     = "Database Error"
-	FormatErr = "Formatting Error"
-	BbErr     = "Blue Button Error"
+	TokenErr    = "Invalid Token"
+	DbErr       = "Database Error"
+	FormatErr   = "Formatting Error"
+	BbErr       = "Blue Button Error"
+	InternalErr = "Internal Error"
 )

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -126,6 +126,7 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 			_, err := w.WriteString(pData + "\n")
 			if err != nil {
 				log.Error(err)
+				appendErrorToFile(acoID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error writing ExplanationOfBenefit to file for beneficiary %s in ACO %s", beneficiaryID, acoID))
 			}
 		}
 	}

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -123,7 +123,6 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 			log.Error(err)
 			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving ExplanationOfBenefit for beneficiary %s in ACO %s", beneficiaryID, acoID))
 		} else {
-			// Append newline because we'll be writing multiple entries per file later
 			_, err := w.WriteString(pData + "\n")
 			if err != nil {
 				log.Error(err)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -48,7 +48,7 @@ func TestWriteEOBDataToFile(t *testing.T) {
 		t.Fail()
 	}
 
-	assert.Equal(t, eobData+"\n", string(fData))
+	assert.Equal(t, eobData+"\n"+eobData+"\n", string(fData))
 
 	os.Remove(filePath)
 }

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -84,7 +84,8 @@ func TestWriteEOBDataToFileWithError(t *testing.T) {
 		t.Fail()
 	}
 
-	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}}]}`
+	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}}]}
+{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 11000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 11000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}}]}`
 	assert.Equal(t, ooResp+"\n", string(fData))
 
 	os.Remove(filePath)


### PR DESCRIPTION
### Fixes [BCDA-355](https://jira.cms.gov/browse/BCDA-355)
We are currently retrieving ExplanationOfBenefit data for only one beneficiary per ACO.

### Proposed changes:
* Retrieve ExplanationOfBenefit data from the Blue Button backend sandbox for all beneficiary IDs in an ACO


### Change Details
* Now that we have a small ACO to test with, we can see that a job for an ACO with 50 beneficiaries takes approximately 9s
* Adjustments to tests that include two beneficiary IDs


### Security Implications
None; all synthetic data


### Acceptance Validation
Can be confirmed by looking at resulting NDJSON file, which will contain as many EOB Bundles as there are beneficiaries in the ACO.


### Feedback Requested
Any
