### PR TITLE
knollfear/bcda-554 Handling errors in order to allow for the running of Gosec test G104

### DIFF
--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -182,18 +182,24 @@ func GetATOPrivateKey() *rsa.PrivateKey {
 	return openPrivateKeyFile(atoPrivateKeyFile)
 }
 func openPrivateKeyFile(privateKeyFile *os.File) *rsa.PrivateKey {
-	pemfileinfo, _ := privateKeyFile.Stat()
+	pemfileinfo, err := privateKeyFile.Stat()
+	if err != nil {
+		log.Panic(err)
+	}
 	var size int64 = pemfileinfo.Size()
 	pembytes := make([]byte, size)
 	buffer := bufio.NewReader(privateKeyFile)
-	_, err := buffer.Read(pembytes)
+	_, err = buffer.Read(pembytes)
 	if err != nil {
 		// Above buffer.Read succeeded on a blank file Not Sure how to reach this
 		log.Panic(err)
 	}
 
 	data, _ := pem.Decode([]byte(pembytes))
-	privateKeyFile.Close()
+	err = privateKeyFile.Close()
+	if err != nil {
+		log.Panic(err)
+	}
 
 	privateKeyImported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
 	if err != nil {
@@ -227,18 +233,24 @@ func GetATOPublicKey() *rsa.PublicKey {
 	return openPublicKeyFile(atoPublicKeyFile)
 }
 func openPublicKeyFile(publicKeyFile *os.File) *rsa.PublicKey {
-	pemfileinfo, _ := publicKeyFile.Stat()
+	pemfileinfo, err := publicKeyFile.Stat()
+	if err != nil {
+		log.Panic(err)
+	}
 	var size int64 = pemfileinfo.Size()
 	pembytes := make([]byte, size)
 	buffer := bufio.NewReader(publicKeyFile)
-	_, err := buffer.Read(pembytes)
+	_, err = buffer.Read(pembytes)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	data, _ := pem.Decode([]byte(pembytes))
 
-	publicKeyFile.Close()
+	err = publicKeyFile.Close()
+	if err != nil {
+		log.Panic(err)
+	}
 
 	publicKeyImported, err := x509.ParsePKIXPublicKey(data.Bytes)
 

--- a/bcda/database/connection.go
+++ b/bcda/database/connection.go
@@ -14,7 +14,10 @@ var logFatal = log.Fatal
 
 func GetDbConnection() *sql.DB {
 	databaseURL := os.Getenv("DATABASE_URL")
-	db, _ := sql.Open("postgres", databaseURL)
+	db, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		logFatal(err)
+	}
 	pingErr := db.Ping()
 	if pingErr != nil {
 		logFatal(pingErr)
@@ -24,7 +27,10 @@ func GetDbConnection() *sql.DB {
 
 func GetGORMDbConnection() *gorm.DB {
 	databaseURL := os.Getenv("DATABASE_URL")
-	db, _ := gorm.Open("postgres", databaseURL)
+	db, err := gorm.Open("postgres", databaseURL)
+	if err != nil {
+		logFatal(err)
+	}
 	pingErr := db.DB().Ping()
 	if pingErr != nil {
 		logFatal(pingErr)

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -16,10 +16,13 @@ func CreateOpOutcome(severity, code, detailsCode, detailsDisplay string) *fhirmo
 }
 
 func WriteError(outcome *fhirmodels.OperationOutcome, w http.ResponseWriter, code int) {
-	outcomeJSON, _ := json.Marshal(outcome)
+	outcomeJSON, err := json.Marshal(outcome)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	_, err := w.Write(outcomeJSON)
+	_, err = w.Write(outcomeJSON)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
@@ -119,10 +122,13 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 }
 
 func WriteCapabilityStatement(statement *fhirmodels.CapabilityStatement, w http.ResponseWriter) {
-	statementJSON, _ := json.Marshal(statement)
+	statementJSON, err := json.Marshal(statement)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err := w.Write(statementJSON)
+	_, err = w.Write(statementJSON)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}

--- a/bcda/servicemux/servicemux.go
+++ b/bcda/servicemux/servicemux.go
@@ -110,8 +110,8 @@ func (sm *ServiceMux) serveHTTPS(tlsCertPath, tlsKeyPath string) {
 	}
 
 	sm.TLSConfig = tls.Config{
-		Certificates: []tls.Certificate{certificate},
-		Rand:         rand.Reader,
+		Certificates:             []tls.Certificate{certificate},
+		Rand:                     rand.Reader,
 		PreferServerCipherSuites: true,
 		CurvePreferences: []tls.CurveID{
 			tls.CurveP256,
@@ -151,7 +151,10 @@ func (sm *ServiceMux) serveHTTP() {
 }
 
 func (sm *ServiceMux) Close() {
-	sm.Listener.Close()
+	err := sm.Listener.Close()
+	if err != nil {
+		log.Panic(err)
+	}
 }
 
 func IsHTTPS(r *http.Request) bool {

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -76,7 +76,10 @@ func (s *AuthTestSuite) SetupAuthBackend() {
 		log.Fatal(err)
 	}
 
-	os.Setenv("JWT_PRIVATE_KEY_FILE", privKeyFile.Name())
+	err = os.Setenv("JWT_PRIVATE_KEY_FILE", privKeyFile.Name())
+	if err != nil {
+		log.Panic(err)
+	}
 	s.TmpFiles = append(s.TmpFiles, privKeyFile.Name())
 	s.SavePrivateKey(privKeyFile, key)
 	defer privKeyFile.Close()
@@ -86,7 +89,10 @@ func (s *AuthTestSuite) SetupAuthBackend() {
 		log.Fatal(err)
 	}
 
-	os.Setenv("JWT_PUBLIC_KEY_FILE", pubKeyFile.Name())
+	err = os.Setenv("JWT_PUBLIC_KEY_FILE", pubKeyFile.Name())
+	if err != nil {
+		log.Panic(err)
+	}
 	s.TmpFiles = append(s.TmpFiles, pubKeyFile.Name())
 	s.SavePubKey(pubKeyFile, publicKey)
 	defer pubKeyFile.Close()
@@ -95,7 +101,10 @@ func (s *AuthTestSuite) SetupAuthBackend() {
 }
 
 func CreateStaging(jobID string) {
-	os.Setenv("FHIR_STAGING_DIR", "data/test")
+	err := os.Setenv("FHIR_STAGING_DIR", "data/test")
+	if err != nil {
+		log.Panic(err)
+	}
 	testdir := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
 
 	if _, err := os.Stat(testdir); os.IsNotExist(err) {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -133,7 +133,11 @@ func processJob(j *que.Job) error {
 				}
 			}
 		}
-		os.Remove(staging)
+		err = os.Remove(staging)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
 		exportJob.Status = "Completed"
 	}
 
@@ -182,7 +186,10 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 		}
 	}
 
-	w.Flush()
+	err = w.Flush()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -14,7 +14,7 @@ mkdir -p test_results/${timestamp}
 mkdir -p test_results/latest
 
 echo "Running gosec..."
-gosec -exclude=G104 ./...
+gosec ./...
 
 echo "Setting up test DB (bcda_test)..."
 DB_HOST_URL=${DB}?sslmode=disable


### PR DESCRIPTION
### Fixes [BCDA-554](https://jira.cms.gov/browse/BCDA-554)

GoSec currently isn't running test G104 which looks for unhandled errors.  This PR adds in error handling for all places it was missing and enables that test 
### Proposed changes:

Handled potential error with opening of Key FIles
Handled potential error with setting of environment variables
Handled potential error with closing of files
Handled potential errors with marshalling of JSON data
Handled potential errors with opening DB connection
Handled potential errors with closing of serviceMUX
handled potential errors with flushing of writer
handled potential errors with removing directory

### Change Details

Most errors are handled in ways similar to other errors within the function.  As these errors were previously unhandled it shouldn't cause any problems to now handle them explicitly

### Security Implications

no PII should be affected

### Acceptance Validation

Run make test and verify that tests complete and that GOSEC runs test G104



### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
Is the handling of the errors correct?  Should we just #nosec any of these instead?