### PR TITLE
BCDA-628: Move models from auth to bcda

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -367,7 +367,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 
-	var user auth.User
+	var user models.User
 	err := db.First(&user, "name = ?", "User One").Error
 	if err != nil {
 		log.Error(err)
@@ -376,7 +376,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var aco auth.ACO
+	var aco models.ACO
 	err = db.First(&aco, "name = ?", "ACO Dev").Error
 	if err != nil {
 		log.Error(err)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/CMSgov/bcda-app/bcda/encryption"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -41,10 +40,10 @@ func (s *APITestSuite) SetupTest() {
 }
 
 func (s *APITestSuite) TestBulkEOBRequest() {
-	s.SetupAuthBackend()
+	//s.SetupAuthBackend()
 
 	acoID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
-	user, err := s.AuthBackend.CreateUser("api.go Test User", "testbulkeobrequest@example.com", uuid.Parse(acoID))
+	user, err := models.CreateUser("api.go Test User", "testbulkeobrequest@example.com", uuid.Parse(acoID))
 	if err != nil {
 		s.T().Error(err)
 	}
@@ -82,7 +81,7 @@ func (s *APITestSuite) TestBulkEOBRequest() {
 
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	s.db.Where("user_id = ?", user.UUID).Delete(models.Job{})
-	s.db.Where("uuid = ?", user.UUID).Delete(auth.User{})
+	s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 }
 
 func (s *APITestSuite) TestBulkEOBRequestNoBeneficiariesInACO() {
@@ -183,11 +182,11 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 	s.SetupAuthBackend()
 
 	acoID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
-	user, err := s.AuthBackend.CreateUser("api.go Test User", "testbulkrequestnoqueue@example.com", uuid.Parse(acoID))
+	user, err := models.CreateUser("api.go Test User", "testbulkrequestnoqueue@example.com", uuid.Parse(acoID))
 	if err != nil {
 		s.T().Error(err)
 	}
-	defer s.db.Where("uuid = ?", user.UUID).Delete(auth.User{})
+	defer s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 
 	token := jwt.New(jwt.SigningMethodRS512)
 	token.Claims = jwt.MapClaims{
@@ -223,7 +222,7 @@ func (s *APITestSuite) TestBulkPatientRequest() {
 	os.Setenv("ENABLE_PATIENT_EXPORT", "true")
 
 	acoID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
-	user, err := s.AuthBackend.CreateUser("api.go Test User", "testbulkpatientrequest@example.com", uuid.Parse(acoID))
+	user, err := models.CreateUser("api.go Test User", "testbulkpatientrequest@example.com", uuid.Parse(acoID))
 	if err != nil {
 		s.T().Error(err)
 	}
@@ -231,7 +230,7 @@ func (s *APITestSuite) TestBulkPatientRequest() {
 	defer func() {
 		os.Setenv("ENABLE_PATIENT_EXPORT", origPtExp)
 		s.db.Where("user_id = ?", user.UUID).Delete(models.Job{})
-		s.db.Where("uuid = ?", user.UUID).Delete(auth.User{})
+		s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 	}()
 
 	token := jwt.New(jwt.SigningMethodRS512)

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"crypto/rsa"
 	"errors"
+	"fmt"
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
@@ -22,9 +23,13 @@ type BackendTestSuite struct {
 	testUtils.AuthTestSuite
 }
 
-func (s *BackendTestSuite) SetupTest() {
+func (s *BackendTestSuite) SetupSuite() {
+	fmt.Println("Initializing models for auth.backend testing")
 	models.InitializeGormModels()
 	auth.InitializeGormModels()
+}
+
+func (s *BackendTestSuite) SetupTest() {
 	s.SetupAuthBackend()
 }
 

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -23,6 +23,7 @@ type BackendTestSuite struct {
 }
 
 func (s *BackendTestSuite) SetupTest() {
+	models.InitializeGormModels()
 	auth.InitializeGormModels()
 	s.SetupAuthBackend()
 }

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/jinzhu/gorm"
 	"os"
@@ -40,36 +41,6 @@ func (s *BackendTestSuite) TestHashCompare() {
 	assert.False(s.T(), hash.Compare(hashString, uuid.NewRandom().String()))
 }
 
-func (s *BackendTestSuite) TestCreateACO() {
-	acoUUID, err := s.AuthBackend.CreateACO("ACO Name")
-
-	assert.Nil(s.T(), err)
-	assert.NotNil(s.T(), acoUUID)
-}
-
-func (s *BackendTestSuite) TestCreateUser() {
-	name, email, sampleUUID, duplicateName := "First Last", "firstlast@exaple.com", "DBBD1CE1-AE24-435C-807D-ED45953077D3", "Duplicate Name"
-
-	// Make a user for an ACO that doesn't exist
-	badACOUser, err := s.AuthBackend.CreateUser(name, email, uuid.NewRandom())
-	//No ID because it wasn't saved
-	assert.True(s.T(), badACOUser.ID == 0)
-	// Should get an error
-	assert.NotNil(s.T(), err)
-
-	// Make a good user
-	user, err := s.AuthBackend.CreateUser(name, email, uuid.Parse(sampleUUID))
-	assert.Nil(s.T(), err)
-	assert.NotNil(s.T(), user.UUID)
-	assert.NotNil(s.T(), user.ID)
-
-	// Try making a duplicate user for the same E-mail address
-	duplicateUser, err := s.AuthBackend.CreateUser(duplicateName, email, uuid.Parse(sampleUUID))
-	// Got a user, not the one that was requested
-	assert.True(s.T(), duplicateUser.Name == name)
-	assert.NotNil(s.T(), err)
-}
-
 func (s *BackendTestSuite) TestGenerateToken() {
 	userUUIDString, acoUUIDString := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	token, err := s.AuthBackend.GenerateTokenString(userUUIDString, acoUUIDString)
@@ -88,7 +59,7 @@ func (s *BackendTestSuite) TestGenerateToken() {
 func (s *BackendTestSuite) TestCreateToken() {
 	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
 	db := database.GetGORMDbConnection()
-	var user auth.User
+	var user models.User
 	if db.Find(&user, "UUID = ?", userID).RecordNotFound() {
 		assert.NotNil(s.T(), errors.New("Unable to locate user"))
 	}
@@ -132,7 +103,7 @@ func (s *BackendTestSuite) TestGetJWClaims() {
 func (s *BackendTestSuite) TestRevokeToken() {
 	db := database.GetGORMDbConnection()
 	userID, acoID := "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
-	var user auth.User
+	var user models.User
 	db.Find(&user, "UUID = ? AND aco_id = ?", userID, acoID)
 	// Good Revoke test
 	_, tokenString, _ := s.AuthBackend.CreateToken(user)
@@ -162,7 +133,7 @@ func (s *BackendTestSuite) TestRevokeUserTokens() {
 
 	db := database.GetGORMDbConnection()
 	// Get the User
-	var revokedUser, validUser auth.User
+	var revokedUser, validUser models.User
 	if db.First(&revokedUser, "Email = ?", revokedEmail).RecordNotFound() {
 		// If this user doesn't exist the test has failed
 		assert.NotNil(s.T(), errors.New("unable to find User"))
@@ -210,7 +181,7 @@ func (s *BackendTestSuite) TestRevokeACOTokens() {
 	db := database.GetGORMDbConnection()
 
 	// Get the ACO's
-	var revokedACO, validACO auth.ACO
+	var revokedACO, validACO models.ACO
 	if db.First(&revokedACO, "UUID = ?", revokedACOUUID).RecordNotFound() {
 		// If this user doesn't exist the test has failed
 		assert.NotNil(s.T(), errors.New("unable to find ACO"))
@@ -220,7 +191,7 @@ func (s *BackendTestSuite) TestRevokeACOTokens() {
 		assert.NotNil(s.T(), errors.New("unable to find ACO"))
 	}
 
-	users := []auth.User{}
+	users := []models.User{}
 
 	// Make a token for each user in the aco and then verify they have a valid token
 	if db.Find(&users, "aco_id = ?", revokedACOUUID).RecordNotFound() {
@@ -288,7 +259,6 @@ func (s *BackendTestSuite) TestRevokeACOTokens() {
 		assert.Nil(s.T(), db.Error)
 
 	}
-
 }
 
 func (s *BackendTestSuite) TestIsBlacklisted() {
@@ -297,8 +267,8 @@ func (s *BackendTestSuite) TestIsBlacklisted() {
 
 	db := database.GetGORMDbConnection()
 
-	var aco auth.ACO
-	var user auth.User
+	var aco models.ACO
+	var user models.User
 	// Bad test if we can't find the ACO
 	if db.Find(&aco, "UUID = ?", acoID).RecordNotFound() {
 		assert.NotNil(s.T(), errors.New("Unable to find ACO"))

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"fmt"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/jinzhu/gorm"
@@ -10,7 +9,6 @@ import (
 )
 
 func InitializeGormModels() *gorm.DB {
-	fmt.Print("Intitialize auth models")
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -1,47 +1,35 @@
 package auth
 
 import (
-	"crypto/rsa"
+	"fmt"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/pborman/uuid"
-
-	"github.com/CMSgov/bcda-app/bcda/database"
 )
 
 func InitializeGormModels() *gorm.DB {
+	fmt.Print("Intitialize auth models")
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 
 	// Migrate the schema
 	// Add your new models here
 	db.AutoMigrate(
-		&ACO{},
 		&Token{},
-		&User{},
 	)
 
 	return db
 }
 
-type ACO struct {
-	gorm.Model
-	UUID uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
-	Name string    `json:"name"`                                   // name
-}
-
-func (aco *ACO) GetPublicKey() *rsa.PublicKey {
-	// todo implement a real thing.  But for now we can use this.
-	return GetATOPublicKey()
-}
-
 type Token struct {
 	gorm.Model
-	UUID   uuid.UUID `gorm:"primary_key" json:"uuid"` // uuid
-	User   User      `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
-	UserID uuid.UUID `json:"user_id"`                                // user_id
-	Value  string    `gorm:"type:varchar(511); unique" json:"value"` // value
-	Active bool      `json:"active"`                                 // active
+	UUID   uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid
+	User   models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
+	UserID uuid.UUID   `json:"user_id"`                                // user_id
+	Value  string      `gorm:"type:varchar(511); unique" json:"value"` // value
+	Active bool        `json:"active"`                                 // active
 }
 
 func (token *Token) BeforeSave() error {
@@ -62,13 +50,4 @@ func (token *Token) BeforeSave() error {
 	}
 
 	return nil
-}
-
-type User struct {
-	gorm.Model
-	UUID  uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
-	Name  string    `json:"name"`                                   // name
-	Email string    `json:"email"`                                  // email
-	Aco   ACO       `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
-	AcoID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` // aco_id
 }

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -19,11 +17,12 @@ func (s *ModelsTestSuite) SetupTest() {
 }
 
 func (s *ModelsTestSuite) TestAco() {
-	db := database.GetGORMDbConnection()
-	db.Create(&ACO{UUID: uuid.NewRandom(), Name: "Test ACO"})
-	var testACO ACO
-	db.First(&testACO, "Name=?", "Test ACO")
-	assert.True(s.T(), testACO.Name == "Test ACO")
+	//db := database.GetGORMDbConnection()
+	//db.Create(&ACO{UUID: uuid.NewRandom(), Name: "Test ACO"})
+	//var testACO ACO
+	//db.First(&testACO, "Name=?", "Test ACO")
+	//assert.True(s.T(), testACO.Name == "Test ACO")
+	assert.True(s.T(), true)
 
 }
 

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -1,29 +1,59 @@
-package auth
+package auth_test
 
 import (
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
+	"github.com/jinzhu/gorm"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
 
 type ModelsTestSuite struct {
-	suite.Suite
+	testUtils.AuthTestSuite
+	db *gorm.DB
 }
 
 func (s *ModelsTestSuite) SetupTest() {
 	// Setup the DB
-	InitializeGormModels()
-
+	auth.InitializeGormModels()
+	s.db = database.GetGORMDbConnection()
+	s.SetupAuthBackend()
 }
 
-func (s *ModelsTestSuite) TestAco() {
-	//db := database.GetGORMDbConnection()
-	//db.Create(&ACO{UUID: uuid.NewRandom(), Name: "Test ACO"})
-	//var testACO ACO
-	//db.First(&testACO, "Name=?", "Test ACO")
-	//assert.True(s.T(), testACO.Name == "Test ACO")
-	assert.True(s.T(), true)
+func (s *ModelsTestSuite) TestTokenCreation() {
+	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+	userUUID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
 
+	tokenString, err := s.AuthBackend.GenerateTokenString(
+		userUUID,
+		acoUUID,
+	)
+
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), tokenString)
+
+	var user models.User
+	s.db.Find(&user, "UUID = ?", userUUID)
+
+	// Get the claims of the token to find the token ID that was created
+	claims := s.AuthBackend.GetJWTClaims(tokenString)
+	tokenUUID := claims["id"].(string)
+	token := auth.Token{
+		UUID:   uuid.Parse(tokenUUID),
+		UserID: user.UUID,
+		Value:  tokenString,
+		Active: true,
+	}
+	s.db.Create(&token)
+
+	var savedToken auth.Token
+	s.db.Find(&savedToken, "UUID = ?", tokenUUID)
+	assert.NotNil(s.T(), savedToken)
+	assert.Equal(s.T(), token.Value, savedToken.Value)
 }
 
 func TestModelsTestSuite(t *testing.T) {

--- a/bcda/encryption/encryption_test.go
+++ b/bcda/encryption/encryption_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"errors"
-	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
@@ -38,14 +37,14 @@ func (s *EncryptionTestSuite) TestEncryptBytes() {
 	// Make a random String for encrypting
 	testBytes := []byte(uuid.NewRandom().String())
 	// Encrypt the sting and get the key back
-	encryptedBytes, encryptedKey, err := EncryptBytes(auth.GetATOPublicKey(), testBytes, "TEST")
+	encryptedBytes, encryptedKey, err := EncryptBytes(models.GetATOPublicKey(), testBytes, "TEST")
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), encryptedBytes)
 	assert.NotNil(s.T(), encryptedKey)
 	// Make sure we changed something
 	assert.NotEqual(s.T(), testBytes, encryptedBytes)
 	// Decrypt the Key
-	decryptedKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, auth.GetATOPrivateKey(), encryptedKey, []byte("TEST"))
+	decryptedKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, models.GetATOPrivateKey(), encryptedKey, []byte("TEST"))
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), decryptedKey)
 	// Decrypted Key can not match the encrypted key
@@ -80,7 +79,7 @@ func (s *EncryptionTestSuite) TestEncryptAndMove() {
 	}
 	s.db.Save(&j)
 	// Do the Encrypt and Move
-	err := EncryptAndMove(fromPath, toPath, fileName, auth.GetATOPublicKey(), j.ID)
+	err := EncryptAndMove(fromPath, toPath, fileName, models.GetATOPublicKey(), j.ID)
 	// No Errors
 	assert.Nil(s.T(), err)
 	// Should have some Job Keys
@@ -107,7 +106,7 @@ func (s *EncryptionTestSuite) TestEncryptAndMove() {
 	assert.NotEqual(s.T(), rawBytes, encryptedBytes)
 	// Get the key back from the Job
 
-	decryptedKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, auth.GetATOPrivateKey(), jobKey.EncryptedKey, []byte("Coverage"))
+	decryptedKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, models.GetATOPrivateKey(), jobKey.EncryptedKey, []byte("Coverage"))
 	assert.Nil(s.T(), err)
 	key := [32]byte{}
 	copy(key[:], decryptedKey[0:32])

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -322,8 +322,7 @@ func createACO(name string) (string, error) {
 		return "", errors.New("ACO name (--name) must be provided")
 	}
 
-	authBackend := auth.InitAuthBackend()
-	acoUUID, err := authBackend.CreateACO(name)
+	acoUUID, err := models.CreateACO(name)
 	if err != nil {
 		return "", err
 	}
@@ -355,8 +354,8 @@ func createUser(acoID, name, email string) (string, error) {
 		return userUUID, errors.New(strings.Join(errMsgs, "\n"))
 	}
 
-	authBackend := auth.InitAuthBackend()
-	user, err := authBackend.CreateUser(name, email, acoUUID)
+	//authBackend := auth.InitAuthBackend()
+	user, err := models.CreateUser(name, email, acoUUID)
 	if err != nil {
 		return userUUID, err
 	}

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -67,49 +67,8 @@ func (s *MainTestSuite) TestCreateACO() {
 	assert.Equal(s.T(), badACO, "")
 	assert.NotNil(s.T(), err)
 
-	//// Might as well roll into user creation here bc otherwise I will just be rewriting this code
-	//name, email := "Unit Test", "UnitTest@mail.com"
-	//userUUID, err := createUser(acoUUID, name, email)
-	//assert.NotNil(s.T(), userUUID)
-	//assert.Nil(s.T(), err)
-	//var testUser models.User
-	//db.First(&testUser, "Email=?", email)
-	//assert.Equal(s.T(), testUser.UUID.String(), userUUID)
-	//
-	//// We have a user and an ACO, time for a token
-	//accessTokenString, err := createAccessToken(acoUUID, userUUID)
-	//assert.NotNil(s.T(), accessTokenString)
-	//assert.Nil(s.T(), err)
-	//
-	//// Bad/Negative tests
-	//
-	//// Blank UUID
-	//badUserUUID, err := createUser("", name, email)
-	//assert.NotNil(s.T(), err)
-	//assert.Equal(s.T(), "", badUserUUID)
-	//
-	//// Blank UUID
-	//badUserUUID, err = createUser(BADUUID, name, email)
-	//assert.NotNil(s.T(), err)
-	//assert.Equal(s.T(), "", badUserUUID)
-	//
-	//// Blank Name
-	//badUserUUID, err = createUser(acoUUID, "", email)
-	//assert.NotNil(s.T(), err)
-	//assert.Equal(s.T(), "", badUserUUID)
-	//
-	//// Blank E-mail address
-	//badUserUUID, err = createUser(acoUUID, name, "")
-	//assert.NotNil(s.T(), err)
-	//assert.Equal(s.T(), "", badUserUUID)
-	//
-	//// Duplicate User
-	//_, err = createUser(acoUUID, name, email)
-	//assert.NotNil(s.T(), err)
-	//assert.Contains(s.T(), err, email, "%s should contain 'already exists'", err)
-	//fmt.Println(err)
+	// we currently allow ACOs with duplicate names
 }
-
 
 func (s *MainTestSuite) TestCreateUser() {
 	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
@@ -54,36 +53,77 @@ func (s *MainTestSuite) TestCreateACO() {
 	//args := []string{CreateACO, "--name", "TEST_ACO"}
 	//err := s.testApp.Run(args)
 	//assert.Nil(s.T(), err)
-	s.SetupAuthBackend()
+	//s.SetupAuthBackend()
 	ACOName := "UNIT TEST ACO"
 	acoUUID, err := createACO(ACOName)
 	assert.NotNil(s.T(), acoUUID)
 	assert.Nil(s.T(), err)
-	var testACO auth.ACO
+	var testACO models.ACO
 	db.First(&testACO, "Name=?", "UNIT TEST ACO")
 	assert.Equal(s.T(), testACO.UUID.String(), acoUUID)
 
-	// Might as well roll into user creation here bc otherwise I will just be rewriting this code
+	// No ACO Name
+	badACO, err := createACO("")
+	assert.Equal(s.T(), badACO, "")
+	assert.NotNil(s.T(), err)
+
+	//// Might as well roll into user creation here bc otherwise I will just be rewriting this code
+	//name, email := "Unit Test", "UnitTest@mail.com"
+	//userUUID, err := createUser(acoUUID, name, email)
+	//assert.NotNil(s.T(), userUUID)
+	//assert.Nil(s.T(), err)
+	//var testUser models.User
+	//db.First(&testUser, "Email=?", email)
+	//assert.Equal(s.T(), testUser.UUID.String(), userUUID)
+	//
+	//// We have a user and an ACO, time for a token
+	//accessTokenString, err := createAccessToken(acoUUID, userUUID)
+	//assert.NotNil(s.T(), accessTokenString)
+	//assert.Nil(s.T(), err)
+	//
+	//// Bad/Negative tests
+	//
+	//// Blank UUID
+	//badUserUUID, err := createUser("", name, email)
+	//assert.NotNil(s.T(), err)
+	//assert.Equal(s.T(), "", badUserUUID)
+	//
+	//// Blank UUID
+	//badUserUUID, err = createUser(BADUUID, name, email)
+	//assert.NotNil(s.T(), err)
+	//assert.Equal(s.T(), "", badUserUUID)
+	//
+	//// Blank Name
+	//badUserUUID, err = createUser(acoUUID, "", email)
+	//assert.NotNil(s.T(), err)
+	//assert.Equal(s.T(), "", badUserUUID)
+	//
+	//// Blank E-mail address
+	//badUserUUID, err = createUser(acoUUID, name, "")
+	//assert.NotNil(s.T(), err)
+	//assert.Equal(s.T(), "", badUserUUID)
+	//
+	//// Duplicate User
+	//_, err = createUser(acoUUID, name, email)
+	//assert.NotNil(s.T(), err)
+	//assert.Contains(s.T(), err, email, "%s should contain 'already exists'", err)
+	//fmt.Println(err)
+}
+
+
+func (s *MainTestSuite) TestCreateUser() {
+	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+	db := database.GetGORMDbConnection()
+
 	name, email := "Unit Test", "UnitTest@mail.com"
 	userUUID, err := createUser(acoUUID, name, email)
 	assert.NotNil(s.T(), userUUID)
 	assert.Nil(s.T(), err)
-	var testUser auth.User
+	var testUser models.User
 	db.First(&testUser, "Email=?", email)
 	assert.Equal(s.T(), testUser.UUID.String(), userUUID)
 
-	// We have a user and an ACO, time for a token
-	accessTokenString, err := createAccessToken(acoUUID, userUUID)
-	assert.NotNil(s.T(), accessTokenString)
-	assert.Nil(s.T(), err)
-
 	// Bad/Negative tests
-
-	// No ACO Name
-	badACOName := ""
-	badACO, err := createACO(badACOName)
-	assert.Equal(s.T(), badACO, "")
-	assert.NotNil(s.T(), err)
 
 	// Blank UUID
 	badUserUUID, err := createUser("", name, email)
@@ -105,6 +145,21 @@ func (s *MainTestSuite) TestCreateACO() {
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "", badUserUUID)
 
+	// Duplicate User
+	_, err = createUser(acoUUID, name, email)
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), email, "%s should contain '%s' and 'already exists'", err, email)
+}
+
+func (s *MainTestSuite) TestCreateToken() {
+	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+	userUUID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
+
+	// Test successful creation
+	accessTokenString, err := createAccessToken(acoUUID, userUUID)
+	assert.NotNil(s.T(), accessTokenString)
+	assert.Nil(s.T(), err)
+
 	// Blank ACO UUID
 	badAccessTokenString, err := createAccessToken("", userUUID)
 	assert.NotNil(s.T(), err)
@@ -124,10 +179,6 @@ func (s *MainTestSuite) TestCreateACO() {
 	badAccessTokenString, err = createAccessToken(acoUUID, BADUUID)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "", badAccessTokenString)
-}
-
-func (s *MainTestSuite) TestCreateUser() {
-
 }
 
 const TOKENHEADER string = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9."

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -1,19 +1,28 @@
 package models
 
 import (
-	"github.com/CMSgov/bcda-app/bcda/auth"
+	"crypto/rsa"
+	"fmt"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/secutils"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
+	"os"
 )
 
 func InitializeGormModels() *gorm.DB {
+	fmt.Print("Intitialize bcda models")
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 
 	// Migrate the schema
 	// Add your new models here
+	// This should probably not be called in production
+	// What happens when you need to make a database change, there's already data you need to preserve, and
+	// you need to run a script to migrate existing data to its new home or shape?
 	db.AutoMigrate(
+		&ACO{},
+		&User{},
 		&Job{},
 		&JobKey{},
 	)
@@ -23,18 +32,88 @@ func InitializeGormModels() *gorm.DB {
 
 type Job struct {
 	gorm.Model
-	Aco        auth.ACO  `gorm:"foreignkey:AcoID;association_foreignkey:UUID"` // aco
+	Aco        ACO  `gorm:"foreignkey:AcoID;association_foreignkey:UUID"` // aco
 	AcoID      uuid.UUID `gorm:"primary_key; type:char(36)" json:"aco_id"`
-	User       auth.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"` // user
+	User       User `gorm:"foreignkey:UserID;association_foreignkey:UUID"` // user
 	UserID     uuid.UUID `gorm:"type:char(36)"`
 	RequestURL string    `json:"request_url"` // request_url
 	Status     string    `json:"status"`      // status
 	JobKeys    []JobKey
 }
+
 type JobKey struct {
 	gorm.Model
 	Job          Job  `gorm:"foreignkey:jobID"`
 	JobID        uint `gorm:"primary_key" json:"job_id"`
 	EncryptedKey []byte
 	FileName     string `gorm:"type:char(127)"`
+}
+
+type ACO struct {
+	gorm.Model
+	UUID uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
+	Name string    `json:"name"`                                   // name
+}
+
+func (aco *ACO) GetPublicKey() *rsa.PublicKey {
+	// todo implement a real thing.  But for now we can use this.
+	return GetATOPublicKey()
+}
+
+// This exists to provide a known static keys used for ACO's in our alpha tests.
+// This key is not meant to protect anything and both halves will be made available publicly
+func GetATOPublicKey() *rsa.PublicKey {
+	fmt.Println("Looking for a key at:")
+	fmt.Println(os.Getenv("ATO_PUBLIC_KEY_FILE"))
+	atoPublicKeyFile, err := os.Open(os.Getenv("ATO_PUBLIC_KEY_FILE"))
+	if err != nil {
+		fmt.Println("failed to open file")
+		panic(err)
+	}
+	return secutils.OpenPublicKeyFile(atoPublicKeyFile)
+}
+
+func GetATOPrivateKey() *rsa.PrivateKey {
+	atoPrivateKeyFile, err := os.Open(os.Getenv("ATO_PRIVATE_KEY_FILE"))
+	if err != nil {
+		panic(err)
+	}
+	return secutils.OpenPrivateKeyFile(atoPrivateKeyFile)
+}
+
+func CreateACO(name string) (uuid.UUID, error) {
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+	aco := ACO{Name: name, UUID: uuid.NewRandom()}
+	db.Create(&aco)
+
+	return aco.UUID, db.Error
+}
+
+type User struct {
+	gorm.Model
+	UUID  uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
+	Name  string    `json:"name"`                                   // name
+	Email string    `json:"email"`                                  // email
+	Aco   ACO       `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
+	AcoID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` // aco_id
+}
+
+func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+	var aco ACO
+	var user User
+	// If we don't find the ACO return a blank user and an error
+	if db.First(&aco, "UUID = ?", acoUUID).RecordNotFound() {
+		return user, fmt.Errorf("unable to locate ACO with id of %v", acoUUID)
+	}
+	// check for duplicate email addresses and only make one if it isn't found
+	if db.First(&user, "email = ?", email).RecordNotFound() {
+		user = User{UUID: uuid.NewRandom(), Name: name, Email: email, AcoID: aco.UUID}
+		db.Create(&user)
+		return user, nil
+	} else {
+		return user, fmt.Errorf("unable to create user for %v because a user with that Email address already exists", email)
+	}
 }

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/jinzhu/gorm"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type ModelsTestSuite struct {
+	suite.Suite
+	db *gorm.DB
+}
+
+func (s *ModelsTestSuite) SetupTest() {
+	InitializeGormModels()
+	s.db = database.GetGORMDbConnection()
+}
+
+func (s *ModelsTestSuite) TestCreateACO() {
+	acoUUID, err := CreateACO("ACO Name")
+
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), acoUUID)
+
+	var aco ACO
+	s.db.Find(&aco, "UUID = ?", acoUUID)
+	assert.NotNil(s.T(), aco)
+	assert.NotNil(s.T(), aco.GetPublicKey())
+	assert.NotNil(s.T(), GetATOPrivateKey())
+	// should confirm they are a matched pair ?
+}
+
+func (s *ModelsTestSuite) TestCreateUser() {
+	name, email, sampleUUID, duplicateName := "First Last", "firstlast@exaple.com", "DBBD1CE1-AE24-435C-807D-ED45953077D3", "Duplicate Name"
+
+	// Make a user for an ACO that doesn't exist
+	badACOUser, err := CreateUser(name, email, uuid.NewRandom())
+	//No ID because it wasn't saved
+	assert.True(s.T(), badACOUser.ID == 0)
+	// Should get an error
+	assert.NotNil(s.T(), err)
+
+	// Make a good user
+	user, err := CreateUser(name, email, uuid.Parse(sampleUUID))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), user.UUID)
+	assert.NotNil(s.T(), user.ID)
+
+	// Try making a duplicate user for the same E-mail address
+	duplicateUser, err := CreateUser(duplicateName, email, uuid.Parse(sampleUUID))
+	// Got a user, not the one that was requested
+	assert.True(s.T(), duplicateUser.Name == name)
+	assert.NotNil(s.T(), err)
+}
+
+func TestModelsTestSuite(t *testing.T) {
+	suite.Run(t, new(ModelsTestSuite))
+}

--- a/bcda/secutils/secutils.go
+++ b/bcda/secutils/secutils.go
@@ -1,0 +1,74 @@
+package secutils
+
+import (
+	"bufio"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"log"
+	"os"
+)
+
+func OpenPrivateKeyFile(privateKeyFile *os.File) *rsa.PrivateKey {
+	pemfileinfo, err := privateKeyFile.Stat()
+	if err != nil {
+		log.Panic(err)
+	}
+	var size int64 = pemfileinfo.Size()
+	pembytes := make([]byte, size)
+	buffer := bufio.NewReader(privateKeyFile)
+	_, err = buffer.Read(pembytes)
+	if err != nil {
+		// Above buffer.Read succeeded on a blank file Not Sure how to reach this
+		log.Panic(err)
+	}
+
+	data, _ := pem.Decode([]byte(pembytes))
+	err = privateKeyFile.Close()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	privateKeyImported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
+	if err != nil {
+		// Above function panicked when receiving a bad and blank key file.  This may be unreachable
+		log.Panic(err)
+	}
+
+	return privateKeyImported
+}
+
+func OpenPublicKeyFile(publicKeyFile *os.File) *rsa.PublicKey {
+	pemfileinfo, err := publicKeyFile.Stat()
+	if err != nil {
+		log.Panic(err)
+	}
+	var size int64 = pemfileinfo.Size()
+	pemBytes := make([]byte, size)
+	buffer := bufio.NewReader(publicKeyFile)
+	_, err = buffer.Read(pemBytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	data, _ := pem.Decode([]byte(pemBytes))
+
+	err = publicKeyFile.Close()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	publicKeyImported, err := x509.ParsePKIXPublicKey(data.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	rsaPub, ok := publicKeyImported.(*rsa.PublicKey)
+
+	if !ok {
+		panic(err)
+	}
+	return rsaPub
+}
+

--- a/bcda/secutils/secutils_test.go
+++ b/bcda/secutils/secutils_test.go
@@ -1,0 +1,43 @@
+package secutils
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"os"
+	"testing"
+)
+
+type SecutilsTestSuite struct {
+	suite.Suite
+}
+//
+//func (s *SecutilsTestSuite) SetupTest() {
+//	publicKeyFile := os.Getenv("ATO_PUBLIC_KEY_FILE")
+//	privateKeyFile := os.Getenv("ATO_PRIVATE_KEY_FILE")
+//}
+
+func (s *SecutilsTestSuite) TestOpenPrivateKeyFile() {
+	atoPrivateKeyFile, err := os.Open(os.Getenv("ATO_PRIVATE_KEY_FILE"))
+	if err != nil {
+		panic(err)
+	}
+
+	assert.NotNil(s.T(), OpenPrivateKeyFile(atoPrivateKeyFile))
+}
+
+func (s *SecutilsTestSuite) TestOpenPublicKeyFile() {
+	atoPublicKeyFile, err := os.Open(os.Getenv("ATO_PUBLIC_KEY_FILE"))
+	if err != nil {
+		fmt.Println("failed to open file")
+		panic(err)
+	}
+
+	assert.NotNil(s.T(), OpenPublicKeyFile(atoPublicKeyFile))
+}
+
+func TestSecutilsTestSuite(t *testing.T) {
+	suite.Run(t, new(SecutilsTestSuite))
+}
+
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,8 +8,8 @@ services:
     environment:
       - DB=postgresql://postgres:toor@db:5432
       - QUEUE_DATABASE_URL=postgresql://postgres:toor@queue:5432/bcda_queue
-      - ATO_PUBLIC_KEY_FILE=../shared_files/ATO_public.pem
-      - ATO_PRIVATE_KEY_FILE=../shared_files/ATO_private.pem
+      - ATO_PUBLIC_KEY_FILE=../../shared_files/ATO_public.pem
+      - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
   smoke_test:


### PR DESCRIPTION
### Completes [BCDA-628](https://jira.cms.gov/browse/BCDA-628)

Our ACO and User models are in the auth package, but the API needs them to exist independent of the auth implementation. Since we are preparing to more rigorously separate auth from the api, we need to move these models to the bcda/models package. The token model remains in auth.

### Change Details
- ACO model and tests moved to bcda/models
- User model and tests moved to bcda/models
- Extracted shared code for reading PKI keys into secutils package
- Added some missing tests

### Security Implications
None

### Acceptance Validation
All tests pass.

### Feedback Requested

Did I miss anything?

I had to change the docker-compose.test.yml file to correct an env path var that had (apparently) not been used by tests before.
