### PR TITLE
BCDA 442: Cleanup files for expired jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ test_results/*
 .idea
 bcda/swaggerui/swagger.json
 bcdaworker/data/*
-bcdaworker/expired/*
+bcdaworker/archive/*

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -521,6 +521,7 @@ func cleanupArchive(hrThreshold int) error {
 			log.WithFields(log.Fields{
 				"job_began":     job.CreatedAt,
 				"files_removed": time.Now(),
+				"job_id":        job.ID,
 			}).Info("Files cleaned from archive and job status set to Expired")
 		}
 	}

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -287,10 +287,12 @@ func setupArchivedJob(s *MainTestSuite, email string, modified time.Time) int {
 		Status:     "Archived",
 	}
 	db.Save(&j)
-	db.Model(&j).UpdateColumn("updated_at", modified)
-	db.Save(&j)
+	db.Exec("UPDATE jobs SET updated_at=? WHERE id = ?", modified.Format("2006-01-02 15:04:05"), j.ID)
+	db.First(&j, "id = ?", j.ID)
 	assert.Nil(s.T(), err);
 	assert.NotNil(s.T(), j.ID)
+	// compare times using formatted strings to avoid differences (like nano seconds) that we don't care about
+	assert.Equal(s.T(), modified.Format("2006-01-02 15:04:05"), j.UpdatedAt.Format("2006-01-02 15:04:05"), "UpdatedAt should match %v", modified)
 
 	return int(j.ID)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       - DEBUG=true
       - FHIR_PAYLOAD_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/data
       - FHIR_STAGING_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/tmpdata
-      - FHIR_EXPIRED_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/expired
-      - EXPIRED_THRESHOLD_HR=24
+      - FHIR_ARCHIVE_DIR=/go/src/github.com/CMSgov/bcda-app/bcdaworker/archive
+      - ARCHIVE_THRESHOLD_HR=24
       - ATO_PUBLIC_KEY_FILE=../../shared_files/ATO_public.pem
       - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
       - HTTP_ONLY=true


### PR DESCRIPTION
### Fixes [BCDA-442](https://jira.cms.gov/browse/BCDA-442)

When a job is expiring due to age, its files are moved to an inaccessible location. See [BCDA-441](https://jira.cms.gov/browse/BCDA-442) for more about this. The work of this ticket is to cleanup that inaccessible location by removing files for jobs that have not been touched for a certain period of time.

### Proposed changes:

Add a CLI command to cleanup the archive location. To run locally in docker:

docker exec -it bcda-app_api_1 bash -c 'tmp/bcda cleanup-archive --threshold 30'

--threshold is required, because I don't think it's appropriate for this argument to have a default.

### Change Details

1. Renamed the original status associated with moving files to the archive location from 'Expired' to 'Archived'

2. When a job has been in 'Archived' state for `threshold` hours, remove the files from the archive and set the job status to 'Expired'

### Security Implications

Can only be run through CLI.

### Acceptance Validation

Tests included.

Logging message
{"files_removed":"2018-11-20T07:41:19.5631881Z","job_began":"2018-11-16T16:42:00Z","job_id":1,"level":"info","msg":"Files cleaned from archive and job status set to Expired","time":"2018-11-20T07:41:19Z"}

