### PR TITLE
A few misc. bug fixes

### DIFF
--- a/Dockerfiles/Dockerfile.bcda
+++ b/Dockerfiles/Dockerfile.bcda
@@ -11,9 +11,6 @@ WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
 RUN dep ensure
 
-ENV BCDA_ERROR_LOG /var/log/bcda-error.log
-ENV BCDA_REQUEST_LOG /var/log/bcda-request.log
-ENV BCDA_BB_LOG /var/log/bcda-bb-request.log
 ENV BB_CLIENT_CERT_FILE ../shared_files/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE ../shared_files/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us

--- a/Dockerfiles/Dockerfile.bcda
+++ b/Dockerfiles/Dockerfile.bcda
@@ -14,8 +14,8 @@ RUN dep ensure
 ENV BCDA_ERROR_LOG /var/log/bcda-error.log
 ENV BCDA_REQUEST_LOG /var/log/bcda-request.log
 ENV BCDA_BB_LOG /var/log/bcda-bb-request.log
-ENV BB_CLIENT_CERT_FILE client/bb-dev-test-cert.pem
-ENV BB_CLIENT_KEY_FILE client/bb-dev-test-key.pem
+ENV BB_CLIENT_CERT_FILE ../shared_files/bb-dev-test-cert.pem
+ENV BB_CLIENT_KEY_FILE ../shared_files/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us
 ENV FHIR_PAYLOAD_DIR ../bcdaworker/data
 

--- a/Dockerfiles/Dockerfile.bcdaworker
+++ b/Dockerfiles/Dockerfile.bcdaworker
@@ -10,8 +10,8 @@ RUN dep ensure
 
 ENV BCDA_WORKER_ERROR_LOG /var/log/bcda-worker-error.log
 ENV BCDA_BB_LOG /var/log/bcda-bb-request.log
-ENV BB_CLIENT_CERT_FILE ../bcda/client/bb-dev-test-cert.pem
-ENV BB_CLIENT_KEY_FILE ../bcda/client/bb-dev-test-key.pem
+ENV BB_CLIENT_CERT_FILE ../shared_files/bb-dev-test-cert.pem
+ENV BB_CLIENT_KEY_FILE ../shared_files/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us
 ENV FHIR_PAYLOAD_DIR data
 ENV BB_TIMEOUT_MS 500

--- a/Dockerfiles/Dockerfile.bcdaworker
+++ b/Dockerfiles/Dockerfile.bcdaworker
@@ -8,8 +8,6 @@ WORKDIR /go/src/github.com/CMSgov/bcda-app
 COPY . .
 RUN dep ensure
 
-ENV BCDA_WORKER_ERROR_LOG /var/log/bcda-worker-error.log
-ENV BCDA_BB_LOG /var/log/bcda-bb-request.log
 ENV BB_CLIENT_CERT_FILE ../shared_files/bb-dev-test-cert.pem
 ENV BB_CLIENT_KEY_FILE ../shared_files/bb-dev-test-key.pem
 ENV BB_SERVER_LOCATION https://fhir.backend.bluebutton.hhsdevcloud.us

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Configure the `bcda` and `bcdaworker` apps by setting the following environment 
 
 ##### bcda
 
+```
 BCDA_ERROR_LOG <file_path>
 BCDA_REQUEST_LOG <file_path>
 BCDA_BB_LOG <file_path>
@@ -58,9 +59,11 @@ BB_CLIENT_KEY_FILE <file_path>
 BB_SERVER_LOCATION <url>
 FHIR_PAYLOAD_DIR <directory_path>
 JWT_EXPIRATION_DELTA <integer> (time in hours that JWT access tokens are valid for)
+```
 
 ##### bcdaworker
 
+```
 BCDA_WORKER_ERROR_LOG <file_path>
 BCDA_BB_LOG <file_path>
 BB_CLIENT_CERT_FILE <file_path>
@@ -68,3 +71,4 @@ BB_CLIENT_KEY_FILE <file_path>
 BB_SERVER_LOCATION <url>
 FHIR_PAYLOAD_DIR <directory_path>
 BB_TIMEOUT_MS <integer>
+```

--- a/README.md
+++ b/README.md
@@ -42,3 +42,29 @@ To interact with the app:
 
 1) Get a token: `http://localhost:3000/api/v1/token`
 2) POST to `http://localhost:3000/api/v1/claims` with `Authorization: Bearer <token>`
