### PR TITLE
Ensure Splunk can see log files

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -31,7 +31,10 @@ func init() {
 	logger = logrus.New()
 	logger.Formatter = &logrus.JSONFormatter{}
 	filePath := os.Getenv("BCDA_BB_LOG")
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
+	
+	/* #nosec -- 0640 permissions required for Splunk ingestion */
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0640)
+	
 	if err == nil {
 		logger.SetOutput(file)
 	} else {

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -18,7 +18,10 @@ func NewStructuredLogger() func(next http.Handler) http.Handler {
 	logger := logrus.New()
 	logger.Formatter = &logrus.JSONFormatter{}
 	filePath := os.Getenv("BCDA_REQUEST_LOG")
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
+
+	/* #nosec -- 0640 permissions required for Splunk ingestion */
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0640)
+
 	if err == nil {
 		logger.SetOutput(file)
 	} else {

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -77,7 +77,10 @@ type bulkResponseBody struct {
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	filePath := os.Getenv("BCDA_ERROR_LOG")
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
+
+	/* #nosec -- 0640 permissions required for Splunk ingestion */
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0640)
+
 	if err == nil {
 		log.SetOutput(file)
 	} else {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -39,7 +39,9 @@ type jobEnqueueArgs struct {
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	filePath := os.Getenv("BCDA_WORKER_ERROR_LOG")
-	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+
+	/* #nosec -- 0640 permissions required for Splunk ingestion */
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
 	if err == nil {
 		log.SetOutput(file)
 	} else {
@@ -189,7 +191,10 @@ func appendErrorToFile(acoID, code, detailsCode, detailsDisplay string, jobID st
 
 	dataDir := os.Getenv("FHIR_STAGING_DIR")
 	fileName := fmt.Sprintf("%s/%s/%s-error.ndjson", dataDir, jobID, acoID)
-	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+
+	/* #nosec -- 0640 permissions required for Splunk ingestion */
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+
 	if err != nil {
 		log.Error(err)
 	}

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -191,9 +191,7 @@ func appendErrorToFile(acoID, code, detailsCode, detailsDisplay string, jobID st
 
 	dataDir := os.Getenv("FHIR_STAGING_DIR")
 	fileName := fmt.Sprintf("%s/%s/%s-error.ndjson", dataDir, jobID, acoID)
-
-	/* #nosec -- 0640 permissions required for Splunk ingestion */
-	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
### Fixes Splunk Bug

Splunk is unable to see files with permissions of 600.  

### Proposed changes:

Update necessary log files to have permissions of 640.


### Change Details

- Update log file permissions to be 640 instead of 600
- Identify in code commentary why we are circumventing a `gosec` rule 

### Security Implications

Group now has `read` privileges.  

