### PR TITLE
BCDA-395: Add /Patient endpoint for bulk export of patient data

### DIFF
--- a/Dockerfiles/Dockerfile.integration_test
+++ b/Dockerfiles/Dockerfile.integration_test
@@ -25,4 +25,4 @@ WORKDIR /go/src/github.com/CMSgov/bcda-app/test/integration_test
 
 # Use simple tester command once the fork gets merged to main repo
 # CMD ["tester", "-var", "PROTOCOL=http", "-var", "HOST=api:3000", "version.toml", "swagger.toml", "metadata.toml", "jobs.toml", "eob.toml"]
-CMD ["go", "run", "/go/src/github.com/whytheplatypus/tester/main.go", "-var", "PROTOCOL=http", "-var", "HOST=api:3000", "version.toml", "swagger.toml", "metadata.toml", "jobs.toml", "eob.toml"]
+CMD ["go", "run", "/go/src/github.com/whytheplatypus/tester/main.go", "-var", "PROTOCOL=http", "-var", "HOST=api:3000", "version.toml", "swagger.toml", "metadata.toml", "jobs.toml", "eob.toml", "patient.toml"]

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -83,26 +83,6 @@ func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("ExplanationOfBenefit", w, r)
 }
 
-/*
-	swagger:route GET /Patient/$export bulkData bulkPatientRequest
-
-	Start patient data export
-
-	Initiates a job to collect data from the Blue Button API for your ACO.
-
-	Produces:
-	- application/fhir+json
-
-	Schemes: http, https
-
-	Security:
-		api_key
-
-	Responses:
-		202:BulkRequestResponse
-		400:ErrorModel
-		500:FHIRResponse
-*/
 func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("Patient", w, r)
 }

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -75,6 +75,13 @@ import (
 		500:FHIRResponse
 */
 func bulkRequest(w http.ResponseWriter, r *http.Request) {
+	t := chi.URLParam(r, "resourceType")
+	if t != "ExplanationOfBenefit" && t != "Patient" {
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.InternalErr)
+		responseutils.WriteError(oo, w, http.StatusNotFound)
+		return
+	}
+
 	m := monitoring.GetMonitor()
 	txn := m.Start("bulkRequest", w, r)
 	defer m.End(txn)
@@ -149,6 +156,7 @@ func bulkRequest(w http.ResponseWriter, r *http.Request) {
 		AcoID:          acoId,
 		UserID:         userId,
 		BeneficiaryIDs: beneficiaryIds,
+		ResourceType:   t,
 		// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
 		Encrypt: encrypt,
 	})

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -88,6 +88,12 @@ func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
+	if t != "ExplanationOfBenefit" && t != "Patient" {
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "Invalid resource type", responseutils.RequestErr)
+		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		return
+	}
+
 	m := monitoring.GetMonitor()
 	txn := m.Start("bulkRequest", w, r)
 	defer m.End(txn)

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -262,8 +263,11 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			scheme = "https"
 		}
 
+		re := regexp.MustCompile(`/(ExplanationOfBenefit|Patient)/\$export`)
+		resourceType := re.FindStringSubmatch(job.RequestURL)[1]
+
 		fi := fileItem{
-			Type: "ExplanationOfBenefit",
+			Type: resourceType,
 			URL:  fmt.Sprintf("%s://%s/data/%s/%s.ndjson", scheme, r.Host, jobID, job.AcoID),
 		}
 

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -56,11 +56,7 @@ import (
 )
 
 /*
-<<<<<<< HEAD
-	swagger:route GET /api/v1/ExplanationOfBenefit/$export bulkData bulkRequest
-=======
 	swagger:route GET /ExplanationOfBenefit/$export bulkData bulkEOBRequest
->>>>>>> Split bulkRequest into two routes and functions to enable Swagger docs
 
 	Start explanation of benefit export
 

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -56,7 +56,11 @@ import (
 )
 
 /*
+<<<<<<< HEAD
 	swagger:route GET /api/v1/ExplanationOfBenefit/$export bulkData bulkRequest
+=======
+	swagger:route GET /ExplanationOfBenefit/$export bulkData bulkEOBRequest
+>>>>>>> Split bulkRequest into two routes and functions to enable Swagger docs
 
 	Start explanation of benefit export
 
@@ -75,14 +79,35 @@ import (
 		400:ErrorModel
 		500:FHIRResponse
 */
