### PR TITLE
BCDA-624: Use os.O_APPEND mode for error/request logs

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -33,7 +33,7 @@ func init() {
 	filePath := os.Getenv("BCDA_BB_LOG")
 
 	/* #nosec -- 0640 permissions required for Splunk ingestion */
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0640)
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
 
 	if err == nil {
 		logger.SetOutput(file)

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -20,7 +20,7 @@ func NewStructuredLogger() func(next http.Handler) http.Handler {
 	filePath := os.Getenv("BCDA_REQUEST_LOG")
 
 	/* #nosec -- 0640 permissions required for Splunk ingestion */
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0640)
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
 
 	if err == nil {
 		logger.SetOutput(file)

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -79,7 +79,7 @@ func init() {
 	filePath := os.Getenv("BCDA_ERROR_LOG")
 
 	/* #nosec -- 0640 permissions required for Splunk ingestion */
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0640)
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
 
 	if err == nil {
 		log.SetOutput(file)


### PR DESCRIPTION
### Fixes [BCDA-624](https://jira.cms.gov/browse/BCDA-624)

Makes `bcda` use "append" mode when opening log files to prevent the issue described here: https://serverfault.com/questions/642286/logrotate-continuous-write-issue

### Proposed changes:

- Update locations where `bcda` opens `BB_ERROR_LOG`, `BCDA_REQUEST_LOG` and `BCDA_ERROR_LOG` to use `os.O_APPEND` mode.