### PR TITLE
BCDA-681 Feature: Create-token command now persist to the db

### DIFF
--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -481,12 +481,21 @@ func (s *MainTestSuite) TestRevokeToken() {
 	// init
 	s.SetupAuthBackend()
 
-	// Create a token
+	// Create an alpha token
 	tokenInfo, err := createAlphaToken("720")
 	assert.Nil(s.T(), err)
 	checkTokenInfo(s, tokenInfo, "720")
-	tokenData := strings.Split(tokenInfo, "\n")
-	accessTokenString := tokenData[2]
+	alphaTokenData := strings.Split(tokenInfo, "\n")
+	alphaTokenString := alphaTokenData[2]
+
+	// Create a token
+	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+	userUUID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
+	token, err := createAccessToken(acoUUID, userUUID)
+	assert.Nil(s.T(), err)
+	checkTokenInfo(s, token, "")
+	tokenData := strings.Split(token, "\n")
+	tokenString := tokenData[2]
 
 	// Negative case - attempt to revoke a token passing in a blank token string
 	args := []string{"bcda", "revoke-token", "--access-token", ""}
@@ -498,8 +507,13 @@ func (s *MainTestSuite) TestRevokeToken() {
 	err = s.testApp.Run(args)
 	assert.NotNil(s.T(), err)
 
+	// Positive case - revoke a token passing in a valid token string (alpha)
+	args = []string{"bcda", "revoke-token", "--access-token", alphaTokenString}
+	err = s.testApp.Run(args)
+	assert.Nil(s.T(), err)
+
 	// Positive case - revoke a token passing in a valid token string
-	args = []string{"bcda", "revoke-token", "--access-token", accessTokenString}
+	args = []string{"bcda", "revoke-token", "--access-token", tokenString}
 	err = s.testApp.Run(args)
 	assert.Nil(s.T(), err)
 }


### PR DESCRIPTION
Fixes [BCDA-681](https://jira.cms.gov/browse/BCDA-681)

Problem: The `create-token` command does not result in any information being persisted to the DB.

Proposed changes:
bcda/main.go - added code to persist token to the db
bcda/main_test.go - added test for revoking a token created from the "create-token" command

Security Implications:
None

Acceptance Validation:
Call the create-token command and be sure that information is persisted to the DB. Revoke-token should also successfully execute.

Feedback Requested:
Any