### PR TITLE
BCDA-396 Feature: Add Coverage endpoint for bulk export of patient data

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -98,8 +98,12 @@ func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("Patient", w, r)
 }
 
+func bulkCoverageRequest(w http.ResponseWriter, r *http.Request) {
+	bulkRequest("Coverage", w, r)
+}
+
 func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
-	if t != "ExplanationOfBenefit" && t != "Patient" {
+	if t != "ExplanationOfBenefit" && t != "Patient" && t != "Coverage" {
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "Invalid resource type", responseutils.RequestErr)
 		responseutils.WriteError(oo, w, http.StatusBadRequest)
 		return
@@ -277,7 +281,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			scheme = "https"
 		}
 
-		re := regexp.MustCompile(`/(ExplanationOfBenefit|Patient)/\$export`)
+		re := regexp.MustCompile(`/(ExplanationOfBenefit|Patient|Coverage)/\$export`)
 		resourceType := re.FindStringSubmatch(job.RequestURL)[1]
 
 		fi := fileItem{

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -3,13 +3,14 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/CMSgov/bcda-app/bcda/monitoring"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/CMSgov/bcda-app/bcda/monitoring"
 
 	"github.com/sirupsen/logrus"
 
@@ -23,6 +24,7 @@ const blueButtonBasePath = "/v1/fhir"
 type APIClient interface {
 	GetExplanationOfBenefitData(patientID, jobID string) (string, error)
 	GetPatientData(patientID, jobID string) (string, error)
+	GetCoverageData(beneficiaryID, jobID string) (string, error)
 }
 
 type BlueButtonClient struct {

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -118,6 +118,7 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 		},
 	}
 	addPatientEndpointToStatement(statement, baseurl)
+	addCoverageEndpointToStatement(statement, baseurl)
 	return statement
 }
 
