### PR TITLE
knollfrear/bcda-747 fixing case sensitive query

### DIFF
--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -192,7 +192,7 @@ func (s *MainTestSuite) TestCreateToken() {
 func checkTokenInfo(s *MainTestSuite, tokenInfo string) {
 	assert := assert.New(s.T())
 	assert.NotNil(tokenInfo)
-	if (len(tokenInfo) == 0) {
+	if len(tokenInfo) == 0 {
 		assert.FailNow("tokenInfo has no content")
 	}
 	lines := strings.Split(tokenInfo, "\n")
@@ -549,7 +549,7 @@ func (s *MainTestSuite) TestStartApi() {
 
 func (s *MainTestSuite) TestCreateAlphaToken() {
 	const ttl = 42
-	claims := checkStructure(s, ttl, "Dev")
+	claims := checkStructure(s, ttl, "dev")
 	checkTTL(s, claims, ttl)
 }
 
@@ -561,7 +561,7 @@ func (s *MainTestSuite) TestCreateSmallAlphaToken() {
 
 func (s *MainTestSuite) TestCreateMediumAlphaToken() {
 	const ttl = 24 * 365
-	claims := checkStructure(s, ttl, "Medium")
+	claims := checkStructure(s, ttl, "MeDIum")
 	checkTTL(s, claims, ttl)
 }
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -98,7 +98,7 @@ type User struct {
 	Name  string    `json:"name"`                                   // name
 	Email string    `json:"email"`                                  // email
 	Aco   ACO       `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
-	AcoID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` 			// aco_id
+	AcoID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` // aco_id
 }
 
 func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
@@ -132,7 +132,7 @@ func CreateAlphaACO(db *gorm.DB) (ACO, error) {
 
 func AssignAlphaBeneficiaries(db *gorm.DB, aco ACO, acoSize string) error {
 	s := "insert into beneficiaries (patient_id, aco_id) select patient_id, '" + aco.UUID.String() +
-		"' from beneficiaries where aco_id = (select uuid from acos where name = 'ACO " + acoSize + "')"
+		"' from beneficiaries where aco_id = (select uuid from acos where name ilike 'ACO " + acoSize + "')"
 	return db.Exec(s).Error
 }
 
@@ -147,4 +147,3 @@ func CreateAlphaUser(db *gorm.DB, aco ACO) (User, error) {
 
 	return user, db.Error
 }
-


### PR DESCRIPTION


<!-- Replace xxx with the JIRA ticket number: -->
### Fixes [BCDA-747](https://jira.cms.gov/browse/BCDA-747)

<!-- describe the problem being solved here -->
Running the command bcda create-alpha-token --size dev returned an ACO with no beneficiaries
running bcda create-alpha-token --size Dev functioned as expected
### Proposed changes:
<!-- List of changes with bullet points here: -->
make SQL query ignore case so any input will work as expected
improve tests to cover weird caSing instances

### Change Details
<!-- add detailed discussion of changes here: -->
changed = to ilike in subquery
adjusted tests to use variable cAsinG

### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
no pii is affected

### Acceptance Validation
<!-- were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
run the command with Dev, dev, and something invalid, validate results in SQL
<!-- insert screenshots if applicable (drag images here) -->


### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
any