+
+
+### Environment variables
+
+Configure the `bcda` and `bcdaworker` apps by setting the following environment variables.
+
+##### bcda
+
+BCDA_ERROR_LOG <file_path>
+BCDA_REQUEST_LOG <file_path>
+BCDA_BB_LOG <file_path>
+BB_CLIENT_CERT_FILE <file_path>
+BB_CLIENT_KEY_FILE <file_path>
+BB_SERVER_LOCATION <url>
+FHIR_PAYLOAD_DIR <directory_path>
+JWT_EXPIRATION_DELTA <integer> (time in hours that JWT access tokens are valid for)
+
+##### bcdaworker
+
+BCDA_WORKER_ERROR_LOG <file_path>
+BCDA_BB_LOG <file_path>
+BB_CLIENT_CERT_FILE <file_path>
+BB_CLIENT_KEY_FILE <file_path>
+BB_SERVER_LOCATION <url>
+FHIR_PAYLOAD_DIR <directory_path>
+BB_TIMEOUT_MS <integer>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/CMSgov/bcda-app.svg?branch=master)](https://travis-ci.org/CMSgov/bcda-app)
 
-
 ### Dependencies
 
 To get started, install some dependencies:
@@ -11,7 +10,6 @@ To get started, install some dependencies:
 2. Install [Docker](https://docs.docker.com/install/)
 3. Install [Docker Compose](https://docs.docker.com/compose/install/)
 4. Ensure all dependencies installed above are on PATH and can be executed directly from command line.
-
 
 ### Build / Start
 
@@ -35,14 +33,9 @@ Run tests and produce test metrics:
 make test
 ```
 
-
 ### Use the application
 
-To interact with the app:
-
-1) Get a token: `http://localhost:3000/api/v1/token`
-2) POST to `http://localhost:3000/api/v1/claims` with `Authorization: Bearer <token>`
-
+See: [API documentation](https://github.com/CMSgov/bcda-app/blob/master/API.md)
 
 ### Environment variables
 

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/jackc/pgx"
 	"os"
 	"os/signal"
@@ -108,9 +107,6 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 	}
 
 	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")
-	testUtils.PrintSeparator()
-	fmt.Println(dataDir)
-	testUtils.PrintSeparator()
 	f, err := os.Create(fmt.Sprintf("%s/%s.ndjson", dataDir, acoID))
 	if err != nil {
 		log.Error(err)
@@ -228,12 +224,11 @@ func setupQueue() {
 
 	workers := que.NewWorkerPool(qc, wm, workerPoolSize)
 	go workers.Start()
+
+	waitForSig()
 }
 
 func main() {
 	fmt.Println("Starting bcdaworker...")
-
 	setupQueue()
-
-	waitForSig()
 }

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -191,7 +191,7 @@ func waitForSig() {
 	os.Exit(code)
 }
 
-func setupQueue() {
+func setupQueue() *pgx.ConnPool {
 	queueDatabaseURL := os.Getenv("QUEUE_DATABASE_URL")
 	pgxcfg, err := pgx.ParseURI(queueDatabaseURL)
 	if err != nil {
@@ -205,7 +205,6 @@ func setupQueue() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer pgxpool.Close()
 
 	qc = que.NewClient(pgxpool)
 	wm := que.WorkMap{
@@ -225,10 +224,12 @@ func setupQueue() {
 	workers := que.NewWorkerPool(qc, wm, workerPoolSize)
 	go workers.Start()
 
-	waitForSig()
+	return pgxpool
 }
 
 func main() {
 	fmt.Println("Starting bcdaworker...")
-	setupQueue()
+	workerPool := setupQueue()
+	defer workerPool.Close()
+	waitForSig()
 }

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/bgentry/que-go"
+	"github.com/jackc/pgx"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -178,7 +179,9 @@ func (s *MainTestSuite) TestProcessJob() {
 }
 
 func (s *MainTestSuite) TestSetupQueue() {
-	setupQueue()
+	var wp *pgx.ConnPool = setupQueue()
+	wp.Close()
 	os.Setenv("WORKER_POOL_SIZE", "7")
-	setupQueue()
+	wp = setupQueue()
+	wp.Close()
 }


### PR DESCRIPTION
- ~~Moves `waitForSig` to the end of `setupQueue` function to prevent deferred actions in the latter from closing the db connection to worker queue.~~
- Make `setupQueue` return the queue db connection, defer closing it in bcdaworker's `main()`. This should ensure it works properly with unit tests _and_ actually running the app.
- Remove env var definitions from Dockerfiles so that error and debug messages are easily visible via docker-compose output.
- Add a list of available env/config vars to the readme.
- Fixes file paths for keys and certs in Dockerfiles.