@@ -129,6 +130,22 @@ func addPatientEndpointToStatement(statement *fhirmodels.CapabilityStatement, ba
 			Name: "export",
 			Definition: &fhirmodels.Reference{
 				Reference: baseUrl + "/api/v1/Patient/$export",
+				Type:      "Endpoint",
+			},
+		}
+		restComponent = append(restComponent, element)
+		statement.Rest[0].Operation = restComponent
+	}
+}
+
+func addCoverageEndpointToStatement(statement *fhirmodels.CapabilityStatement, baseUrl string) {
+	if os.Getenv("ENABLE_COVERAGE_EXPORT") == "true" {
+		restComponent := statement.Rest[0].Operation
+
+		element := fhirmodels.CapabilityStatementRestOperationComponent{
+			Name: "export",
+			Definition: &fhirmodels.Reference{
+				Reference: baseUrl + "/api/v1/Coverage/$export",
 				Type:      "Endpoint",
 			},
 		}

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -31,6 +31,9 @@ func NewAPIRouter() http.Handler {
 		if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
 			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Patient/$export", bulkPatientRequest))
 		}
+		if os.Getenv("ENABLE_COVERAGE_EXPORT") == "true" {
+			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Coverage/$export", bulkCoverageRequest))
+		}
 		r.With(auth.RequireTokenAuth).Get(m.WrapHandler("/jobs/{jobId}", jobStatus))
 		r.Get(m.WrapHandler("/metadata", metadata))
 		if os.Getenv("DEBUG") == "true" {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -180,6 +180,8 @@ func writeBBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []strin
 		bbFunc = bb.GetExplanationOfBenefitData
 	case "Patient":
 		bbFunc = bb.GetPatientData
+	case "Coverage":
+		bbFunc = bb.GetCoverageData
 	default:
 		err := fmt.Errorf("Invalid resource type requested: %s", t)
 		log.Error(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
       - HTTP_ONLY=true
       - ENABLE_PATIENT_EXPORT=true
+      - ENABLE_COVERAGE_EXPORT=true
     volumes:
      - .:/go/src/github.com/CMSgov/bcda-app
     ports:

--- a/test/postman_test/BCDA_Tests.postman_collection.json
+++ b/test/postman_test/BCDA_Tests.postman_collection.json
@@ -280,6 +280,131 @@
 			]
 		},
 		{
+			"name": "Coverage",
+			"item": [
+				{
+					"name": "Start Coverage export, no token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f1078057-407c-4833-b49a-6f80bb5acefb",
+								"exec": [
+									"pm.test(\"Status code is 401\", function() {",
+									"    pm.response.to.have.status(401);",
+									"});",
+									"",
+									"var respJson = pm.response.json();",
+									"",
+									"pm.test(\"Resource type is OperationOutcome\", function() {",
+									"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
+									"});",
+									"",
+									"pm.test(\"Issue details text is Invalid Token\", function() {",
+									"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid Token\")",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/fhir+json",
+								"type": "text"
+							},
+							{
+								"key": "Prefer",
+								"value": "respond-async",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{scheme}}://{{host}}/api/v1/Coverage/$export",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"Coverage",
+								"$export"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Start Coverage export, valid token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4aa90ed8-0665-474f-a6fd-218c56c7387b",
+								"exec": [
+									"pm.test(\"Status code is 202\", function() {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"pm.test(\"Has Content-Location header\", function() {",
+									"    pm.response.to.have.header(\"Content-Location\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/fhir+json"
+							},
+							{
+								"key": "Prefer",
+								"type": "text",
+								"value": "respond-async"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{scheme}}://{{host}}/api/v1/Coverage/$export",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"Coverage",
+								"$export"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "Job status",
 			"item": [
 				{

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -305,6 +305,69 @@
 			"response": []
 		},
 		{
+			"name": "Start Coverage export, no token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "f1078057-407c-4833-b49a-6f80bb5acefb",
+						"exec": [
+							"pm.test(\"Status code is 401\", function() {",
+							"    pm.response.to.have.status(401);",
+							"});",
+							"",
+							"var respJson = pm.response.json();",
+							"",
+							"pm.test(\"Resource type is OperationOutcome\", function() {",
+							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
+							"});",
+							"",
+							"pm.test(\"Issue details text is Invalid Token\", function() {",
+							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid Token\")",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/fhir+json",
+						"type": "text"
+					},
+					{
+						"key": "Prefer",
+						"value": "respond-async",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}/api/v1/Coverage/$export",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"Coverage",
+						"$export"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Get job status, no token",
 			"event": [
 				{
@@ -775,6 +838,72 @@
 			"response": []
 		},
 		{
+			"name": "Start Coverage export",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "4aa90ed8-0665-474f-a6fd-218c56c7387b",
+						"exec": [
+							"pm.test(\"Status code is 202\", function() {",
+							"    pm.response.to.have.status(202);",
+							"});",
+							"",
+							"pm.test(\"Has Content-Location header\", function() {",
+							"    pm.response.to.have.header(\"Content-Location\");",
+							"});",
+							"",
+							"pm.environment.set(\"coverageJobUrl\", pm.response.headers.get(\"Content-Location\"));"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/fhir+json"
+					},
+					{
+						"key": "Prefer",
+						"type": "text",
+						"value": "respond-async"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}/api/v1/Coverage/$export",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"Coverage",
+						"$export"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Get Patient export job status",
 			"event": [
 				{
@@ -905,6 +1034,136 @@
 			"response": []
 		},
 		{
+			"name": "Get Coverage export job status",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "dc6615ac-febe-49d0-98b6-9b4b8614bfcf",
+						"exec": [
+							"pm.test(\"Status code is 202 or 200\", function() {",
+							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
+							"});",
+							"",
+							"if (pm.response.code === 202) {",
+							"    pm.test(\"Has X-Progress header\", function() {",
+							"        pm.response.to.have.header(\"X-Progress\", \"In Progress\");",
+							"    });",
+							"} else if (pm.response.code === 200) {",
+							"    const schema = {",
+							"        \"properties\": {",
+							"            \"transactionTime\": {",
+							"                \"type\": \"string\"",
+							"            },",
+							"            \"request\": {",
+							"                \"type\": \"string\"",
+							"            },",
+							"            \"requiresAccessToken\": {",
+							"                \"type\": \"boolean\"",
+							"            },",
+							"            \"output\": {",
+							"                \"type\": \"array\"",
+							"            },",
+							"            \"error\": {",
+							"                \"type\": \"array\"",
+							"            }",
+							"        }",
+							"    };",
+							"    ",
+							"    var respJson = pm.response.json();",
+							"    ",
+							"    pm.test(\"Schema is valid\", function() {",
+							"        pm.expect(tv4.validate(respJson, schema)).to.be.true;",
+							"    });",
+							"    ",
+							"    pm.environment.set(\"coverageDataUrl\", respJson.output[0].url);",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "cff036f5-befc-4bfb-9482-309f10272212",
+						"exec": [
+							"const retryDelay = 5000;",
+							"const maxRetries = 10;",
+							"",
+							"var coverageJobReq = {",
+							"  url: pm.environment.get(\"coverageJobUrl\"),",
+							"  method: \"GET\",",
+							"  header: \"Authorization: Bearer \" + pm.environment.get(\"token\")",
+							"};",
+							"",
+							"function awaitExportJob(retryCount) {",
+							"    pm.sendRequest(coverageJobReq, function (err, response) {",
+							"        if (err) {",
+							"            console.error(err);",
+							"        } else if (response.code == 202) {",
+							"            if (retryCount < maxRetries) {",
+							"                console.log(\"Coverage export still in progress. Retrying...\");",
+							"                setTimeout(function() {",
+							"                    awaitExportJob(++retryCount);",
+							"                }, retryDelay);",
+							"            } else {",
+							"                console.log(\"Retry limit reached for Coverage job status.\");",
+							"                postman.setNextRequest(null);",
+							"            }",
+							"        } else if (response.code == 200) {",
+							"            console.log(\"Coverage export job complete.\");",
+							"        } else {",
+							"            console.error(\"Unexpected response from Coverage export job: \" + response.status);",
+							"        }",
+							"    });",
+							"}",
+							"",
+							"awaitExportJob(1);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/fhir+json",
+						"disabled": true
+					},
+					{
+						"key": "Prefer",
+						"type": "text",
+						"value": "respond-async",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{coverageJobUrl}}",
+					"host": [
+						"{{coverageJobUrl}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Get Patient export data",
 			"event": [
 				{
@@ -945,6 +1204,52 @@
 					"raw": "{{patientDataUrl}}",
 					"host": [
 						"{{patientDataUrl}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Coverage export data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "9cc089de-3f67-4a42-9290-8e32afdbeb9",
+						"exec": [
+							"pm.test(\"Status code is 200\", function() {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Body contains data\", function() {",
+							"    pm.expect(pm.response.length > 0)",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{coverageDataUrl}}",
+					"host": [
+						"{{coverageDataUrl}}"
 					]
 				}
 			},

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -6,3 +6,4 @@ set -e
 
 go run bcda_client.go -host=api:3000 -endpoint=ExplanationOfBenefit
 go run bcda_client.go -host=api:3000 -endpoint=Patient
+go run bcda_client.go -host=api:3000 -endpoint=Coverage


### PR DESCRIPTION
Fixes [BCDA-396](https://jira.cms.gov/browse/BCDA-396)

Problem:
Added new endpoint.

Change Details:
bcda/api.go - added "coverage" option for a bulk request.
bcda/api_test.go - added test case for new endpoint
bcda/client/bluebutton.go - added new function for APIClient interface
bcda/router.go - added new coverage endpoint
bcdaworker/main.go - added new case for coverage function
docker-compose.yml - added ENABLE_COVERAGE_EXPORT config var
test/postman_test/BCDA_Tests.postman_collection.json- added postman tests
test/postman_test/BCDA_Tests_Sequential.postman_collection.json - added postman tests
test/smoke_test/smoke_test.sh - added smoke tests

 Security Implications
None, but env flags should be used to control enabling/disabling of this endpoint

Acceptance Validation:
Yes

Feedback Requested
Any and all
