### PR TITLE
Remove sleep and enable smoke test in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,7 @@ before_script:
 # script always runs to completion (set +e). If we have linter issues AND a
 # failing test, we want to see both. Configure golangci-lint with a
 # .golangci.yml file at the top level of your repo.
-#
-# TODO: when the 404 File Not Found issue is resolved during file download,
-#       then re-enable smoke-test... script section will look like this:
-#   script:
-#    - make docker-bootstrap
-#    - make test
-#    - make smoke-test
-#
 script:
+  - make docker-bootstrap
   - make test
+  - make smoke-test

--- a/test/bcda_client.go
+++ b/test/bcda_client.go
@@ -160,7 +160,6 @@ func main() {
 				}
 
 				fmt.Printf("fetching: %s\n", data[0].Url)
-				time.Sleep(60 * time.Second)
 				download := getFile(data[0].Url)
 				if download.StatusCode == 200 {
 					fmt.Println("writing download to disk: /tmp/download.json")


### PR DESCRIPTION
- Enable smoke test to be executed in Travis CI.
- Remove `sleep` from `bcda_client.go`
