### PR TITLE
BCDA-415 Create Access Tokens for Alpha Partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ To get started, install some dependencies:
 
 Build the images and start the containers:
 
-1. Build the images
+1. Build the images and load with fixture data
 ```sh
 make docker-bootstrap
 ```
+
 2. Start the containers
 ```sh
 docker-compose up
@@ -36,6 +37,7 @@ make test
 ### Use the application
 
 See: [API documentation](https://github.com/CMSgov/bcda-app/blob/master/API.md)
+
 
 ### Environment variables
 
@@ -64,4 +66,23 @@ BB_CLIENT_KEY_FILE <file_path>
 BB_SERVER_LOCATION <url>
 FHIR_PAYLOAD_DIR <directory_path>
 BB_TIMEOUT_MS <integer>
+```
+
+### Other things you can do
+
+Use docker to look at the api database with psql:
+```sh
+docker run --rm --network bcda-app_default -it postgres psql -h bcda-app_db_1 -U postgres bcda
+```
+
+See docker-compose.yml for the password.
+
+Use docker to run the CLI against an API instance
+```
+docker exec -it bcda-app_api_1 bash -c 'tmp/bcda -h'
+```
+
+If you have no data in your database, you can load the fixture data with
+```sh
+make load-fixtures
 ```

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -368,6 +368,20 @@ func (s *BackendTestSuite) TestPublicKey() {
 
 }
 
+func (s *BackendTestSuite) TestCreateAlphaToken() {
+	db := database.GetGORMDbConnection()
+	aco, user, tokenString, err := s.AuthBackend.CreateAlphaToken()
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), aco)
+	assert.NotNil(s.T(), user)
+	assert.NotNil(s.T(), tokenString)
+	assert.Equal(s.T(), aco.UUID, user.AcoID)
+	var count int
+	db.Table("beneficiaries").Where("aco_id = ?", aco.UUID.String()).Count(&count)
+	assert.Equal(s.T(), 50, count)
+}
+
+
 func TestBackendTestSuite(t *testing.T) {
 	suite.Run(t, new(BackendTestSuite))
 }

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -221,6 +221,19 @@ func setUpApp() *cli.App {
 			},
 		},
 		{
+			Name:	  "create-alpha-token",
+			Category: "Alpha tools",
+			Usage:    "Create a disposable alpha participant token",
+			Action:   func(c *cli.Context) error {
+				accessToken, err := createAlphaToken()
+				if err != nil {
+					return err
+				}
+				fmt.Println(accessToken)
+				return nil
+			},
+		},
+		{
 			Name:     "sql-migrate",
 			Category: "Database tools",
 			Usage:    "Migrate GORM schema changes to the DB",
@@ -330,4 +343,11 @@ func revokeAccessToken(accessToken string) error {
 	authBackend := auth.InitAuthBackend()
 
 	return authBackend.RevokeToken(accessToken)
+}
+
+func createAlphaToken() (string, error) {
+	authBackend := auth.InitAuthBackend()
+
+	aco, user, tokenString, err := authBackend.CreateAlphaToken()
+	return fmt.Sprintf("%s\n%s\n%s", aco.Name, user.Name, tokenString), err
 }


### PR DESCRIPTION
### Completes [BCDA-415](https://jira.cms.gov/browse/BCDA-415)

<!-- describe the problem being solved here -->

### Proposed changes:
<!-- List of changes with bullet points here: -->

- Adds a 'create-alpha-token' command to the CLI
- Implements that command in auth/backend.go

The plan is that a human will use the CLI to create tokens for our alpha participants in the alpha sandbox. For more details and discussion, see the Jira Ticket.

### Change Details
<!-- add detailed discussion of changes here: -->

- Creates an ACO entry with a fixed name format like 'Alpha ACO #'.
- Creates a User entry with a fixed name format like 'Alpha User#' and email like alpha.user.#@nosuchdomain.com
- Copies the 50 beneficiaries associated with 'ACO dev' and associates those copies with the new ACO
- Creates an authentication token
- Displays the ACO name and user name in plain text, and the token in base64 encoded string form

### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
We chose to generate synthetic ACO and User names and email addresses to avoid any issues with PII.

Also, since we generate the token and sign it with our key, we can know for sure that the key has not been changed since we issued it.

### Acceptance Validation

I have run the whole process from end-to-end locally. Here's the new command shown in the CLI's help message:

<img width="708" alt="screen shot 2018-10-24 at 10 08 37 pm" src="https://user-images.githubusercontent.com/14351382/47478444-31062d00-d7de-11e8-986a-18eb43d33504.png">

I am a huge fan of CLIs for services; they make operationalizing them so much easier! Kudos team! 

Ran the CLI command locally with this docker command:
`docker exec -it bcda-app_api_1 bash -c 'tmp/bcda create-alpha-token'`

The command output looks like this:
<img width="1172" alt="screen shot 2018-10-24 at 11 05 22 pm" src="https://user-images.githubusercontent.com/14351382/47479289-76782980-d7e1-11e8-8724-f2b42a513eed.png">

The token is the long string on the third line in 3 parts separated by '.'

I then used Postman to submit requests to 
- http://localhost:3000/api/v1/ExplanationOfBenefit/$export
- http://localhost:3000/api/v1/jobs/1
- http://localhost:3000/data/ff273da5-9881-4a60-a2f0-83d04bd296e0.ndjson
  - I stopped scrolling through at line 379193
- http://localhost:3000/data/ff273da5-9881-4a60-a2f0-83d04bd296e0-error.ndjson

### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->

@epfrankle @michaelrobertsutton  we will need to correlate between the synthetic names / tokens and the actual ACO that is using each one. Do we need any more information?

@rnagle @embh @knollfear @tbellj thoughts / comments / questions?