### PR TITLE
BCDA-637: Implement RevokeClientCredentials() on alpha plugin

### DIFF
--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -118,7 +118,7 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	}
 	log.Info(fmt.Sprintf("%d token(s) revoked", revokedCount))
 	if len(errs) > 0 {
-		return fmt.Errorf("%d of %d tokens could not be revoked due to errors", len(errs), len(tokens))
+		return fmt.Errorf("%d of %d token(s) could not be revoked due to errors", len(errs), len(tokens))
 	}
 
 	return nil

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type AlphaAuthPlugin struct{}
@@ -71,7 +73,55 @@ func (p *AlphaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, erro
 
 // look up the active access token associated with id, and call RevokeAccessToken
 func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
-	return errors.New("not yet implemented")
+	clientID, err := GetParamString(params, "clientID")
+	if err != nil {
+		return err
+	}
+
+	db := database.GetGORMDbConnection()
+
+	var aco models.ACO
+	err = db.First(&aco, "client_id = ?", clientID).Error
+	if err != nil {
+		return errors.New("no ACO found for client ID")
+	}
+
+	var users []models.User
+	db.Find(&users, "aco_id = ?", aco.UUID)
+	if len(users) == 0 {
+		return errors.New("no users found in client's ACO")
+	}
+
+	var (
+		userIDs []uuid.UUID
+		tokens  []auth.Token
+	)
+	for _, u := range users {
+		userIDs = append(userIDs, u.UUID)
+	}
+
+	db.Find(&tokens, "user_id in (?)", userIDs)
+	if len(tokens) == 0 {
+		return errors.New("no tokens found for users in client's ACO")
+	}
+
+	var errs []string
+	revokedCount := 0
+	for _, t := range tokens {
+		err := p.RevokeAccessToken(fmt.Sprintf(`{"token":"%s"}`, t.UUID))
+		if err != nil {
+			log.Error(err)
+			errs = append(errs, err.Error())
+		} else {
+			revokedCount = revokedCount + 1
+		}
+	}
+	log.Info(fmt.Sprintf("%d token(s) revoked", revokedCount))
+	if len(errs) > 0 {
+		return fmt.Errorf("%d of %d tokens could not be revoked due to errors", len(errs), len(tokens))
+	}
+
+	return nil
 }
 
 // generate a token for the id (which user? just have a single "user" (alpha2, alpha3, ...) per test cycle?)
@@ -122,7 +172,7 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
 	token := auth.Token{
 		UUID:        tokenUUID,
 		UserID:      user.UUID,
-		Value:       tokenString,	// replaced with hash when saved to db
+		Value:       tokenString, // replaced with hash when saved to db
 		Active:      true,
 		Token:       jwtToken,
 		TokenString: tokenString,

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -79,6 +79,7 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	}
 
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 
 	var aco models.ACO
 	err = db.First(&aco, "client_id = ?", clientID).Error

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -92,6 +92,7 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 		ClientID: clientID,
 	}
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	db.Save(&aco)
 
 	var user = models.User{

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -84,10 +84,6 @@ func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
-<<<<<<< HEAD
-	err := s.p.RevokeClientCredentials([]byte("{}"))
-	assert.Equal(s.T(), "not yet implemented", err.Error())
-=======
 	c, err := s.p.RegisterClient([]byte(fmt.Sprintf(`{"clientID": "%s"}`, KnownFixtureACO)))
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), c)
@@ -95,7 +91,6 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 	err = s.p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID": "%s"}`, KnownFixtureACO)))
 	// TODO: Update this test when RevokeAccessToken() is implemented
 	assert.NotNil(s.T(), err)
->>>>>>> RevokeClientCredentials() in progress
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -84,8 +84,18 @@ func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
+<<<<<<< HEAD
 	err := s.p.RevokeClientCredentials([]byte("{}"))
 	assert.Equal(s.T(), "not yet implemented", err.Error())
+=======
+	c, err := s.p.RegisterClient([]byte(fmt.Sprintf(`{"clientID": "%s"}`, KnownFixtureACO)))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), c)
+
+	err = s.p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID": "%s"}`, KnownFixtureACO)))
+	// TODO: Update this test when RevokeAccessToken() is implemented
+	assert.NotNil(s.T(), err)
+>>>>>>> RevokeClientCredentials() in progress
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {


### PR DESCRIPTION
### Fixes [BCDA-637](https://jira.cms.gov/browse/BCDA-637)
`RevokeClientCredentials()` is not yet implemented in our alpha plugin.

### Proposed changes:
Implement `RevokeClientCredentials()` in alpha.go.

### Change Details
* Looks up ACO by client ID, users by ACO, and tokens by users. Calls `RevokeToken()` on any tokens found.
* Test added in alpha_test.go that will need to be fully implemented with `RevokeToken()`.


### Security Implications
No changes.


### Acceptance Validation
Input is the same. Currently returns an error due to `RevokeToken()` not being implemented yet.


### Feedback Requested
Do we want to return errors in the case of the ACO, users, or tokens not being found? Or should it return nil because if they're not found, there's nothing to revoke?
