### PR TITLE
Add a (temporary) way for clients to request file encryption

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -38,6 +38,8 @@ type jobEnqueueArgs struct {
 	AcoID          string
 	UserID         string
 	BeneficiaryIDs []string
+	// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
+	Encrypt bool
 }
 
 // swagger:model fileItem

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -32,6 +32,8 @@ type jobEnqueueArgs struct {
 	AcoID          string
 	UserID         string
 	BeneficiaryIDs []string
+	// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
+	Encrypt bool
 }
 
 func init() {
@@ -107,8 +109,9 @@ func processJob(j *que.Job) error {
 					return err
 				}
 			}
-			// Skipping encryption is NOT the default.  This code will be removed before ATO
-			if os.Getenv("DO_ENCRYPTION") == "FALSE" {
+
+			// TODO(rnagle): this condition should be removed when file encryption is ready for release
+			if !jobArgs.Encrypt {
 				err := os.Rename(oldpath, newpath)
 				if err != nil {
 					log.Error(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ services:
       - DATABASE_URL=postgresql://postgres:toor@db:5432/bcda?sslmode=disable
       - FHIR_PAYLOAD_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/data
       - FHIR_STAGING_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/tmpdata
-      - ATO_PUBLIC_KEY_FILE=../../shared_files/ATO_public.pem
-      - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
+      - ATO_PUBLIC_KEY_FILE=/go/src/github.com/CMSgov/bcda-app/shared_files/ATO_public.pem
+      - ATO_PRIVATE_KEY_FILE=/go/src/github.com/CMSgov/bcda-app/shared_files/ATO_private.pem
       - DO_ENCRYPTION=FALSE
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       - EXPIRED_THRESHOLD_HR=24
       - ATO_PUBLIC_KEY_FILE=../../shared_files/ATO_public.pem
       - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
-      - DO_ENCRYPTION=FALSE
     volumes:
      - .:/go/src/github.com/CMSgov/bcda-app
     ports:
@@ -56,7 +55,6 @@ services:
       - FHIR_STAGING_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/tmpdata
       - ATO_PUBLIC_KEY_FILE=/go/src/github.com/CMSgov/bcda-app/shared_files/ATO_public.pem
       - ATO_PRIVATE_KEY_FILE=/go/src/github.com/CMSgov/bcda-app/shared_files/ATO_private.pem
-      - DO_ENCRYPTION=FALSE
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     depends_on:


### PR DESCRIPTION
### Overview/background

This change adds a check for `?encrypt=true` appended to `/api/v1/ExplanationOfBenefit/$export` and executes the file encryption routine when it is present.

This is necessary since we do not plan to share and discuss file encryption functionality with our pilot users in research sessions. We'll hold off on sharing it until after the first round of research is done and we have documentation explaining how they're meant to interact with the encrypted files (see: https://jira.cms.gov/browse/BCDA-512).

At the same time, we need a way to allow security auditors to test/validate that our file encryption is present and works properly. This should help accomplish that goal.

### Proposed changes:

As stated above, this adds a check for `?encrypt=true` in requests for bulk data. When this query parameter is present, the aggregation job that is created is marked for encryption. When the worker process picks up a job marked for encryption, the file encryption routine runs.

When the `encrypt` query param is omitted (or is any value other than `true`), file encryption is bypassed.

### Security Implications

- Since this is only intended for use in our sandbox environment where no PHI/PII is stored, bypassing file encryption presents no inherent risk.
- There are several `TODO` items marked in the code where we will need to make changes when we are ready to make file encryption the default.