### PR TITLE
Set connection: close response header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,7 @@ before_script:
 # script always runs to completion (set +e). If we have linter issues AND a
 # failing test, we want to see both. Configure golangci-lint with a
 # .golangci.yml file at the top level of your repo.
-#
-# TODO: when the 404 File Not Found issue is resolved during file download,
-#       then re-enable smoke-test... script section will look like this:
-#   script:
-#    - make docker-bootstrap
-#    - make test
-#    - make smoke-test
-#
 script:
+  - make docker-bootstrap
   - make test
+  - make smoke-test

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -318,11 +318,29 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 
 	authBackend := auth.InitAuthBackend()
 
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+
+	var user auth.User
+	err := db.First(&user, "name = ?", "User One").Error
+	if err != nil {
+		log.Print(err)
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
+		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		return
+	}
+
+	var aco auth.ACO
+	err = db.First(&aco, "name = ?", "ACO Dev").Error
+	if err != nil {
+		log.Print(err)
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
+		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		return
+	}
+
 	// Generates a token for fake user and ACO combination
-	token, err := authBackend.GenerateTokenString(
-		"82503A18-BF3B-436D-BA7B-BAE09B7FFD2F",
-		"0C527D2E-2E8A-4808-B11D-0FA06BAF8254",
-	)
+	token, err := authBackend.GenerateTokenString(user.UUID.String(), aco.UUID.String())
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -324,7 +324,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	var user auth.User
 	err := db.First(&user, "name = ?", "User One").Error
 	if err != nil {
-		log.Print(err)
+		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
 		responseutils.WriteError(oo, w, http.StatusInternalServerError)
 		return
@@ -333,7 +333,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	var aco auth.ACO
 	err = db.First(&aco, "name = ?", "ACO Dev").Error
 	if err != nil {
-		log.Print(err)
+		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
 		responseutils.WriteError(oo, w, http.StatusInternalServerError)
 		return

--- a/bcda/middleware.go
+++ b/bcda/middleware.go
@@ -39,3 +39,10 @@ func ValidateBulkRequestHeaders(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+func ConnectionClose(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "close")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -14,7 +14,7 @@ import (
 
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
-	r.Use(auth.ParseToken, logging.NewStructuredLogger())
+	r.Use(auth.ParseToken, logging.NewStructuredLogger(), ConnectionClose)
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui"))
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -39,7 +39,8 @@ func NewAPIRouter() http.Handler {
 
 func NewDataRouter() http.Handler {
 	r := chi.NewRouter()
-	r.With(auth.ParseToken, logging.NewStructuredLogger(), auth.RequireTokenAuth, auth.RequireTokenACOMatch).Get("/data/{jobID}/{acoID}.ndjson", serveData)
+	r.With(auth.ParseToken, logging.NewStructuredLogger(), auth.RequireTokenAuth,
+		auth.RequireTokenACOMatch, ConnectionClose).Get("/data/{jobID}/{acoID}.ndjson", serveData)
 	return r
 }
 

--- a/test/bcda_client.go
+++ b/test/bcda_client.go
@@ -160,7 +160,6 @@ func main() {
 				}
 
 				fmt.Printf("fetching: %s\n", data[0].Url)
-				time.Sleep(60 * time.Second)
 				download := getFile(data[0].Url)
 				if download.StatusCode == 200 {
 					fmt.Println("writing download to disk: /tmp/download.json")


### PR DESCRIPTION
Since we are routing requests to two different instances of `http.Server`, we can not support persistent connections and must set a `Connection: close` header in our responses.

The consequence of not setting this header is that, when a client makes back-to-back requests for endpoints handled by separate `http.Server` instances, the app will be unable to route the request properly and send back a false `404` error.

The [HTTP/1.1 whitepaper](https://tools.ietf.org/html/rfc2616#section-14.10) indicates setting the `Connection` header is acceptable (and, in fact, required) when the application does not support persistent connections.

### Proposed changes:

- Adds a `ConnectionClose` middleware and uses it with the api and data server routers

### Change details

- Note: since we are deploying the app behind AWS ELB, the "client" in our case is _technically_ the load balancer. Even though we send `Connection: close` on the backend, the load balancer will still use a keep-alive connections on the frontend (between the load balancer and end users), meaning there is ultimately no performance/resource implication for them.