### PR TITLE
Configure git for usage in the container

### DIFF
--- a/Dockerfiles/Dockerfile.integration_test
+++ b/Dockerfiles/Dockerfile.integration_test
@@ -11,6 +11,8 @@ FROM golang:1.10.3
 #
 RUN go get -u github.com/whytheplatypus/tester
 WORKDIR /go/src/github.com/whytheplatypus/tester
+RUN git config --global user.email "bcda-ops.group@adhocteam.us"
+RUN git config --global user.name "BCDA Ops"
 RUN git remote add fork https://github.com/msnook/tester.git
 RUN git pull fork master
 #


### PR DESCRIPTION
`git` is being leveraged in our test container and sporadically fails if not configured.  This PR configures `git` appropriately.
