### PR TITLE
Close db connection in `healthCheck()`

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -463,7 +463,10 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	m := make(map[string]string)
 
-	if database.GetGORMDbConnection().DB().Ping() == nil {
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+
+	if db.DB().Ping() == nil {
 		m["database"] = "ok"
 		w.WriteHeader(http.StatusOK)
 	} else {

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -29,6 +29,7 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -463,10 +464,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	m := make(map[string]string)
 
-	db := database.GetGORMDbConnection()
-	defer db.Close()
-
-	if db.DB().Ping() == nil {
+	if isDatabaseOK() {
 		m["database"] = "ok"
 		w.WriteHeader(http.StatusOK)
 	} else {
@@ -484,6 +482,16 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
+}
+
+func isDatabaseOK() bool {
+	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+
+	return db.Ping() == nil
 }
 
 func readTokenClaims(r *http.Request) (jwt.MapClaims, error) {


### PR DESCRIPTION
### Fixes [BCDA-757](https://jira.cms.gov/browse/BCDA-757)
Uh oh. We never close the database connection in the health check function.

### Proposed changes:
Add a new `isDatabaseOK()` function instead of unnecessary call to `GetGormDbConnection()` and make sure it closes the connection

### Security Implications
None

### Acceptance Validation
Health check still works. We will want to check the connection count in AWS after this is deployed.

### Feedback Requested
Any. Angry reminders to always close connections are welcome.
