### PR TITLE
BCDA-610: Narrative Documentation: /Patient endpoint for bulk export of patient data

### DIFF
--- a/API.md
+++ b/API.md
@@ -451,3 +451,132 @@ The response will be the requested data as FHIR ExplanationOfBenefit resources i
   ]
 }
 ```
+
+### Beneficiary Patient Data
+The process of retrieving patient data is very similar to exporting explanation of benefit data.
+
+#### 1. Obtain an access token
+See [Authentication and Authorization](#authentication-and-authorization) above.
+
+#### 2. Initiate an export job
+
+##### Request
+`GET /api/v1/Patient/$export`
+
+To start a patient data export job, a GET request is made to the Patient export endpoint. An access token as well as `Accept` and `Prefer` headers are required.
+
+The dollar sign ('$') before the word "export" in the URL indicates that the endpoint is an action rather than a resource. The format is defined by the [FHIR Bulk Data Export spec](https://github.com/smart-on-fhir/fhir-bulk-data-docs/blob/master/export.md).
+
+###### Headers
+* `Authorization: Bearer {token}`
+* `Accept: application/fhir+json`
+* `Prefer: respond-async`
+
+###### cURL command
+```sh
+curl -v https://sandbox.bcda.cms.gov/api/v1/Patient/\$export \
+-H 'Authorization: Bearer {token}' \
+-H 'Accept: application/fhir+json' \
+-H 'Prefer: respond-async'
+```
+
+##### Response
+If the request was successful, a `202 Accepted` response code will be returned and the response will include a `Content-Location` header. The value of this header indicates the location to check for job status and outcome. In the example header below, the number 43 in the URL represents the ID of the export job.
+
+###### Headers
+* `Content-Location: https://sandbox.bcda.cms.gov/api/v1/jobs/43`
+
+#### 3. Check the status of the export job
+
+##### Request
+`GET https://sandbox.bcda.cms.gov/api/v1/jobs/43`
+
+Using the `Content-Location` header value from the Patient data export response, you can check the status of the export job. The status will change from `202 Accepted` to `200 OK` when the export job is complete and the data is ready to be downloaded.
+
+###### Headers
+* `Authorization: Bearer {token}`
+
+###### cURL Command
+```sh
+curl -v https://sandbox.bcda.cms.gov/api/v1/jobs/43 \
+-H 'Authorization: Bearer {token}'
+```
+
+##### Responses
+* `202 Accepted` indicates that the job is processing. Headers will include `X-Progress: In Progress`
+* `200 OK` indicates that the job is complete. Below is an example of the format of the response body.
+```json
+{
+  "transactionTime": "2018-10-19T14:47:33.975024Z",
+  "request": "https://sandbox.bcda.cms.gov/api/v1/Patient/$export",
+  "requiresAccessToken": true,
+  "output": [
+    {
+      "type": "Patient",
+      "url": "https://sandbox.bcda.cms.gov/data/43/DBBD1CE1-AE24-435C-807D-ED45953077D3.ndjson"
+    }
+  ],
+  "error": [
+    {
+      "type": "OperationOutcome",
+      "url": "https://sandbox.bcda.cms.gov/data/43/DBBD1CE1-AE24-435C-807D-ED45953077D3-error.ndjson"
+    }
+  ]
+}
+```
+Patient demographic data can be found at the URLs within the `output` field. The number 43 in the data file URLs is the same job ID from the `Content-Location` header URL in previous step. If some of the data cannot be exported due to errors, details of the errors can be found at the URLs in the `error` field. The errors are provided in an NDJSON file as FHIR [OperationOutcome](https://www.hl7.org/fhir/operationoutcome.html) resources.
+
+#### 4. Retrieve the NDJSON output file(s)
+To obtain the exported explanation of benefit data, a GET request is made to the output URLs in the job status response when the job reaches the Completed state. The data will be presented as an NDJSON file of [Patient](https://www.hl7.org/fhir/patient.html) resources.
+
+##### Request
+`GET https://sandbox.bcda.cms.gov/data/43/DBBD1CE1-AE24-435C-807D-ED45953077D3.ndjson`
+
+###### Headers
+* `Authorization: Bearer {token}`
+
+###### cURL command
+```sh
+curl https://sandbox.bcda.cms.gov/data/43/DBBD1CE1-AE24-435C-807D-ED45953077D3.ndjson \
+-H 'Authorization: Bearer {token}'
+```
+
+##### Response
+The response will be the requested data as FHIR Patient resources in NDJSON format. An example of one such resource is shown below.
+
+```json
+{
+	"fullUrl": "https:///v1/fhir/Patient/19990000002901",
+	"resource": {
+		"address": [{
+			"district": "999",
+			"postalCode": "99999",
+			"state": "34"
+		}],
+		"birthDate": "1999-06-01",
+		"extension": [{
+			"url": "https://bluebutton.cms.gov/resources/variables/race",
+			"valueCoding": {
+				"code": "1",
+				"display": "White",
+				"system": "https://bluebutton.cms.gov/resources/variables/race"
+			}
+		}],
+		"gender": "unknown",
+		"id": "19990000002901",
+		"identifier": [{
+			"system": "https://bluebutton.cms.gov/resources/variables/bene_id",
+			"value": "19990000002901"
+		}, {
+			"system": "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
+			"value": "77174c6546668151f741cca47739271baf364d19825a387101d39fc303d91f2c"
+		}],
+		"name": [{
+			"family": "Doe",
+			"given": ["Jane", "X"],
+			"use": "usual"
+		}],
+		"resourceType": "Patient"
+	}
+}
+```

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -55,7 +55,7 @@ import (
 )
 
 /*
-  swagger:route GET /api/v1/ExplanationOfBenefit/$export bulkData bulkRequest
+  	swagger:route GET /api/v1/ExplanationOfBenefit/$export bulkData bulkRequest
 
 	Start explanation of benefit export
 
@@ -79,7 +79,7 @@ func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	swagger:route GET /Patient/$export bulkData bulkRequest
+	swagger:route GET /api/v1/Patient/$export bulkData bulkRequest
 
 	Start patient data export
 

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -56,7 +56,7 @@ import (
 )
 
 /*
-	swagger:route GET /ExplanationOfBenefit/$export bulkData bulkEOBRequest
+	swagger:route GET /ExplanationOfBenefit/$export bulkData bulkRequest
 
 	Start explanation of benefit export
 
@@ -80,7 +80,7 @@ func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	swagger:route GET /Patient/$export bulkData bulkPatientRequest
+	swagger:route GET /Patient/$export bulkData bulkRequest
 
 	Start patient data export
 

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -79,6 +79,26 @@ func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("ExplanationOfBenefit", w, r)
 }
 
+/*
+	swagger:route GET /Patient/$export bulkData bulkPatientRequest
+
+	Start patient data export
+
+	Initiates a job to collect data from the Blue Button API for your ACO.
+
+	Produces:
+	- application/fhir+json
+
+	Schemes: [http, https]
+
+	Security:
+		api_key
+
+	Responses:
+		202:BulkRequestResponse
+		400:ErrorModel
+		500:FHIRResponse
+*/
 func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("Patient", w, r)
 }


### PR DESCRIPTION
### Fixes [BCDA-610](https://jira.cms.gov/browse/BCDA-610)
We don't yet have narrative or Swagger documentation for our new Patient data export endpoint.

Note: This will not be merged until we are ready to release the new endpoint.

### Proposed changes:
Create narrative and Swagger docs for /Patient/$export

### Change Details
* Adds Patient export example to API.md
* Adds Swagger-generating comment to `bulkPatientRequest()` in api.go

### Security Implications
None

### Acceptance Validation
Narrative documentation can be seen in Markdown file.

Swagger:
<img width="451" alt="screen shot 2018-12-06 at 3 19 33 pm" src="https://user-images.githubusercontent.com/1923441/49609735-6455e300-f96a-11e8-996f-abab5fd7c4ff.png">

### Feedback Requested
Any