-func bulkRequest(w http.ResponseWriter, r *http.Request) {
-	t := chi.URLParam(r, "resourceType")
-	if t != "ExplanationOfBenefit" && t != "Patient" {
-		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.InternalErr)
-		responseutils.WriteError(oo, w, http.StatusNotFound)
-		return
-	}
+func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
+	bulkRequest("ExplanationOfBenefit", w, r)
+}
 
+/*
+	swagger:route GET /Patient/$export bulkData bulkPatientRequest
+
+	Start patient data export
+
+	Initiates a job to collect data from the Blue Button API for your ACO.
+
+	Produces:
+	- application/fhir+json
+
+	Schemes: http, https
+
+	Security:
+		api_key
+
+	Responses:
+		202:BulkRequestResponse
+		400:ErrorModel
+		500:FHIRResponse
+*/
+func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
+	bulkRequest("Patient", w, r)
+}
+
+func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 	m := monitoring.GetMonitor()
 	txn := m.Start("bulkRequest", w, r)
 	defer m.End(txn)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -40,7 +40,7 @@ func (s *APITestSuite) SetupTest() {
 	s.rr = httptest.NewRecorder()
 }
 
-func (s *APITestSuite) TestBulkRequest() {
+func (s *APITestSuite) TestBulkEOBRequest() {
 	s.SetupAuthBackend()
 
 	acoID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
@@ -81,7 +81,7 @@ func (s *APITestSuite) TestBulkRequest() {
 
 	qc = que.NewClient(pgxpool)
 
-	handler := http.HandlerFunc(bulkRequest)
+	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
@@ -89,7 +89,7 @@ func (s *APITestSuite) TestBulkRequest() {
 	s.db.Where("uuid = ?", user.UUID).Delete(auth.User{})
 }
 
-func (s *APITestSuite) TestBulkRequestNoBeneficiariesInACO() {
+func (s *APITestSuite) TestBulkEOBRequestNoBeneficiariesInACO() {
 	s.SetupAuthBackend()
 
 	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
@@ -127,20 +127,20 @@ func (s *APITestSuite) TestBulkRequestNoBeneficiariesInACO() {
 
 	qc = que.NewClient(pgxpool)
 
-	handler := http.HandlerFunc(bulkRequest)
+	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 }
 
-func (s *APITestSuite) TestBulkRequestMissingToken() {
+func (s *APITestSuite) TestBulkEOBRequestMissingToken() {
 	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
 
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	handler := http.HandlerFunc(bulkRequest)
+	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
@@ -156,7 +156,7 @@ func (s *APITestSuite) TestBulkRequestMissingToken() {
 	assert.Equal(s.T(), responseutils.TokenErr, respOO.Issue[0].Details.Coding[0].Display)
 }
 
-func (s *APITestSuite) TestBulkRequestUserDoesNotExist() {
+func (s *APITestSuite) TestBulkEOBRequestUserDoesNotExist() {
 	s.SetupAuthBackend()
 
 	acoID := "dbbd1ce1-ae24-435c-807d-ed45953077d3"
@@ -178,7 +178,7 @@ func (s *APITestSuite) TestBulkRequestUserDoesNotExist() {
 	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	handler := http.HandlerFunc(bulkRequest)
+	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusInternalServerError, s.rr.Code)
@@ -194,7 +194,7 @@ func (s *APITestSuite) TestBulkRequestUserDoesNotExist() {
 	assert.Equal(s.T(), responseutils.DbErr, respOO.Issue[0].Details.Coding[0].Display)
 }
 
-func (s *APITestSuite) TestBulkRequestNoQueue() {
+func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 	qc = nil
 	s.SetupAuthBackend()
 
@@ -219,7 +219,7 @@ func (s *APITestSuite) TestBulkRequestNoQueue() {
 	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	handler := http.HandlerFunc(bulkRequest)
+	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusInternalServerError, s.rr.Code)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -265,9 +265,15 @@ func (s *APITestSuite) TestBulkPatientRequest() {
 	handler := http.HandlerFunc(bulkPatientRequest)
 	handler.ServeHTTP(s.rr, req)
 
-	fmt.Println("RESPONSE", s.rr.Body.String())
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+}
 
+func (s *APITestSuite) TestBulkRequestInvalidType() {
+	req := httptest.NewRequest("GET", "/api/v1/test/Foo/$export", nil)
+
+	bulkRequest("Foo", s.rr, req)
+
+	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
 }
 
 func (s *APITestSuite) TestJobStatusInvalidJobID() {

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -5,11 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/encryption"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/CMSgov/bcda-app/bcda/encryption"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
@@ -56,8 +57,12 @@ func (s *APITestSuite) TestBulkRequest() {
 	}
 	token.Valid = true
 
-	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
+	req := httptest.NewRequest("GET", "/api/v1/test/ExplanationOfBenefit/$export", nil)
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	queueDatabaseURL := os.Getenv("QUEUE_DATABASE_URL")
 	pgxcfg, err := pgx.ParseURI(queueDatabaseURL)
@@ -101,6 +106,10 @@ func (s *APITestSuite) TestBulkRequestNoBeneficiariesInACO() {
 	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
 	queueDatabaseURL := os.Getenv("QUEUE_DATABASE_URL")
 	pgxcfg, err := pgx.ParseURI(queueDatabaseURL)
 	if err != nil {
@@ -126,6 +135,10 @@ func (s *APITestSuite) TestBulkRequestNoBeneficiariesInACO() {
 
 func (s *APITestSuite) TestBulkRequestMissingToken() {
 	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	handler := http.HandlerFunc(bulkRequest)
 	handler.ServeHTTP(s.rr, req)
@@ -160,6 +173,10 @@ func (s *APITestSuite) TestBulkRequestUserDoesNotExist() {
 
 	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	handler := http.HandlerFunc(bulkRequest)
 	handler.ServeHTTP(s.rr, req)
@@ -197,6 +214,11 @@ func (s *APITestSuite) TestBulkRequestNoQueue() {
 
 	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("resourceType", "ExplanationOfBenefit")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
 	handler := http.HandlerFunc(bulkRequest)
 	handler.ServeHTTP(s.rr, req)
 

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -20,7 +20,8 @@ var logger *logrus.Logger
 const blueButtonBasePath = "/v1/fhir"
 
 type APIClient interface {
-	GetExplanationOfBenefitData(patientID string, jobID string) (string, error)
+	GetExplanationOfBenefitData(patientID, jobID string) (string, error)
+	GetPatientData(patientID, jobID string) (string, error)
 }
 
 type BlueButtonClient struct {
@@ -78,14 +79,16 @@ func NewBlueButtonClient() (*BlueButtonClient, error) {
 	return &BlueButtonClient{*client}, nil
 }
 
-func (bbc *BlueButtonClient) GetPatientData(patientID string) (string, error) {
+type BeneDataFunc func(string, string) (string, error)
+
+func (bbc *BlueButtonClient) GetPatientData(patientID, jobID string) (string, error) {
 	params := url.Values{}
 	params.Set("_id", patientID)
 	params.Set("_format", "application/fhir+json")
 	return bbc.getData(blueButtonBasePath+"/Patient/", params, "")
 }
 
-func (bbc *BlueButtonClient) GetCoverageData(beneficiaryID string) (string, error) {
+func (bbc *BlueButtonClient) GetCoverageData(beneficiaryID, jobID string) (string, error) {
 	params := url.Values{}
 	params.Set("beneficiary", beneficiaryID)
 	params.Set("_format", "application/fhir+json")

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -37,13 +37,13 @@ func (s *BBTestSuite) SetupTest() {
 }
 
 func (s *BBTestSuite) TestGetBlueButtonPatientData() {
-	p, err := s.bbClient.GetPatientData("012345")
+	p, err := s.bbClient.GetPatientData("012345", "543210")
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), `{ "test": "ok" }`, p)
 }
 
 func (s *BBTestSuite) TestGetBlueButtonCoverageData() {
-	c, err := s.bbClient.GetCoverageData("012345")
+	c, err := s.bbClient.GetCoverageData("012345", "543210")
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), `{ "test": "ok" }`, c)
 }

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -39,6 +39,7 @@ type jobEnqueueArgs struct {
 	AcoID          string
 	UserID         string
 	BeneficiaryIDs []string
+	ResourceType   string
 	// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
 	Encrypt bool
 }

--- a/bcda/responseutils/issuedetail.go
+++ b/bcda/responseutils/issuedetail.go
@@ -7,4 +7,5 @@ const (
 	FormatErr   = "Formatting Error"
 	BbErr       = "Blue Button Error"
 	InternalErr = "Internal Error"
+	RequestErr  = "Request Error"
 )

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -25,7 +25,8 @@ func NewAPIRouter() http.Handler {
 		}
 	})
 	r.Route("/api/v1", func(r chi.Router) {
-		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/{resourceType:ExplanationOfBenefit|Patient}/$export", bulkRequest)
+		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/ExplanationOfBenefit/$export", bulkEOBRequest)
+		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/Patient/$export", bulkPatientRequest)
 		r.With(auth.RequireTokenAuth).Get("/jobs/{jobId}", jobStatus)
 		r.Get("/metadata", metadata)
 		if os.Getenv("DEBUG") == "true" {

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -26,7 +26,9 @@ func NewAPIRouter() http.Handler {
 	})
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/ExplanationOfBenefit/$export", bulkEOBRequest)
-		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/Patient/$export", bulkPatientRequest)
+		if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
+			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/Patient/$export", bulkPatientRequest)
+		}
 		r.With(auth.RequireTokenAuth).Get("/jobs/{jobId}", jobStatus)
 		r.Get("/metadata", metadata)
 		if os.Getenv("DEBUG") == "true" {

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -25,7 +25,7 @@ func NewAPIRouter() http.Handler {
 		}
 	})
 	r.Route("/api/v1", func(r chi.Router) {
-		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/ExplanationOfBenefit/$export", bulkRequest)
+		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get("/{resourceType:ExplanationOfBenefit|Patient}/$export", bulkRequest)
 		r.With(auth.RequireTokenAuth).Get("/jobs/{jobId}", jobStatus)
 		r.Get("/metadata", metadata)
 		if os.Getenv("DEBUG") == "true" {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -33,6 +33,7 @@ type jobEnqueueArgs struct {
 	AcoID          string
 	UserID         string
 	BeneficiaryIDs []string
+	ResourceType   string
 	// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
 	Encrypt bool
 }
@@ -91,7 +92,8 @@ func processJob(j *que.Job) error {
 			return err
 		}
 	}
-	err = writeEOBDataToFile(bb, jobArgs.AcoID, jobArgs.BeneficiaryIDs, jobID)
+
+	err = writeBBDataToFile(bb, jobArgs.AcoID, jobArgs.BeneficiaryIDs, jobID, jobArgs.ResourceType)
 
 	if err != nil {
 		exportJob.Status = "Failed"
@@ -151,16 +153,29 @@ func processJob(j *que.Job) error {
 	return nil
 }
 
-func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []string, jobID string) error {
-	re := regexp.MustCompile("[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}")
-	if !re.Match([]byte(acoID)) {
-		err := errors.New("Invalid ACO ID")
+func writeBBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []string, jobID, t string) error {
+	if bb == nil {
+		err := errors.New("Blue Button client is required")
 		log.Error(err)
 		return err
 	}
 
-	if bb == nil {
-		err := errors.New("Blue Button client is required")
+	// TODO: Should this error be returned or written to file?
+	var bbFunc client.BeneDataFunc
+	switch t {
+	case "ExplanationOfBenefit":
+		bbFunc = bb.GetExplanationOfBenefitData
+	case "Patient":
+		bbFunc = bb.GetPatientData
+	default:
+		err := fmt.Errorf("Invalid resource type requested: %s", t)
+		log.Error(err)
+		return err
+	}
+
+	re := regexp.MustCompile("[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}")
+	if !re.Match([]byte(acoID)) {
+		err := errors.New("Invalid ACO ID")
 		log.Error(err)
 		return err
 	}
@@ -177,12 +192,12 @@ func writeEOBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []stri
 	w := bufio.NewWriter(f)
 
 	for _, beneficiaryID := range beneficiaryIDs {
-		pData, err := bb.GetExplanationOfBenefitData(beneficiaryID, jobID)
+		pData, err := bbFunc(beneficiaryID, jobID)
 		if err != nil {
 			log.Error(err)
-			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving ExplanationOfBenefit for beneficiary %s in ACO %s", beneficiaryID, acoID), jobID)
+			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving %s for beneficiary %s in ACO %s", t, beneficiaryID, acoID), jobID)
 		} else {
-			fhirBundleToResourceNDJSON(w, pData, "ExplanationOfBenefits", beneficiaryID, acoID, jobID)
+			fhirBundleToResourceNDJSON(w, pData, t, beneficiaryID, acoID, jobID)
 		}
 	}
 
@@ -217,12 +232,12 @@ func appendErrorToFile(acoID, code, detailsCode, detailsDisplay string, jobID st
 	}
 }
 
-func fhirBundleToResourceNDJSON(w *bufio.Writer, jsonData, jsonType, beneficiaryID, acoID string, jobID string) {
+func fhirBundleToResourceNDJSON(w *bufio.Writer, jsonData, jsonType, beneficiaryID, acoID, jobID string) {
 	var jsonOBJ map[string]interface{}
 	err := json.Unmarshal([]byte(jsonData), &jsonOBJ)
 	if err != nil {
 		log.Error(err)
-		appendErrorToFile(acoID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error UnMarshaling %s from data for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
+		appendErrorToFile(acoID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error UnMarshaling %s resources from data for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
 		return
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - ATO_PUBLIC_KEY_FILE=../../shared_files/ATO_public.pem
       - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
       - HTTP_ONLY=true
+      - ENABLE_PATIENT_EXPORT=true
     volumes:
      - .:/go/src/github.com/CMSgov/bcda-app
     ports:

--- a/test/integration_test/patient-notoken.json
+++ b/test/integration_test/patient-notoken.json
@@ -1,0 +1,4 @@
+{
+	"required": ["resourceType", "issue"]
+}
+

--- a/test/integration_test/patient.toml
+++ b/test/integration_test/patient.toml
@@ -1,0 +1,9 @@
+[bcda-patient-request-test]
+name = "Patient request test (invalid token)"
+uri = "{{.PROTOCOL}}://{{.HOST}}/api/v1/Patient/$export"
+method = "GET"
+	[bcda-patient-request-test.assert]
+		[bcda-patient-request-test.assert.code]
+		code = 401
+                [bcda-patient-request-test.assert.jsonschema]
+                ref = "./patient-notoken.json"

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -58,10 +58,10 @@ func getAccessToken() string {
 	return string(respData)
 }
 
-func startJob() *http.Response {
+func startJob(resourceType string) *http.Response {
 	client := &http.Client{}
 	req, err := http.NewRequest(
-		"GET", fmt.Sprintf("%s://%s/api/v1/ExplanationOfBenefit/$export", proto, apiHost), nil)
+		"GET", fmt.Sprintf("%s://%s/api/v1/%s/$export", proto, apiHost, resourceType), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -129,64 +129,66 @@ func writeFile(resp *http.Response) {
 }
 
 func main() {
-	fmt.Println("making request to start data aggregation job")
-	end := time.Now().Add(time.Duration(timeout) * time.Second)
-	if result := startJob(); result.StatusCode == 202 {
-		for {
-			<-time.After(5 * time.Second)
+	for _, t := range [2]string{"ExplanationOfBenefit", "Patient"} {
+		fmt.Printf("making request to start %s data aggregation job\n", t)
+		end := time.Now().Add(time.Duration(timeout) * time.Second)
+		if result := startJob(t); result.StatusCode == 202 {
+			for {
+				<-time.After(5 * time.Second)
 
-			if time.Now().After(end) {
-				fmt.Println("timeout exceeded...")
-				os.Exit(1)
-			}
-
-			fmt.Println("checking job status...")
-			status := checkStatus(result.Header["Content-Location"][0])
-
-			if status.StatusCode == 200 {
-				fmt.Println("file is ready for download...")
-
-				defer status.Body.Close()
-
-				var objmap map[string]*json.RawMessage
-				err := json.NewDecoder(status.Body).Decode(&objmap)
-				if err != nil {
-					panic(err)
-				}
-				output := (*json.RawMessage)(objmap["output"])
-
-				var data OutputCollection
-				if err := json.Unmarshal(*output, &data); err != nil {
-					panic(err)
-				}
-
-				fmt.Printf("fetching: %s\n", data[0].Url)
-				download := getFile(data[0].Url)
-				if download.StatusCode == 200 {
-					fmt.Println("writing download to disk: /tmp/download.json")
-					writeFile(download)
-
-					fmt.Println("validating file...")
-					fi, err := os.Stat("/tmp/download.json")
-					if err != nil {
-						panic(err)
-					}
-					if fi.Size() <= 0 {
-						fmt.Println("Error: file is empty!.")
-						os.Exit(1)
-					}
-					fmt.Println("done.")
-				} else {
-					fmt.Printf("error: unable to request file download... status is: %s\n", download.Status)
+				if time.Now().After(end) {
+					fmt.Println("timeout exceeded...")
 					os.Exit(1)
 				}
 
-				break
+				fmt.Println("checking job status...")
+				status := checkStatus(result.Header["Content-Location"][0])
+
+				if status.StatusCode == 200 {
+					fmt.Println("file is ready for download...")
+
+					defer status.Body.Close()
+
+					var objmap map[string]*json.RawMessage
+					err := json.NewDecoder(status.Body).Decode(&objmap)
+					if err != nil {
+						panic(err)
+					}
+					output := (*json.RawMessage)(objmap["output"])
+
+					var data OutputCollection
+					if err := json.Unmarshal(*output, &data); err != nil {
+						panic(err)
+					}
+
+					fmt.Printf("fetching: %s\n", data[0].Url)
+					download := getFile(data[0].Url)
+					if download.StatusCode == 200 {
+						fmt.Println("writing download to disk: /tmp/download.json")
+						writeFile(download)
+
+						fmt.Println("validating file...")
+						fi, err := os.Stat("/tmp/download.json")
+						if err != nil {
+							panic(err)
+						}
+						if fi.Size() <= 0 {
+							fmt.Println("Error: file is empty!.")
+							os.Exit(1)
+						}
+						fmt.Println("done.")
+					} else {
+						fmt.Printf("error: unable to request file download... status is: %s\n", download.Status)
+						os.Exit(1)
+					}
+
+					break
+				}
+				fmt.Println("  => job is still pending. waiting...")
 			}
-			fmt.Println("  => job is still pending. waiting...")
+		} else {
+			fmt.Printf("error: failed to start %s data aggregation job\n", t)
+			os.Exit(1)
 		}
-	} else {
-		fmt.Println("error: failed to start data aggregation job")
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### Fixes [BCDA-395](https://jira.cms.gov/browse/BCDA-395)
We need a way for ACOs to retrieve patient data as found in CCLF-8.

### Proposed changes:
* Add endpoint for starting a patient data export job


### Change Details
* Adds `/Patient/$export` route
* Adds resource type parameter to `bulkRequest()`
* Uses environment variable `ENABLE_PATIENT_EXPORT` to determine whether endpoint is accessible. Enabled only if that value is true.


### Security Implications
Retrieves PII from Blue Button and returns it in the generated data file.


### Acceptance Validation
Includes smoke and integration tests. Does *not* include Swagger docs because we can't seem to control that with an env var. There is a separate ticket for narrative documentation, which we can roll this into.


### Feedback Requested
Any
