### PR TITLE
Rebuild test images each time they are executed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ package:
 smoke-test:
 	docker-compose up -d 
 	sleep 30
-	docker-compose -f docker-compose.test.yml up --force-recreate --exit-code-from smoke_test smoke_test
+	docker-compose -f docker-compose.test.yml up --build --force-recreate --exit-code-from smoke_test smoke_test
 
 test:
 	docker-compose up -d db queue
-	docker-compose -f docker-compose.test.yml up --force-recreate --exit-code-from unit_test unit_test
+	docker-compose -f docker-compose.test.yml up --build --force-recreate --exit-code-from unit_test unit_test
 
 load-fixtures:
 	docker-compose up -d db


### PR DESCRIPTION
### Makefile Updates

Jenkins was using cached images for `unit_test` and `smoke_test`

### Proposed changes:

Force a rebuild of the images within the `Makefile` targets


### Change Details

Added `--build` to force the rebuild of the `unit_test` and `smoke_test` images


### Security Implications

None.


### Acceptance Validation

Tested locally and ensured the image is rebuilt.

### Feedback Requested

Please review.