### PR TITLE
BCDA-353: Update RPM build process to avoid using lib-ld-musl

### DIFF
--- a/Dockerfiles/Dockerfile.package
+++ b/Dockerfiles/Dockerfile.package
@@ -1,8 +1,7 @@
-FROM golang:1.10-alpine3.8
+FROM golang:1.10
 
-RUN apk upgrade
-RUN apk update
-RUN apk add --no-cache gcc make ruby ruby-dev rpm libc-dev git
+RUN apt-get update
+RUN apt-get install -y build-essential ruby ruby-dev rpm git
 RUN gem install --no-ri --no-rdoc fpm etc
 RUN go get -u github.com/golang/dep/cmd/dep
 

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -19,11 +19,11 @@ go clean
 echo "Building bcda binary..." 
 go build -ldflags "-X main.version=$VERSION"
 echo "Packaging bcda binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcda bcda
+fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bin/bcda
 cd ../bcdaworker
 go clean 
 echo "Building bcdaworker..."
 go build
 echo "Packaging bcdaworker binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker
+fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bin/bcdaworker
 


### PR DESCRIPTION
### Fixes [BCDA-353](https://jira.cms.gov/browse/BCDA-353)

App-packaging scripts related to the ops changes defined in this PR: https://github.com/CMSgov/bcda-ops/pull/26

### Proposed changes:

The build/package Docker image is based on Alpine, which uses lib-ld-musl instead of libgc.  To avoid compatability issues, I'm switching to Debian Linux Docker image so that the RPMs run successfully on RHEL.

### Change Details

- Updated packaging Dockerfile to use Debian instead of Alpine
- Update build/package script to adjust path (/usr/local/bin instead of root dir)


### Security Implications

None.


### Acceptance Validation

- Build/Package Jenkins job succeeded when run with feature branches that contain the app and ops changes: https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/52/parameters/
- BCDA is running in dev: http://bcda-api-dev-837966021.us-east-1.elb.amazonaws.com/
- Screenshot below to show that it is running from the RPM (`bcda` executable is running from /usr/local/bin instead of /usr/local/gopath/bin... in fact, /usr/local/gopath/bin no longer exists)

<img width="308" alt="screen shot 2018-10-31 at 1 46 44 pm" src="https://user-images.githubusercontent.com/37818548/47808562-fab43a80-dd14-11e8-99b5-6a8c896b91f9.png">


### Feedback Requested

Please provide feedback.
