### PR TITLE
bcda-630: add decodeAccessToken and unit test for alpha plugin

### DIFF
--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -3,11 +3,12 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"testing"
 
+	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
+
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
@@ -95,9 +96,10 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
-	t, err := s.p.DecodeAccessToken("")
+	ts, _ := auth.InitAuthBackend().GenerateTokenString("504", "911")
+	t, err := s.p.DecodeAccessToken(ts)
+	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), jwt.Token{}, t)
-	assert.Equal(s.T(), "Not yet implemented", err.Error())
 }
 
 func TestAlphaAuthPluginSuite(t *testing.T) {

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -100,6 +100,7 @@ func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
 	t, err := s.p.DecodeAccessToken(ts)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), jwt.Token{}, t)
+	assert.NotNil(s.T(), t.Claims.(*CustomClaims).Aco)
 }
 
 func TestAlphaAuthPluginSuite(t *testing.T) {

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -96,7 +96,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
-	ts, _ := auth.InitAuthBackend().GenerateTokenString("504", "911")
+	ts, _ := auth.InitAuthBackend().GenerateTokenString(uuid.NewRandom().String(), uuid.NewRandom().String())
 	t, err := s.p.DecodeAccessToken(ts)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), jwt.Token{}, t)

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -96,11 +96,14 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
-	ts, _ := auth.InitAuthBackend().GenerateTokenString(uuid.NewRandom().String(), uuid.NewRandom().String())
+	userID := uuid.NewRandom().String()
+	acoID := uuid.NewRandom().String()
+	ts, _ := auth.InitAuthBackend().GenerateTokenString(userID, acoID)
 	t, err := s.p.DecodeAccessToken(ts)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), jwt.Token{}, t)
-	assert.NotNil(s.T(), t.Claims.(*CustomClaims).Aco)
+	assert.Equal(s.T(), userID, t.Claims.(*CustomClaims).Subject)
+	assert.Equal(s.T(), acoID, t.Claims.(*CustomClaims).Aco)
 }
 
 func TestAlphaAuthPluginSuite(t *testing.T) {


### PR DESCRIPTION
### Fixes [BCDA-630](https://jira.cms.gov/browse/BCDA-630)
adds a working `decodeAccessToken()` func and an associated unit test for the alpha plugin

### Proposed changes:
- make `decodeAccessToken()` work
- write a simple unit test to test it

### Acceptance Validation
test passes!