### PR TITLE
fix the bug

### DIFF
--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -133,6 +133,11 @@ func processJob(j *que.Job) error {
 					log.Error(err)
 					return err
 				}
+				err = os.Remove(oldpath)
+				if err != nil {
+					log.Error(err)
+					return err
+				}
 			}
 		}
 		err = os.Remove(staging)


### PR DESCRIPTION
### Fixes [BCDA-654](https://jira.cms.gov/browse/BCDA-654)

Encrypting data files for delivery broke after a recent commit.

### Change Details
In PR-85 we added a bunch of missing error handling. That error handling caught a previously silent error that was occurring only when we were delivering encrypted files.

The steps were:

1. Get BB data and put it in a staging directory
2. encrypt that data in memory
3. write the encrypted data to a file in the data directory
4. remove the staging directory  <<< PR-85 catches the error here

The steps are now:

1. Get BB data and put it in a staging directory
2. encrypt that data in memory
3. write the encrypted data to a file in the data directory
4. remove the bb data files from the staging directory <<< this PR adds this missing step
5. remove the staging directory 


### Security Implications
None

### Acceptance Validation
Hand testing only by sending an encrypt=true parameter on an $export request.

