### PR TITLE
BCDA-645: Create /_health endpoint

### DIFF
--- a/Dockerfiles/Dockerfile.integration_test
+++ b/Dockerfiles/Dockerfile.integration_test
@@ -25,4 +25,4 @@ WORKDIR /go/src/github.com/CMSgov/bcda-app/test/integration_test
 
 # Use simple tester command once the fork gets merged to main repo
 # CMD ["tester", "-var", "PROTOCOL=http", "-var", "HOST=api:3000", "version.toml", "swagger.toml", "metadata.toml", "jobs.toml", "eob.toml"]
-CMD ["go", "run", "/go/src/github.com/whytheplatypus/tester/main.go", "-var", "PROTOCOL=http", "-var", "HOST=api:3000", "version.toml", "swagger.toml", "metadata.toml", "jobs.toml", "eob.toml", "patient.toml"]
+CMD ["go", "run", "/go/src/github.com/whytheplatypus/tester/main.go", "-var", "PROTOCOL=http", "-var", "HOST=api:3000", "version.toml", "swagger.toml", "metadata.toml", "jobs.toml", "eob.toml", "patient.toml", "health.toml"]

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -465,6 +465,29 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func healthCheck(w http.ResponseWriter, r *http.Request) {
+	m := make(map[string]string)
+
+	if database.GetGORMDbConnection().DB().Ping() == nil {
+		m["database"] = "ok"
+		w.WriteHeader(http.StatusOK)
+	} else {
+		m["database"] = "error"
+		w.WriteHeader(http.StatusBadGateway)
+	}
+
+	respJSON, err := json.Marshal(m)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(respJSON)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}
+
 func readTokenClaims(r *http.Request) (jwt.MapClaims, error) {
 	var (
 		claims jwt.MapClaims

--- a/bcda/database/connection.go
+++ b/bcda/database/connection.go
@@ -2,25 +2,26 @@ package database
 
 import (
 	"database/sql"
+	"log"
+	"os"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/lib/pq"
-	"log"
-	"os"
 )
 
 // Variable substitution to support testing.
-var logFatal = log.Fatal
+var LogFatal = log.Fatal
 
 func GetDbConnection() *sql.DB {
 	databaseURL := os.Getenv("DATABASE_URL")
 	db, err := sql.Open("postgres", databaseURL)
 	if err != nil {
-		logFatal(err)
+		LogFatal(err)
 	}
 	pingErr := db.Ping()
 	if pingErr != nil {
-		logFatal(pingErr)
+		LogFatal(pingErr)
 	}
 	return db
 }
@@ -29,11 +30,11 @@ func GetGORMDbConnection() *gorm.DB {
 	databaseURL := os.Getenv("DATABASE_URL")
 	db, err := gorm.Open("postgres", databaseURL)
 	if err != nil {
-		logFatal(err)
+		LogFatal(err)
 	}
 	pingErr := db.DB().Ping()
 	if pingErr != nil {
-		logFatal(pingErr)
+		LogFatal(pingErr)
 	}
 	return db
 }

--- a/bcda/database/connection_test.go
+++ b/bcda/database/connection_test.go
@@ -3,11 +3,12 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 type ConnectionTestSuite struct {
@@ -19,11 +20,11 @@ type ConnectionTestSuite struct {
 func (suite *ConnectionTestSuite) TestDbConnections() {
 
 	// after this test, replace the original log.Fatal() function
-	origLogFatal := logFatal
-	defer func() { logFatal = origLogFatal }()
+	origLogFatal := LogFatal
+	defer func() { LogFatal = origLogFatal }()
 
 	// create the mock version of log.Fatal()
-	logFatal = func(args ...interface{}) {
+	LogFatal = func(args ...interface{}) {
 		fmt.Println("FATAL (NO-OP)")
 	}
 

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -36,6 +36,7 @@ func NewAPIRouter() http.Handler {
 		}
 	})
 	r.Get("/_version", getVersion)
+	r.Get("/_health", healthCheck)
 	return r
 }
 

--- a/test/Beneficiary Claims Data API Tests, Sequential.postman_collection.json
+++ b/test/Beneficiary Claims Data API Tests, Sequential.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6fd2f4ae-9805-477a-bca6-22e70d94cd8f",
+		"_postman_id": "77534917-a94a-4ca8-a3a5-cc25170c681d",
 		"name": "Beneficiary Claims Data API Tests, Sequential",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -142,6 +142,42 @@
 						"api",
 						"v1",
 						"metadata"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Health check",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d982c280-433d-4732-8169-bc7d8ed0a217",
+						"exec": [
+							"pm.test(\"Response contains database status\", function() {",
+							"    pm.expect(pm.response.json()).to.have.property(\"database\");",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}/_health",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"_health"
 					]
 				}
 			},

--- a/test/Beneficiary Claims Data API Tests.postman_collection.json
+++ b/test/Beneficiary Claims Data API Tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6071963a-3f7c-4f40-965b-7ebff2e8727b",
+		"_postman_id": "8736f37c-2dd2-4668-8fd1-3cde6c55f164",
 		"name": "Beneficiary Claims Data API Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -570,6 +570,42 @@
 					],
 					"path": [
 						"_version"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Health check",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d982c280-433d-4732-8169-bc7d8ed0a217",
+						"exec": [
+							"pm.test(\"Response contains database status\", function() {",
+							"    pm.expect(pm.response.json()).to.have.property(\"database\");",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}/_health",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"_health"
 					]
 				}
 			},

--- a/test/integration_test/health.json
+++ b/test/integration_test/health.json
@@ -1,0 +1,4 @@
+{
+	"required": ["database"]
+}
+

--- a/test/integration_test/health.toml
+++ b/test/integration_test/health.toml
@@ -1,0 +1,10 @@
+[bcda-health-request-test]
+name = "Health check request test"
+uri = "{{.PROTOCOL}}://{{.HOST}}/_health"
+method = "GET"
+	[bcda-health-request-test.assert]
+		[bcda-health-request-test.assert.code]
+		code = 200
+                [bcda-health-request-test.assert.jsonschema]
+		ref = "./health.json"
+


### PR DESCRIPTION
### Fixes [BCDA-645](https://jira.cms.gov/browse/BCDA-645)
We need a way to check the health of the API.

### Proposed changes:
Add a health check endpoint that returns a response based on database connectivity. Note that this ticket originally included Blue Button connectivity, but that will be checked by the worker application instead.

### Change Details
* Creates unauthenticated endpoint, `/_health`
  * Checks database with GORM`Ping()`
  * Returns `200 OK` if database is accessible and `502 Bad Gateway` if not
  * Includes tests in api_test.go

### Security Implications
None

### Acceptance Validation
![screen shot 2018-12-17 at 12 00 15 pm](https://user-images.githubusercontent.com/1923441/50103485-b82bbc00-01f5-11e9-9a92-718e6aa65b1a.png)

### Feedback Requested
Any

