### PR TITLE
BCDA-659: Ensure that ConnectionClose middleware is always called

### DIFF
--- a/bcda/router.go
+++ b/bcda/router.go
@@ -42,8 +42,9 @@ func NewAPIRouter() http.Handler {
 
 func NewDataRouter() http.Handler {
 	r := chi.NewRouter()
+	r.Use(ConnectionClose)
 	r.With(auth.ParseToken, logging.NewStructuredLogger(), auth.RequireTokenAuth,
-		auth.RequireTokenACOMatch, ConnectionClose).Get("/data/{jobID}/{acoID}.ndjson", serveData)
+		auth.RequireTokenACOMatch).Get("/data/{jobID}/{acoID}.ndjson", serveData)
 	return r
 }
 


### PR DESCRIPTION
### Fixes [BCDA-659](https://jira.cms.gov/browse/BCDA-659)
When making repeated API requests, there are sometimes unexpected 404s. Repeatable when making a failed data request followed by an API request.

### Proposed changes:
Adjust data router middleware to ensure that connections are closed.

### Change Details
* Moves `ConnectionClose` from `r.With()` to `r.Use()` in `NewDataRouter()`

### Security Implications
None

### Acceptance Validation
To confirm, make a request to download data with no token (to cause an error response), followed by a request to any API endpoint. This should cause a 404 for the API request without this change, but a success response for this branch.

### Feedback Requested
Any
