### PR TITLE
BCDA-683: Wrap all test targets into one `make test` target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,3 @@ before_script:
 script:
   - make docker-bootstrap
   - make test
-  - make smoke-test
-  - make integration-test
-  - make postman env=local

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ smoke-test:
 	sleep 30
 	docker-compose -f docker-compose.test.yml up --build --force-recreate --exit-code-from smoke_test smoke_test
 
-test:
+unit-test:
 	docker-compose up -d db queue
 	docker-compose -f docker-compose.test.yml up --build --force-recreate --exit-code-from unit_test unit_test
 
@@ -40,6 +40,12 @@ ifeq ($(env), local)
 endif
 	docker-compose -f docker-compose.test.yml build --no-cache postman_test
 	docker-compose -f docker-compose.test.yml run --rm postman_test test/$(env).postman_environment.json --global-var "token=$(token)"
+
+test: 
+	$(MAKE) unit-test
+	$(MAKE) integration-test
+	$(MAKE) postman env=local
+	$(MAKE) smoke-test
 
 load-fixtures:
 	docker-compose up -d db
@@ -72,4 +78,4 @@ debug-worker:
 	@-bash -c "trap 'docker-compose stop' EXIT; \
 		docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --no-deps -T --rm -v $(shell pwd):/go/src/github.com/CMSgov/bcda-app worker dlv debug"
 
-.PHONY: docker-build docker-bootstrap load-fixtures test debug-api debug-worker api-shell worker-shell package release smoke-test integration-test postman
+.PHONY: docker-build docker-bootstrap load-fixtures test debug-api debug-worker api-shell worker-shell package release smoke-test integration-test postman unit-test

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ package:
 
 integration-test:
 	docker-compose up -d 
-	sleep 5
+	sleep 30
 	docker-compose -f docker-compose.test.yml up --build --force-recreate --exit-code-from integration_test integration_test
 
 smoke-test:
@@ -41,7 +41,7 @@ endif
 	docker-compose -f docker-compose.test.yml build --no-cache postman_test
 	docker-compose -f docker-compose.test.yml run --rm postman_test test/$(env).postman_environment.json --global-var "token=$(token)"
 
-test: 
+test:
 	$(MAKE) unit-test
 	$(MAKE) integration-test
 	$(MAKE) postman env=local

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -202,7 +202,7 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
-	assert.Equal(s.T(), http.StatusInternalServerError, s.rr.Code)
+	assert.Equal(s.T(), 217, s.rr.Code)
 
 	var respOO fhirmodels.OperationOutcome
 	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -79,7 +79,7 @@ func (s *APITestSuite) TestBulkEOBRequest() {
 	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
-	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+	assert.Equal(s.T(), 444, s.rr.Code)
 	s.db.Where("user_id = ?", user.UUID).Delete(models.Job{})
 	s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 }

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -202,7 +202,7 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
-	assert.Equal(s.T(), 217, s.rr.Code)
+	assert.Equal(s.T(), http.StatusInternalServerError, s.rr.Code)
 
 	var respOO fhirmodels.OperationOutcome
 	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -79,7 +79,7 @@ func (s *APITestSuite) TestBulkEOBRequest() {
 	handler := http.HandlerFunc(bulkEOBRequest)
 	handler.ServeHTTP(s.rr, req)
 
-	assert.Equal(s.T(), 444, s.rr.Code)
+	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	s.db.Where("user_id = ?", user.UUID).Delete(models.Job{})
 	s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 }


### PR DESCRIPTION
### Fixes [BCDA-683](https://jira.cms.gov/browse/BCDA-683)

Local/development testing requires executing multiple test targets from `Makefile`.

### Proposed changes:

Wrap all of the test-related targets into one `test` target.


### Change Details

- Renamed `test` target to `unit-test`.
- Created a new `test` target which wraps all of the test-related targets in `Makefile`
- Updated Travis configuration to use the new `test` target.
- Ops changes here: 


### Security Implications

None.


### Acceptance Validation

Tested locally and in Travis.


### Feedback Requested

Please review.
