### PR TITLE
BCDA-609 Feature: Updated capability statement with Patient endpoint

### DIFF
--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -117,11 +117,11 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 			},
 		},
 	}
-	checkEnv(statement, baseurl)
+	addPatientEndpointToStatement(statement, baseurl)
 	return statement
 }
 
-func checkEnv(statement *fhirmodels.CapabilityStatement, baseUrl string) {
+func addPatientEndpointToStatement(statement *fhirmodels.CapabilityStatement, baseUrl string) {
 	if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
 		restComponent := statement.Rest[0].Operation
 

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -117,8 +117,24 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 			},
 		},
 	}
-
+	checkEnv(statement, baseurl)
 	return statement
+}
+
+func checkEnv(statement *fhirmodels.CapabilityStatement, baseUrl string) {
+	if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
+		restComponent := statement.Rest[0].Operation
+
+		element := fhirmodels.CapabilityStatementRestOperationComponent{
+			Name: "export",
+			Definition: &fhirmodels.Reference{
+				Reference: baseUrl + "/api/v1/Patient/$export",
+				Type:      "Endpoint",
+			},
+		}
+		restComponent = append(restComponent, element)
+		statement.Rest[0].Operation = restComponent
+	}
 }
 
 func WriteCapabilityStatement(statement *fhirmodels.CapabilityStatement, w http.ResponseWriter) {


### PR DESCRIPTION
Fixes [BCDA-609](https://jira.cms.gov/browse/BCDA-609)

Problem:
Capability statement was out of date with our latest code changes, specifically the Patient endpoint that was recently added.

Proposed changes:
This will adjust our capability statement to correctly reflect all of our endpoints (in their respective environments)

Change Details:
bcda/responseutils/writer.go -- updated capability statement with the "Patient" endpoint

Security Implications:
No PII/PHI but this statement should only show the Patient endpoint when that environment is configured to expose that resource.

Acceptance Validation:
Be sure capability statement shows the correct metadata in the correct environments.

Feedback Requested
Any