### PR TITLE
BCDA-635: Implement RevokeAccessToken()

### DIFF
--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -120,13 +121,14 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthBlackListed() {
 	if db.Find(&user, "UUID = ?", userID).RecordNotFound() {
 		assert.NotNil(s.T(), errors.New("Unable to find User"))
 	}
-	_, tokenString, err := s.AuthBackend.CreateToken(user)
+	t, tokenString, err := s.AuthBackend.CreateToken(user)
 	assert.Nil(s.T(), err)
 	// Convert tokenString to a jwtToken
 	jwtToken, err := s.AuthBackend.GetJWToken(tokenString)
 	assert.Nil(s.T(), err)
 
-	_ = s.AuthBackend.RevokeToken(tokenString)
+	t.Active = false
+	db.Save(&t)
 
 	// just to be sure it is blacklisted
 	blacklisted := s.AuthBackend.IsBlacklisted(jwtToken)

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -132,6 +132,8 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
 	backend := auth.InitAuthBackend()
 	db := database.GetGORMDbConnection()
+	defer db.Close()
+
 	jwtToken := jwt.Token{}
 
 	acoUUID, err := GetParamString(params, "clientID")
@@ -203,6 +205,8 @@ func (p *AlphaAuthPlugin) RevokeAccessToken(tokenString string) error {
 
 func revokeAccessTokenByID(tokenID uuid.UUID) error {
 	db := database.GetGORMDbConnection()
+	defer db.Close()
+
 	var token auth.Token
 	if db.First(&token, "UUID = ? and active = true", tokenID).RecordNotFound() {
 		return gorm.ErrRecordNotFound
@@ -238,6 +242,7 @@ func getACOFromDB(acoUUID string) (models.ACO, error) {
 		aco models.ACO
 		err error
 	)
+	defer db.Close()
 
 	if db.Find(&aco, "UUID = ?", acoUUID).RecordNotFound() {
 		err = errors.New("no ACO record found for " + acoUUID)

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -136,6 +136,8 @@ func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
 
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	db := database.GetGORMDbConnection()
+	defer db.Close()
+
 	userID, acoID := "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	var user models.User
 	db.Find(&user, "UUID = ? AND aco_id = ?", userID, acoID)

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -149,9 +149,11 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 
 	err = s.p.RevokeAccessToken(tokenString)
 	assert.Nil(err)
-	jwtToken, err := s.AuthBackend.GetJWToken(tokenString)
+	jwtToken, err := s.p.DecodeAccessToken(tokenString)
 	assert.Nil(err)
-	assert.True(s.AuthBackend.IsBlacklisted(jwtToken))
+	c, _ := jwtToken.Claims.(CustomClaims)
+	var tokenFromDB jwt.Token
+	assert.False(db.Find(&tokenFromDB, "UUID = ? AND active = false", c.ID).RecordNotFound())
 
 	// Revoke the token again, you can't
 	err = s.p.RevokeAccessToken(tokenString)

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jinzhu/gorm"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -120,9 +119,9 @@ func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
 	// quick and dirty register client
 	aco.ClientID = aco.UUID.String()
 	err = connections["TestGenerateClientCredentials"].Save(&aco).Error
-	assert.Nil(s.T(), err,"wtf? %v", err)
+	assert.Nil(s.T(), err, "wtf? %v", err)
 	user, err := models.CreateUser("Fake User", "fake@genclientcredstest.com", aco.UUID)
-	assert.Nil(s.T(), err,"wtf? %v", err)
+	assert.Nil(s.T(), err, "wtf? %v", err)
 
 	r, err = s.p.GenerateClientCredentials(j)
 	assert.NotNil(s.T(), r)
@@ -181,8 +180,7 @@ func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
-	db := database.GetGORMDbConnection()
-	defer db.Close()
+	db := connections["TestRevokeAccessToken"]
 
 	userID, acoID := "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	var user models.User

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -14,8 +14,8 @@ type Provider interface {
 	RevokeClientCredentials(params []byte) error
 
 	RequestAccessToken(params []byte) (jwt.Token, error)
-	RevokeAccessToken(token string) error
+	RevokeAccessToken(tokenString string) error
 
-	ValidateAccessToken(token string) error
-	DecodeAccessToken(token string) (jwt.Token, error)
+	ValidateAccessToken(tokenString string) error
+	DecodeAccessToken(tokenString string) (jwt.Token, error)
 }

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -95,7 +95,7 @@ func GetAuthProvider() auth.Provider {
 	v := os.Getenv("BCDA_AUTH_PROVIDER")
 	switch v {
 	case "Alpha":
-		return new(plugin.AlphaAuthPlugin)		// could fallthrough here, but prefer to be explicit
+		return new(plugin.AlphaAuthPlugin) // could fallthrough here, but prefer to be explicit
 	default:
 		return new(plugin.AlphaAuthPlugin)
 	}
@@ -274,7 +274,7 @@ func setUpApp() *cli.App {
 			Action: func(c *cli.Context) error {
 				if ttl == "" {
 					ttl = os.Getenv("JWT_EXPIRATION_DELTA")
-					if (ttl == "") {
+					if ttl == "" {
 						ttl = "72"
 					}
 				}
@@ -421,9 +421,9 @@ func revokeAccessToken(accessToken string) error {
 		return errors.New("Access token (--access-token) must be provided")
 	}
 
-	authBackend := auth.InitAuthBackend()
+	authProvider := GetAuthProvider()
 
-	return authBackend.RevokeToken(accessToken)
+	return authProvider.RevokeAccessToken(accessToken)
 }
 
 func validateAlphaTokenInputs(ttl, acoSize string) (int, error) {

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	accessToken, apiHost, proto, endpoint string
-	timeout                     int
+	timeout                               int
+	encrypt                               bool
 )
 
 type OutputCollection []Output
@@ -29,6 +30,7 @@ func init() {
 	flag.StringVar(&proto, "proto", "http", "protocol to use")
 	flag.StringVar(&endpoint, "endpoint", "ExplanationOfBenefit", "endpoint to test")
 	flag.IntVar(&timeout, "timeout", 300, "amount of time to wait for file to be ready and downloaded.")
+	flag.BoolVar(&encrypt, "encrypt", false, "whether to request encryption of data")
 	flag.Parse()
 
 	if accessToken == "" {
@@ -61,8 +63,13 @@ func getAccessToken() string {
 
 func startJob(resourceType string) *http.Response {
 	client := &http.Client{}
-	req, err := http.NewRequest(
-		"GET", fmt.Sprintf("%s://%s/api/v1/%s/$export", proto, apiHost, resourceType), nil)
+
+	var url string = fmt.Sprintf("%s://%s/api/v1/%s/$export", proto, apiHost, resourceType)
+	if encrypt {
+		url = fmt.Sprintf("%s?encrypt=true", url)
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Fixes [BCDA-635](https://jira.cms.gov/browse/BCDA-635)
The `RevokeAccessToken()` function in our alpha plugin is not yet implemented.

### Proposed changes:
Implement `RevokeAccessToken()` and use it in the CLI.

### Change Details
* Implements `RevokeAccessToken()` and tests
* Uses `RevokeAccessToken()` for the `revoke-token` CLI command
* Removes old token revocation code and tests
* Adds `revokeAccessTokenByID()` to the plugin, called by `RevokeAccessToken()` and `RevokeClientCredentials()`

### Security Implications
No changes.

### Acceptance Validation
Tokens can still be successfully revoked from the CLI.

### Feedback Requested
Are we okay with the approach of the having a private function to revoke a token that accepts the ID, or do we want to change the parameter(s) for the public function? Any other thoughts?
