### PR TITLE
BCDA-392: Swagger endpoint in AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ release:
 	docker run --rm -e GITHUB_ACCESS_TOKEN='${GITHUB_ACCESS_TOKEN}' -e GITHUB_USER='${GITHUB_USER}' -e GITHUB_EMAIL='${GITHUB_EMAIL}' -e GITHUB_GPG_KEY_FILE='${GITHUB_GPG_KEY_FILE}' -v ${PWD}:/go/src/github.com/CMSgov/bcda-app release
 
 package:
-	# This target should be executed by passing in an argument reprsenting the version of the artifacts we are packaging
+	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1
+	docker-compose up -d documentation
 	docker build -t packaging -f Dockerfiles/Dockerfile.package .
-	docker run -v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version) 
+	docker run --rm -v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
 test:
 	docker-compose up -d db queue

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -14,6 +14,12 @@ then
   exit 1
 fi
 
+if [ ! -f ../bcda/swaggerui/swagger.json ]
+then
+  echo "Swagger doc generation must be completed prior to creating package."
+  exit 1
+fi
+
 cd ../bcda
 go clean
 echo "Building bcda binary..." 

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -25,11 +25,11 @@ go clean
 echo "Building bcda binary..." 
 go build -ldflags "-X main.version=$VERSION"
 echo "Packaging bcda binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bin/bcda
+fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bcda/bcda swaggerui=/usr/local/bcda/swaggerui
 cd ../bcdaworker
 go clean 
 echo "Building bcdaworker..."
 go build
 echo "Packaging bcdaworker binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bin/bcdaworker
+fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bcda/bcdaworker
 

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -25,7 +25,7 @@ go clean
 echo "Building bcda binary..." 
 go build -ldflags "-X main.version=$VERSION"
 echo "Packaging bcda binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bcda/bcda swaggerui=/usr/local/bcda
+fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bcda/bcda swaggerui=/etc/sv/api
 cd ../bcdaworker
 go clean 
 echo "Building bcdaworker..."

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -25,11 +25,11 @@ go clean
 echo "Building bcda binary..." 
 go build -ldflags "-X main.version=$VERSION"
 echo "Packaging bcda binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bcda/bcda swaggerui=/etc/sv/api
+fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bin/bcda swaggerui=/etc/sv/api
 cd ../bcdaworker
 go clean 
 echo "Building bcdaworker..."
 go build
 echo "Packaging bcdaworker binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bcda/bcdaworker
+fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bin/bcdaworker
 

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -25,7 +25,7 @@ go clean
 echo "Building bcda binary..." 
 go build -ldflags "-X main.version=$VERSION"
 echo "Packaging bcda binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bcda/bcda swaggerui=/usr/local/bcda/swaggerui
+fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bcda/bcda swaggerui=/usr/local/bcda
 cd ../bcdaworker
 go clean 
 echo "Building bcdaworker..."


### PR DESCRIPTION
### Fixes [BCDA-392](https://jira.cms.gov/browse/BCDA-392)

Swagger doc endpoint is working on localhost, but not working in AWS.  The changes brought forth in this PR ensure that the swagger doc endpoint works in AWS environments.

### Proposed changes:

Package the swagger directory as part of the RPM.


### Change Details

- Slight modifications to Dockerfile to ensure that the documentation has been generated as part of packaging process.
- Update to build/package script to ensure that the swagger doc directory is included in the RPM packaging.


### Security Implications

None


### Acceptance Validation

Built and tested in AWS dev environment.  See screenshot (not the AWS dev env URL):

<img width="1303" alt="screen shot 2018-11-01 at 8 23 42 pm" src="https://user-images.githubusercontent.com/37818548/47889994-1efe3d00-de23-11e8-8847-7795e57bf9db.png">



### Feedback Requested

Please provide feedback.
