### PR TITLE
knollfear/bcda-667 clean up job encryption keys

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -279,13 +279,11 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			URL:  fmt.Sprintf("%s://%s/data/%s/%s.ndjson", scheme, r.Host, jobID, job.AcoID),
 		}
 
-		var jobKeys []string
 		keyMap := make(map[string]string)
 		var jobKeysObj []models.JobKey
 		db.Find(&jobKeysObj, "job_id = ?", job.ID)
 		for _, jobKey := range jobKeysObj {
-			jobKeys = append(jobKeys, hex.EncodeToString(jobKey.EncryptedKey)+"|"+jobKey.FileName)
-			keyMap[jobKey.FileName] = hex.EncodeToString(jobKey.EncryptedKey)
+			keyMap[strings.TrimSpace(jobKey.FileName)] = hex.EncodeToString(jobKey.EncryptedKey)
 		}
 
 		rb := bulkResponseBody{
@@ -293,9 +291,9 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			RequestURL:          job.RequestURL,
 			RequiresAccessToken: true,
 			Files:               []fileItem{fi},
-			Keys:                jobKeys,
 			Errors:              []fileItem{},
 			KeyMap:              keyMap,
+			JobID:               job.ID,
 		}
 
 		errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), jobID, job.AcoID)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -451,7 +451,6 @@ func (s *APITestSuite) TestJobStatusCompleted() {
 	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
 	assert.Equal(s.T(), expectedurl, rb.Files[0].URL)
 	assert.NotNil(s.T(), rb.KeyMap)
-	assert.NotNil(s.T(), rb.Keys)
 	assert.Empty(s.T(), rb.Errors)
 
 	s.db.Delete(&j)

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -66,13 +66,11 @@ type bulkResponseBody struct {
 	// Files included in the payload
 	// collection format: csv
 	Files []fileItem `json:"output"`
-	// Keys created during encryption of the files for this job
-	// These keys are encrypted using the ACO's public key
-	Keys []string `json:"keys"`
 	// Errors encountered during processing
 	// collection format: csv
 	Errors []fileItem        `json:"error"`
 	KeyMap map[string]string `json:"KeyMap"`
+	JobID  uint
 }
 
 func init() {


### PR DESCRIPTION
Removing JobKey list, cleaning up filenames for the key map and adding Job ID to the payload.

<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->
### Fixes [BCDA-667](https://jira.cms.gov/browse/BCDA-667)

<!-- describe the problem being solved here -->
THe encryption keys were being delivered in 2 ways, it looks like the map was better, but it had some extra white space so that was removed.  In addition a job ID was added to the payload to make it easier to associate the result and the job
### Proposed changes:
<!-- List of changes with bullet points here: -->
removed keylist from job status response
trimmed whitespace from file name in KeyMap
Added in job id to the payload

### Change Details
<!-- add detailed discussion of changes here: -->


### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
removes one copy of the keys used to generate the files, but no meaningful change to PII

### Acceptance Validation
<!-- were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
Run bulk export job (with encryption) to completion
Verify completed status body has only a key map
verify the job ID is part of the payload
<!-- insert screenshots if applicable (drag images here) -->

![image](https://user-images.githubusercontent.com/42681520/50116167-6a27b000-0217-11e9-813f-b56501b7993a.png)

### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
