### PR TITLE
BCDA-629: Add an auth provider interface and an alpha plugin

### DIFF
--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"errors"
+)
+
+type AlphaAuthPlugin struct{}
+
+func (p *AlphaAuthPlugin) RegisterClient(params []byte) error {
+	return errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) UpdateClient(params []byte) error {
+	return errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) DeleteClient(params []byte) error {
+	return errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, error) {
+	return nil, errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
+	return errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) ([]byte, error) {
+	return nil, errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) RevokeAccessToken(params []byte) error {
+	return errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) ValidateAccessToken(params []byte) ([]byte, error) {
+	return nil, errors.New("Not yet implemented")
+}
+
+func (p *AlphaAuthPlugin) DecodeAccessToken(params []byte) ([]byte, error) {
+	return nil, errors.New("Not yet implemented")
+}

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -2,16 +2,18 @@ package auth
 
 import (
 	"errors"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type AlphaAuthPlugin struct{}
 
-func (p *AlphaAuthPlugin) RegisterClient(params []byte) error {
-	return errors.New("Not yet implemented")
+func (p *AlphaAuthPlugin) RegisterClient(params []byte) ([]byte, error) {
+	return nil, errors.New("Not yet implemented")
 }
 
-func (p *AlphaAuthPlugin) UpdateClient(params []byte) error {
-	return errors.New("Not yet implemented")
+func (p *AlphaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
+	return nil, errors.New("Not yet implemented")
 }
 
 func (p *AlphaAuthPlugin) DeleteClient(params []byte) error {
@@ -26,18 +28,18 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	return errors.New("Not yet implemented")
 }
 
-func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) ([]byte, error) {
-	return nil, errors.New("Not yet implemented")
+func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
+	return jwt.Token{}, errors.New("Not yet implemented")
 }
 
-func (p *AlphaAuthPlugin) RevokeAccessToken(params []byte) error {
+func (p *AlphaAuthPlugin) RevokeAccessToken(token string) error {
 	return errors.New("Not yet implemented")
 }
 
-func (p *AlphaAuthPlugin) ValidateAccessToken(params []byte) ([]byte, error) {
-	return nil, errors.New("Not yet implemented")
+func (p *AlphaAuthPlugin) ValidateAccessToken(token string) error {
+	return errors.New("Not yet implemented")
 }
 
-func (p *AlphaAuthPlugin) DecodeAccessToken(params []byte) ([]byte, error) {
-	return nil, errors.New("Not yet implemented")
+func (p *AlphaAuthPlugin) DecodeAccessToken(token string) (jwt.Token, error) {
+	return jwt.Token{}, errors.New("Not yet implemented")
 }

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type AlphaAuthPluginTestSuite struct {
+	suite.Suite
+	p *AlphaAuthPlugin
+}
+
+func (s *AlphaAuthPluginTestSuite) SetupTest() {
+	s.p = new(AlphaAuthPlugin)
+}
+
+func (s *AlphaAuthPluginTestSuite) TestRegisterClient() {
+	err := s.p.RegisterClient([]byte("{}"))
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestUpdateClient() {
+	err := s.p.UpdateClient([]byte("{}"))
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestDeleteClient() {
+	err := s.p.DeleteClient([]byte("{}"))
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
+	r, err := s.p.GenerateClientCredentials([]byte("{}"))
+	assert.Nil(s.T(), r)
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
+	err := s.p.RevokeClientCredentials([]byte("{}"))
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
+	r, err := s.p.RequestAccessToken([]byte("{}"))
+	assert.Nil(s.T(), r)
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
+	err := s.p.RevokeAccessToken([]byte("{}"))
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
+	r, err := s.p.ValidateAccessToken([]byte("{}"))
+	assert.Nil(s.T(), r)
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
+	r, err := s.p.DecodeAccessToken([]byte("{}"))
+	assert.Nil(s.T(), r)
+	assert.Equal(s.T(), "Not yet implemented", err.Error())
+}
+
+func TestAlphaAuthPluginSuite(t *testing.T) {
+	suite.Run(t, new(AlphaAuthPluginTestSuite))
+}

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"testing"
 
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -17,12 +18,14 @@ func (s *AlphaAuthPluginTestSuite) SetupTest() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRegisterClient() {
-	err := s.p.RegisterClient([]byte("{}"))
+	c, err := s.p.RegisterClient([]byte("{}"))
+	assert.Nil(s.T(), c)
 	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 
 func (s *AlphaAuthPluginTestSuite) TestUpdateClient() {
-	err := s.p.UpdateClient([]byte("{}"))
+	c, err := s.p.UpdateClient([]byte("{}"))
+	assert.Nil(s.T(), c)
 	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 
@@ -43,25 +46,24 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
-	r, err := s.p.RequestAccessToken([]byte("{}"))
-	assert.Nil(s.T(), r)
+	t, err := s.p.RequestAccessToken([]byte("{}"))
+	assert.IsType(s.T(), jwt.Token{}, t)
 	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
-	err := s.p.RevokeAccessToken([]byte("{}"))
+	err := s.p.RevokeAccessToken("")
 	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 
 func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
-	r, err := s.p.ValidateAccessToken([]byte("{}"))
-	assert.Nil(s.T(), r)
+	err := s.p.ValidateAccessToken("")
 	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 
 func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
-	r, err := s.p.DecodeAccessToken([]byte("{}"))
-	assert.Nil(s.T(), r)
+	t, err := s.p.DecodeAccessToken("")
+	assert.IsType(s.T(), jwt.Token{}, t)
 	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -1,5 +1,9 @@
 package auth
 
+import (
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
 // Provider is an interface for operations performed through an authentication provider.
 type Provider interface {
 	RegisterClient(params []byte) ([]byte, error)
@@ -9,9 +13,9 @@ type Provider interface {
 	GenerateClientCredentials(params []byte) ([]byte, error)
 	RevokeClientCredentials(params []byte) error
 
-	RequestAccessToken(params []byte) ([]byte, error)
-	RevokeAccessToken(params []byte) error
+	RequestAccessToken(params []byte) (jwt.Token, error)
+	RevokeAccessToken(token string) error
 
-	ValidateAccessToken(params []byte) ([]byte, error)
-	DecodeAccessToken(params []byte) ([]byte, error)
+	ValidateAccessToken(token string) error
+	DecodeAccessToken(token string) (jwt.Token, error)
 }

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -2,8 +2,8 @@ package auth
 
 // Provider is an interface for operations performed through an authentication provider.
 type Provider interface {
-	RegisterClient(params []byte) error
-	UpdateClient(params []byte) error
+	RegisterClient(params []byte) ([]byte, error)
+	UpdateClient(params []byte) ([]byte, error)
 	DeleteClient(params []byte) error
 
 	GenerateClientCredentials(params []byte) ([]byte, error)

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -1,0 +1,17 @@
+package auth
+
+// Provider is an interface for operations performed through an authentication provider.
+type Provider interface {
+	RegisterClient(params []byte) error
+	UpdateClient(params []byte) error
+	DeleteClient(params []byte) error
+
+	GenerateClientCredentials(params []byte) ([]byte, error)
+	RevokeClientCredentials(params []byte) error
+
+	RequestAccessToken(params []byte) ([]byte, error)
+	RevokeAccessToken(params []byte) error
+
+	ValidateAccessToken(params []byte) ([]byte, error)
+	DecodeAccessToken(params []byte) ([]byte, error)
+}


### PR DESCRIPTION
### Fixes [BCDA-629](https://jira.cms.gov/browse/BCDA-629)
We'd like to have an interface to be implemented by auth plugins.

### Proposed changes:
Create an auth provider interface and alpha plugin.

### Change Details
* Adds auth/provider.go, an interface of provider operations
* Adds auth/alpha.go, an implementation of the interface (returns only "Not yet implemented" errors)
  * auth/alpha_test.go is a suite of simple tests for the plugin

### Security Implications
None

### Acceptance Validation
All tests pass.
<img width="504" alt="screen shot 2018-12-18 at 12 02 53 pm" src="https://user-images.githubusercontent.com/1923441/50170009-e4f6d680-02bc-11e9-95ef-afb7c5efd416.png">

### Feedback Requested
I'm a bit out of the loop on auth; happy to make any adjustments you need for this to work with your implementation.
Any opinions on using pointer vs value receivers here? My inclination is pointer, but value could be preferable if we're not modifying the plugin in any of the methods. https://golang.org/doc/faq#methods_on_values_or_pointers