### PR TITLE
BCDA-507: Tweak CLI's create-alpha-token command

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -91,7 +91,7 @@ func setUpApp() *cli.App {
 	app.Name = Name
 	app.Usage = Usage
 	app.Version = version
-	var acoName, acoID, userName, userEmail, userID, accessToken string
+	var acoName, acoID, userName, userEmail, userID, accessToken, ttl string
 	app.Commands = []cli.Command{
 		{
 			Name:  "start-api",
@@ -241,8 +241,15 @@ func setUpApp() *cli.App {
 			Name:     "create-alpha-token",
 			Category: "Alpha tools",
 			Usage:    "Create a disposable alpha participant token",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "ttl",
+					Usage:       "Set custom Time To Live in hours",
+					Destination: &ttl,
+				},
+			},
 			Action: func(c *cli.Context) error {
-				accessToken, err := createAlphaToken()
+				accessToken, err := createAlphaToken(ttl)
 				if err != nil {
 					return err
 				}
@@ -362,11 +369,19 @@ func revokeAccessToken(accessToken string) error {
 	return authBackend.RevokeToken(accessToken)
 }
 
-func createAlphaToken() (string, error) {
+func createAlphaToken(ttl string) (string, error) {
 	authBackend := auth.InitAuthBackend()
+	tokenString, err := authBackend.CreateAlphaToken(ttl)
+	claims := authBackend.GetJWTClaims(tokenString)
 
-	aco, user, tokenString, err := authBackend.CreateAlphaToken()
-	return fmt.Sprintf("%s\n%s\n%s", aco.Name, user.Name, tokenString), err
+	if claims == nil {
+		return "", errors.New("Could not read token claims")
+	}
+
+	expiresOn := time.Unix(int64(claims["exp"].(float64)), 0).Format(time.RFC850)
+	tokenId := claims["id"].(string)
+
+	return fmt.Sprintf("%s\n%s\n%s", expiresOn, tokenId, tokenString), err
 }
 
 func getEnvInt(varName string, defaultVal int) int {

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/urfave/cli"
 	"strings"
 	"testing"
+	"time"
 )
 
 const BADUUID = "QWERTY-ASDFG-ZXCVBN-POIUYT"
@@ -125,28 +126,30 @@ func (s *MainTestSuite) TestCreateUser() {
 
 const TOKENHEADER string = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9."
 
-func checkTokenInfo(s *MainTestSuite, tokenInfo string) {
+func checkTokenInfo(s *MainTestSuite, tokenInfo string, ttl string) {
 	assert.NotNil(s.T(), tokenInfo)
 	lines := strings.Split(tokenInfo, "\n")
-
-	assert.Regexp(s.T(), "Alpha ACO [0-9]+", lines[0], "no correctly formatted Alpha ACO name in first line %s", lines[0])
-	assert.Regexp(s.T(), "Alpha User[0-9]+", lines[1], "no correctly formatted Alpha User name in second line %s", lines[1])
+	assert.Equal(s.T(), 3, len(lines))
+	expDate, err := time.Parse(time.RFC850, lines[0])
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), expDate)
+	assert.Regexp(s.T(), "[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}", lines[1], "no correctly formatted token id in second line %s", lines[1])
 	assert.True(s.T(), strings.HasPrefix(lines[2], TOKENHEADER), "incorrect token header %s", lines[2])
 	assert.InDelta(s.T(),500, len(tokenInfo), 100, "encoded token string length should be 500+-100; it is %d\n%s", len(tokenInfo), lines[2])
 }
 
 func (s *MainTestSuite) TestCreateAlphaToken() {
 
-	alphaTokenInfo, err := createAlphaToken()
+	alphaTokenInfo, err := createAlphaToken("")
 	assert.Nil(s.T(), err)
-	checkTokenInfo(s, alphaTokenInfo)
+	checkTokenInfo(s, alphaTokenInfo, "0")
 
-	anotherTokenInfo, err := createAlphaToken()
+	anotherTokenInfo, err := createAlphaToken("720")
 	assert.Nil(s.T(), err)
-	checkTokenInfo(s, anotherTokenInfo)
+	checkTokenInfo(s, anotherTokenInfo, "720")
 
 	l1 := strings.Split(alphaTokenInfo, "\n")
 	l2 := strings.Split(anotherTokenInfo, "\n")
-	assert.NotEqual(s.T(), l1[0], l2[0], "alpha ACO names should be different (%s == %s)", l1[0], l1[0])
-	assert.NotEqual(s.T(), l1[1], l2[1], "alpha ACO names should be different (%s == %s)", l1[1], l1[1])
+	assert.NotEqual(s.T(), l1[0], l2[0], "alpha expiration dates should be different (%s == %s)", l1[0], l2[0])
+	assert.NotEqual(s.T(), l1[1], l2[1], "alpha token uuids should be different (%s == %s)", l1[1], l2[1])
 }


### PR DESCRIPTION
### Fixes [BCDA-507](https://jira.cms.gov/browse/BCDA-507)

With our [process for distributing alpha tokens](https://confluence.cms.gov/display/BCDA/Distributing+Alpha+Partner+Tokens) now formalized, we need an additional option and different output from the CLI command.

### Proposed changes:

The command now supports an optional --ttl argument to set a custom TTL on an alpha token.
The output now contains the expiration date and alpha token id, instead of the fake ACO name and fake user name.

The [initial implementation PR](https://github.com/CMSgov/bcda-app/pull/58) may be useful as a reference.

### Security Implications

Command is only accessible via the CLI.

### Acceptance Validation

Unit tests and hand testing output.
