### PR TITLE
BCDA-344: Full test coverage for logging/middleware.go

### DIFF
--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -88,6 +88,7 @@ func TestWriteEOBDataToFileWithError(t *testing.T) {
 {"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 11000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 11000 in ACO 9c05c1f8-349d-400f-9b69-7963f2262b07"}}]}`
 	assert.Equal(t, ooResp+"\n", string(fData))
 
+	os.Remove(fmt.Sprintf("%s/%s.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), acoID))
 	os.Remove(filePath)
 }
 


### PR DESCRIPTION
### Fixes [BCDA-344](https://jira.cms.gov/browse/BCDA-344)
Test coverage for logging/middleware.go is not quite 100%.

### Proposed changes:
* Update test suite to reach 100% coverage

### Change Details
* Added test for logging/middleware.go `Panic()` function
* Also added line in bcdaworker/main_test.go to clean up a test NDJSON file

### Security Implications
None

### Acceptance Validation
![screen shot 2018-10-18 at 3 53 29 pm](https://user-images.githubusercontent.com/1923441/47180201-00aa2480-d2ee-11e8-909f-000789cbb639.png)


### Feedback Requested
Any
