### PR TITLE
BCDA-636: implement GenerateClientCredentials on Alpha plugin

### DIFF
--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -83,12 +83,10 @@ func (p *AlphaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, erro
 		return empty, fmt.Errorf("ACO %s does not have a registered client", clientID)
 	}
 
-	/* uncomment when PR 128 implementing BCDA-637 is merged
 	err = p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID":"%s"}`, clientID)))
 	if err != nil {
 		return empty, fmt.Errorf("unable to revoke existing credentials for ACO %s because %s", clientID, err)
 	}
-	*/
 
 	jwtToken, err := p.RequestAccessToken([]byte(params))
 	if err != nil {

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -29,26 +29,24 @@ type CustomClaims struct {
 // It returns a single string as well, being the clientID this implementation knows this client by
 // NB: Other implementations will probably expect more input, and will certainly return more data
 func (p *AlphaAuthPlugin) RegisterClient(params []byte) ([]byte, error) {
-	var empty []byte
-
 	acoUUID, err := GetParamString(params, "clientID")
 	if err != nil {
-		return empty, err
+		return nil, err
 	}
 
 	// We'll check carefully in this method, because we're returning something to be used as an id
 	// Normally, a plugin would treat this value as a black box external key, but this implementation is
 	// intimate with the API. So, we're going to protect against accidental bad things
 	if len(acoUUID) != 36 {
-		return empty, errors.New("you must provide a non-empty string 36 characters in length")
+		return nil, errors.New("you must provide a non-empty string 36 characters in length")
 	}
 
 	if matched, err := regexp.MatchString("^[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$", acoUUID); !matched || err != nil {
-		return empty, errors.New("expected a valid UUID string")
+		return nil, errors.New("expected a valid UUID string")
 	}
 
 	if _, err := getACOFromDB(acoUUID); err != nil {
-		return empty, err
+		return nil, err
 	}
 
 	// return the aco UUID as our auth client id. why? because we have to return something that the API / CLI will
@@ -68,7 +66,6 @@ func (p *AlphaAuthPlugin) DeleteClient(params []byte) error {
 
 // can treat as a no-op or call RequestAccessToken
 func (p *AlphaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, error) {
-	var empty []byte
 	clientID, err := GetParamString(params, "clientID")
 	if err != nil {
 		return nil, err
@@ -76,25 +73,25 @@ func (p *AlphaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, erro
 
 	aco, err := getACOFromDB(clientID)
 	if err != nil {
-		return empty, fmt.Errorf(`no ACO found for client ID %s because %s`, clientID, err)
+		return nil, fmt.Errorf(`no ACO found for client ID %s because %s`, clientID, err)
 	}
 
 	if aco.ClientID == "" {
-		return empty, fmt.Errorf("ACO %s does not have a registered client", clientID)
+		return nil, fmt.Errorf("ACO %s does not have a registered client", clientID)
 	}
 
 	err = p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID":"%s"}`, clientID)))
 	if err != nil {
-		return empty, fmt.Errorf("unable to revoke existing credentials for ACO %s because %s", clientID, err)
+		return nil, fmt.Errorf("unable to revoke existing credentials for ACO %s because %s", clientID, err)
 	}
 
 	jwtToken, err := p.RequestAccessToken([]byte(params))
 	if err != nil {
-		return empty, fmt.Errorf("unable to generate new credentials for ACO %s because %s", clientID, err)
+		return nil, fmt.Errorf("unable to generate new credentials for ACO %s because %s", clientID, err)
 	}
 	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
 	if err != nil {
-		return empty, fmt.Errorf("unable to generate tokenString because %s", err)
+		return nil, fmt.Errorf("unable to generate tokenString because %s", err)
 	}
 
 	return []byte(fmt.Sprintf(`{"tokenString":"%s"}`, tokenString)), err
@@ -108,7 +105,11 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	}
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Infof("error closing db connection in %s because %s", "alpha plugin", err)
+		}
+	}()
 
 	var aco models.ACO
 	err = db.First(&aco, "client_id = ?", clientID).Error
@@ -180,7 +181,7 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
 		return jwtToken, errors.New("no user found for " + aco.UUID.String())
 	}
 
-	ttl, err := GetParamInt(params, "ttl")
+	ttl, err := GetParamPositiveInt(params, "ttl")
 	if err != nil {
 		return jwtToken, errors.New("no valid ttl found because " + err.Error())
 	}
@@ -228,7 +229,7 @@ func (p *AlphaAuthPlugin) ValidateAccessToken(token string) error {
 func (p *AlphaAuthPlugin) DecodeAccessToken(token string) (jwt.Token, error) {
 	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return auth.InitAuthBackend().PublicKey, nil
 	}
@@ -271,7 +272,7 @@ func GetParamString(params []byte, name string) (string, error) {
 	return stringForName, err
 }
 
-func GetParamInt(params []byte, name string) (int, error) {
+func GetParamPositiveInt(params []byte, name string) (int, error) {
 	var (
 		j   interface{}
 		err error

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -106,7 +106,7 @@ func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
 		UUID: uuid.NewRandom(),
 		Name: "Gen Client Creds Test",
 	}
-	err = database.GetGORMDbConnection().Save(&aco).Error
+	err = connections["TestGenerateClientCredentials"].Save(&aco).Error
 	assert.Nil(s.T(), err, "wtf? %v", err)
 	j := []byte(fmt.Sprintf(`{"clientID":"%s", "ttl":720}`, aco.UUID.String()))
 	// we know that we use aco.UUID as the ClientID
@@ -138,8 +138,7 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 		Name:     "RevokeClientCredentials Test ACO",
 		ClientID: clientID,
 	}
-	db := database.GetGORMDbConnection()
-	defer db.Close()
+	db := connections["TestRevokeClientCredentials"]
 	db.Save(&aco)
 
 	var user = models.User{


### PR DESCRIPTION
### Fixes [BCDA-636](https://jira.cms.gov/browse/BCDA-636)

GenerateClientCredentials() needs to be implemented on the alpha plugin. The intent of this method is to generate new or to replace existing credentials with new ones.

### Proposed changes:

Verifies that ACO has a ClientID (i.e., RegisterClient() has been called for the ACO previously).
Will use RevokeClientCredentials() to revoke any existing credentials (needs merge of BCDA-637)
Uses CreateAccessToken() to generate credentials.
Returns a token string.
Adds tests. 

### Security Implications
No changes.

### Acceptance Validation
All tests pass.

### Feedback Requested
Any objections to revoking existing credentials as part of this call?