### PR TITLE
BCDA-648 Feature: Wrapped http handlers for monitoring

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -43,7 +43,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
-	"github.com/CMSgov/bcda-app/bcda/monitoring"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/bgentry/que-go"
@@ -90,10 +89,6 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		responseutils.WriteError(oo, w, http.StatusBadRequest)
 		return
 	}
-
-	m := monitoring.GetMonitor()
-	txn := m.Start("bulkRequest", w, r)
-	defer m.End(txn)
 
 	var (
 		claims jwt.MapClaims
@@ -220,10 +215,6 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		500:FHIRResponse
 */
 func jobStatus(w http.ResponseWriter, r *http.Request) {
-	m := monitoring.GetMonitor()
-	txn := m.Start("jobStatus", w, r)
-	defer m.End(txn)
-
 	jobID := chi.URLParam(r, "jobId")
 	db := database.GetGORMDbConnection()
 	defer db.Close()
@@ -347,10 +338,6 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 		500:FHIRResponse
 */
 func serveData(w http.ResponseWriter, r *http.Request) {
-	m := monitoring.GetMonitor()
-	txn := m.Start("serveData", w, r)
-	defer m.End(txn)
-
 	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")
 	acoID := chi.URLParam(r, "acoID")
 	jobID := chi.URLParam(r, "jobID")
@@ -358,10 +345,6 @@ func serveData(w http.ResponseWriter, r *http.Request) {
 }
 
 func getToken(w http.ResponseWriter, r *http.Request) {
-	m := monitoring.GetMonitor()
-	txn := m.Start("getToken", w, r)
-	defer m.End(txn)
-
 	authBackend := auth.InitAuthBackend()
 
 	db := database.GetGORMDbConnection()

--- a/bcda/monitoring/monitoring.go
+++ b/bcda/monitoring/monitoring.go
@@ -50,3 +50,10 @@ func GetMonitor() *apm {
 	}
 	return a
 }
+
+func (a apm) WrapHandler(pattern string, h http.HandlerFunc) (string, func(http.ResponseWriter, *http.Request)) {
+	if a.App != nil {
+		return newrelic.WrapHandleFunc(a.App, pattern, h)
+	}
+	return "", nil
+}

--- a/bcda/monitoring/monitoring.go
+++ b/bcda/monitoring/monitoring.go
@@ -50,10 +50,3 @@ func GetMonitor() *apm {
 	}
 	return a
 }
-
-func (a apm) WrapHandler(pattern string, h http.HandlerFunc) (string, func(http.ResponseWriter, *http.Request)) {
-	if a.App != nil {
-		return newrelic.WrapHandleFunc(a.App, pattern, h)
-	}
-	return "", nil
-}

--- a/bcda/monitoring/monitoring.go
+++ b/bcda/monitoring/monitoring.go
@@ -50,3 +50,10 @@ func GetMonitor() *apm {
 	}
 	return a
 }
+
+func (a apm) WrapHandler(pattern string, h http.HandlerFunc) (string, func(http.ResponseWriter, *http.Request)) {
+	if a.App != nil {
+		return newrelic.WrapHandleFunc(a.App, pattern, h)
+	}
+	return pattern, h
+}

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	newrelic "github.com/newrelic/go-agent"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
@@ -28,14 +27,14 @@ func NewAPIRouter() http.Handler {
 		}
 	})
 	r.Route("/api/v1", func(r chi.Router) {
-		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(newrelic.WrapHandleFunc(m.App, "/ExplanationOfBenefit/$export", bulkEOBRequest))
+		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/ExplanationOfBenefit/$export", bulkEOBRequest))
 		if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
-			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(newrelic.WrapHandleFunc(m.App, "/Patient/$export", bulkPatientRequest))
+			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Patient/$export", bulkPatientRequest))
 		}
-		r.With(auth.RequireTokenAuth).Get(newrelic.WrapHandleFunc(m.App, "/jobs/{jobId}", jobStatus))
+		r.With(auth.RequireTokenAuth).Get(m.WrapHandler("/jobs/{jobId}", jobStatus))
 		r.Get("/metadata", metadata)
 		if os.Getenv("DEBUG") == "true" {
-			r.Get(newrelic.WrapHandleFunc(m.App, "/token", getToken))
+			r.Get(m.WrapHandler("/token", getToken))
 		}
 	})
 	r.Get("/_version", getVersion)
@@ -47,7 +46,7 @@ func NewDataRouter() http.Handler {
 	m := monitoring.GetMonitor()
 	r.Use(ConnectionClose)
 	r.With(auth.ParseToken, logging.NewStructuredLogger(), auth.RequireTokenAuth,
-		auth.RequireTokenACOMatch).Get(newrelic.WrapHandleFunc(m.App, "/data/{jobID}/{acoID}.ndjson", serveData))
+		auth.RequireTokenACOMatch).Get(m.WrapHandler("/data/{jobID}/{acoID}.ndjson", serveData))
 	return r
 }
 


### PR DESCRIPTION
Fixes [BCDA-648](https://jira.cms.gov/browse/BCDA-648)

Problem:
We needed a way to capture more properties for our nrql queries and wrapping our html handlers provides those additional bits of information.

Proposed changes:
bcda/monitoring/monitoring.go - added a wrapper function for the new relic handler
bcda/router.go - added handler wrapping for our routes
bcda/api.go - removed old way of capturing a transaction

Security Implications:
None

Acceptance Validation:
Running new relic with the changes gives us additional query parameters for our transactions

Feedback Requested:
Any