### PR TITLE
BCDA-393 Feature: Added staging directory for FHIR payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ bcdaworker/debug
 test_results/*
 .idea
 bcda/swaggerui/swagger.json
-bcdaworker/data/*.ndjson
+bcdaworker/data/*

--- a/Dockerfiles/Dockerfile.bcda
+++ b/Dockerfiles/Dockerfile.bcda
@@ -18,6 +18,7 @@ ENV BB_CLIENT_CERT_FILE client/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE client/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us
 ENV FHIR_PAYLOAD_DIR ../bcdaworker/data
+ENV FHIR_STAGING_DIR ../bcdaworker/tmpdata
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcda
 CMD ["fresh", "-r", "start-api"]

--- a/Dockerfiles/Dockerfile.bcdaworker
+++ b/Dockerfiles/Dockerfile.bcdaworker
@@ -14,6 +14,7 @@ ENV BB_CLIENT_CERT_FILE ../bcda/client/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE ../bcda/client/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us
 ENV FHIR_PAYLOAD_DIR data
+ENV FHIR_STAGING_DIR tmpdata
 ENV BB_TIMEOUT_MS 500
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcdaworker

--- a/Dockerfiles/Dockerfile.unit_test
+++ b/Dockerfiles/Dockerfile.unit_test
@@ -19,6 +19,7 @@ ENV BB_CLIENT_CERT_FILE client/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE client/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us
 ENV FHIR_PAYLOAD_DIR ../bcdaworker/data
+ENV FHIR_STAGING_DIR ../bcdaworker/tmpdata
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 CMD ["bash", "unit_test.sh"]

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -229,7 +229,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 
 		fi := fileItem{
 			Type: "ExplanationOfBenefit",
-			URL:  fmt.Sprintf("%s://%s/data/%s.ndjson", scheme, r.Host, job.AcoID),
+			URL:  fmt.Sprintf("%s://%s/data/%s/%s.ndjson", scheme, r.Host, jobID, job.AcoID),
 		}
 
 		rb := bulkResponseBody{
@@ -240,11 +240,11 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			Errors:              []fileItem{},
 		}
 
-		errFilePath := fmt.Sprintf("%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), job.AcoID)
+		errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), jobID, job.AcoID)
 		if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
 			errFI := fileItem{
 				Type: "OperationOutcome",
-				URL:  fmt.Sprintf("%s://%s/data/%s-error.ndjson", scheme, r.Host, job.AcoID),
+				URL:  fmt.Sprintf("%s://%s/data/%s/%s-error.ndjson", scheme, r.Host, jobID, job.AcoID),
 			}
 			rb.Errors = append(rb.Errors, errFI)
 		}
@@ -270,7 +270,8 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 func serveData(w http.ResponseWriter, r *http.Request) {
 	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")
 	acoID := chi.URLParam(r, "acoID")
-	http.ServeFile(w, r, fmt.Sprintf("%s/%s.ndjson", dataDir, acoID))
+	jobID := chi.URLParam(r, "jobID")
+	http.ServeFile(w, r, fmt.Sprintf("%s/%s/%s.ndjson", dataDir, jobID, acoID))
 }
 
 func getToken(w http.ResponseWriter, r *http.Request) {

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -35,7 +35,7 @@ func NewRouter() http.Handler {
 			r.Get("/bb_metadata", blueButtonMetadata)
 		}
 	})
-	r.With(auth.RequireTokenAuth).With(auth.RequireTokenACOMatch).Get("/data/{acoID}.ndjson", serveData)
+	r.With(auth.RequireTokenAuth).With(auth.RequireTokenACOMatch).Get("/data/{jobID}/{acoID}.ndjson", serveData)
 	return r
 }
 

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"regexp"
@@ -74,11 +75,45 @@ func processJob(j *que.Job) error {
 		return err
 	}
 
-	err = writeEOBDataToFile(bb, jobArgs.AcoID, jobArgs.BeneficiaryIDs)
+	jobID := strconv.Itoa(jobArgs.ID)
+	staging := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
+	data := fmt.Sprintf("%s/%s", os.Getenv("FHIR_PAYLOAD_DIR"), jobID)
+
+	if _, err := os.Stat(staging); os.IsNotExist(err) {
+		err = os.MkdirAll(staging, os.ModePerm)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+	}
+	err = writeEOBDataToFile(bb, jobArgs.AcoID, jobArgs.BeneficiaryIDs, jobID)
 
 	if err != nil {
 		exportJob.Status = "Failed"
 	} else {
+		files, err := ioutil.ReadDir(staging)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+
+		for _, f := range files {
+			oldpath := staging + "/" + f.Name()
+			newpath := data + "/" + f.Name()
+			if _, err := os.Stat(data); os.IsNotExist(err) {
+				err = os.Mkdir(data, os.ModePerm)
+				if err != nil {
+					log.Error(err)
+					return err
+				}
+			}
+			err := os.Rename(oldpath, newpath)
+			if err != nil {
+				log.Error(err)
+				return err
+			}
+		}
+		os.Remove(staging)
 		exportJob.Status = "Completed"
 	}
 
@@ -92,7 +127,7 @@ func processJob(j *que.Job) error {
 	return nil
 }
 
-func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []string) error {
+func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []string, jobID string) error {
 	re := regexp.MustCompile("[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}")
 	if !re.Match([]byte(acoID)) {
 		err := errors.New("Invalid ACO ID")
@@ -106,8 +141,8 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 		return err
 	}
 
-	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")
-	f, err := os.Create(fmt.Sprintf("%s/%s.ndjson", dataDir, acoID))
+	dataDir := os.Getenv("FHIR_STAGING_DIR")
+	f, err := os.Create(fmt.Sprintf("%s/%s/%s.ndjson", dataDir, jobID, acoID))
 	if err != nil {
 		log.Error(err)
 		return err
@@ -121,12 +156,12 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 		pData, err := bb.GetExplanationOfBenefitData(beneficiaryID)
 		if err != nil {
 			log.Error(err)
-			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving ExplanationOfBenefit for beneficiary %s in ACO %s", beneficiaryID, acoID))
+			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving ExplanationOfBenefit for beneficiary %s in ACO %s", beneficiaryID, acoID), jobID)
 		} else {
 			_, err := w.WriteString(pData + "\n")
 			if err != nil {
 				log.Error(err)
-				appendErrorToFile(acoID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error writing ExplanationOfBenefit to file for beneficiary %s in ACO %s", beneficiaryID, acoID))
+				appendErrorToFile(acoID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error writing ExplanationOfBenefit to file for beneficiary %s in ACO %s", beneficiaryID, acoID), jobID)
 			}
 		}
 	}
@@ -136,11 +171,11 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 	return nil
 }
 
-func appendErrorToFile(acoID, code, detailsCode, detailsDisplay string) {
+func appendErrorToFile(acoID, code, detailsCode, detailsDisplay string, jobID string) {
 	oo := responseutils.CreateOpOutcome(responseutils.Error, code, detailsCode, detailsDisplay)
 
-	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")
-	fileName := fmt.Sprintf("%s/%s-error.ndjson", dataDir, acoID)
+	dataDir := os.Getenv("FHIR_STAGING_DIR")
+	fileName := fmt.Sprintf("%s/%s/%s-error.ndjson", dataDir, jobID, acoID)
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
Replace 393 with the JIRA ticket number:
Fixes [BCDA-393](https://jira.cms.gov/browse/BCDA-393)

Problem:
Previously our data files could be accessed while they were being constructed and prior to any encryption this could pose a security issue. Now by having a separate location for constructing and encrypting the files (unknown to our users) we can ensure the files will be ready and encrypted when we expose our /data endpoint.

Change Details:
Dockerfile.bcda - added fhir staging dir env
Dockerfile.bcdaworker -  added fhir staging dir env
Dockerfile.unit_test -  added fhir staging dir env
api.go - added jobID to path locations for completed and error .ndjson files
router.go - added jobID to the actual data request/download url
main.go - most of the code changes here. Added the staging dir location while files are being constructed. Added jobID to file and error writing locations
.gitignore - Added ignore location for all files we write in /data/

Security Implications
None

Acceptance Validation:
Create a few bulk data request and see the different folders in play. Make sure you can still access everything as usual on completion.

Feedback Requested:
Any feedback especially concerning the new data path for storing our temp and real data files