### PR TITLE
BCDA-720: Encryption enabled by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,7 @@ This API follows the workflow outlined by the [FHIR Bulk Data Export Proposal](h
    1. [APIs](#apis)
    1. [Authentication and Authorization](#authentication-and-authorization)
    1. [Environment](#environment)
+   1. [Encryption](#encryption)
 1. [Examples](#examples)
    1. [BCDA Metadata](#bcda-metadata)
    1. [Beneficiary Explanation of Benefit Data](#beneficiary-explanation-of-benefit-data)
@@ -24,6 +25,9 @@ An access token is required for most requests. The token is presented in API req
 
 ### Environment
 The examples below include [cURL](https://curl.haxx.se/) commands, but may be followed using any tool that can make HTTP GET requests with headers, such as [Postman](https://www.getpostman.com/).
+
+### Encryption
+Details on the data encryption process, including decryption details, can be found in the [Encryption documentation](https://github.com/CMSgov/bcda-app/blob/master/ENCRYPTION.md).
 
 ## Examples
 Examples are shown as requests to the BCDA sandbox environment.

--- a/API.md
+++ b/API.md
@@ -7,7 +7,6 @@ This API follows the workflow outlined by the [FHIR Bulk Data Export Proposal](h
    1. [APIs](#apis)
    1. [Authentication and Authorization](#authentication-and-authorization)
    1. [Environment](#environment)
-   1. [Encryption](#encryption)
 1. [Examples](#examples)
    1. [BCDA Metadata](#bcda-metadata)
    1. [Beneficiary Explanation of Benefit Data](#beneficiary-explanation-of-benefit-data)
@@ -25,9 +24,6 @@ An access token is required for most requests. The token is presented in API req
 
 ### Environment
 The examples below include [cURL](https://curl.haxx.se/) commands, but may be followed using any tool that can make HTTP GET requests with headers, such as [Postman](https://www.getpostman.com/).
-
-### Encryption
-Details on the data encryption process, including decryption details, can be found in the [Encryption documentation](https://github.com/CMSgov/bcda-app/blob/master/ENCRYPTION.md).
 
 ## Examples
 Examples are shown as requests to the BCDA sandbox environment.

--- a/ENCRYPTION.md
+++ b/ENCRYPTION.md
@@ -32,7 +32,7 @@ The steps in our encryption process are:
 ```
 {
     "transactionTime": "2018-12-11T06:29:56.723792Z",
-    "request": "http://localhost:3000/api/v1/ExplanationOfBenefit/$export?encrypt=true",
+    "request": "http://localhost:3000/api/v1/ExplanationOfBenefit/$export",
     "requiresAccessToken": true,
     "output": [
         {

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -162,9 +162,9 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: this checks for ?encrypt=false appended to the bulk data request URL
-        // By default, our encryption process is enabled but for now we are giving users the ability to turn
-        // it off
-        // Eventually, we will remove the ability for users to turn it off and it will remain on always
+	// By default, our encryption process is enabled but for now we are giving users the ability to turn
+	// it off
+	// Eventually, we will remove the ability for users to turn it off and it will remain on always
 	var encrypt bool = true
 	param, ok := r.URL.Query()["encrypt"]
 	if ok && strings.ToLower(param[0]) == "false" {

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -161,13 +161,14 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		beneficiaryIds = append(beneficiaryIds, id)
 	}
 
-	// TODO(rnagle): this checks for ?encrypt=true appended to the bulk data request URL
-	// This is a temporary addition to allow SCA/ACT auditors to verify encryption of files works properly
-	// without exposing file encryption functionality to BCDA pilot users.
-	var encrypt bool = false
+	// TODO: this checks for ?encrypt=false appended to the bulk data request URL
+        // By default, our encryption process is enabled but for now we are giving users the ability to turn
+        // it off
+        // Eventually, we will remove the ability for users to turn it off and it will remain on always
+	var encrypt bool = true
 	param, ok := r.URL.Query()["encrypt"]
-	if ok && strings.ToLower(param[0]) == "true" {
-		encrypt = true
+	if ok && strings.ToLower(param[0]) == "false" {
+		encrypt = false
 	}
 
 	args, err := json.Marshal(jobEnqueueArgs{
@@ -176,7 +177,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		UserID:         userId,
 		BeneficiaryIDs: beneficiaryIds,
 		ResourceType:   t,
-		// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
+		// TODO: remove `Encrypt` when file encryption disable functionality is ready to be deprecated
 		Encrypt: encrypt,
 	})
 	if err != nil {

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -42,7 +42,7 @@ type jobEnqueueArgs struct {
 	UserID         string
 	BeneficiaryIDs []string
 	ResourceType   string
-	// TODO(rnagle): remove `Encrypt` when file encryption functionality is ready for release
+	// TODO: remove `Encrypt` when file encryption disable functionality is ready to be deprecated
 	Encrypt bool
 }
 

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -33,7 +33,7 @@ func init() {
 	flag.StringVar(&proto, "proto", "http", "protocol to use")
 	flag.StringVar(&endpoint, "endpoint", "ExplanationOfBenefit", "endpoint to test")
 	flag.IntVar(&timeout, "timeout", 300, "amount of time to wait for file to be ready and downloaded.")
-	flag.BoolVar(&encrypt, "encrypt", false, "whether to request encryption of data")
+	flag.BoolVar(&encrypt, "encrypt", true, "whether to disable encryption")
 	flag.Parse()
 
 	if accessToken == "" {
@@ -68,8 +68,8 @@ func startJob(resourceType string) *http.Response {
 	client := &http.Client{}
 
 	var url string = fmt.Sprintf("%s://%s/api/v1/%s/$export", proto, apiHost, resourceType)
-	if encrypt {
-		url = fmt.Sprintf("%s?encrypt=true", url)
+	if !encrypt {
+		url = fmt.Sprintf("%s?encrypt=false", ural)
 	}
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -69,7 +69,7 @@ func startJob(resourceType string) *http.Response {
 
 	var url string = fmt.Sprintf("%s://%s/api/v1/%s/$export", proto, apiHost, resourceType)
 	if !encrypt {
-		url = fmt.Sprintf("%s?encrypt=false", ural)
+		url = fmt.Sprintf("%s?encrypt=false", url)
 	}
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -4,7 +4,7 @@
 #
 set -e
 
-go run bcda_client.go decrypt_util.go -host=api:3000 -endpoint=ExplanationOfBenefit -encrypt=true
-go run bcda_client.go decrypt_util.go -host=api:3000 -endpoint=Patient -encrypt=true
+go run bcda_client.go decrypt_util.go -host=api:3000 -endpoint=ExplanationOfBenefit
+go run bcda_client.go decrypt_util.go -host=api:3000 -endpoint=Patient
 go run bcda_client.go decrypt_util.go -host=api:3000 -endpoint=ExplanationOfBenefit -encrypt=false
 go run bcda_client.go decrypt_util.go -host=api:3000 -endpoint=Patient -encrypt=false


### PR DESCRIPTION
### Fixes [BCDA-720](https://jira.cms.gov/browse/BCDA-720)

Encryption is currently not enabled by default.  An explicit parameter must be passed in order to enable encryption.

### Proposed changes:

Update the application so that all bulk requests encrypt the ndjson file by default, and permit a parameter to be passed to the endpoints to bypass the encryption (for now).


### Change Details

- Updated the example request in ENCRYPTION.MD 
- No changes in API.MD - instead using the writeup from here: https://github.com/CMSgov/bcda-app/pull/143
- Updated the API to enable encryption by default, and only disable it if a parameter is passed to the endpoint (`?encrypt=false`)
- Update the smoke test appropriately
- Ops-related changes performed in this PR: https://github.com/CMSgov/bcda-ops/pull/113


### Security Implications

Client user has the ability to disable encryption, resulting in unencrypted files living on our system at rest.  This will eventually be phased out and the unencrypted option will be deprecated.

### Acceptance Validation

In [BCDA-721](https://github.com/CMSgov/bcda-app/pull/142) encryption testing (via decryption) and file format validation was introduced into the smoke test.  These techniques were used to validate the work performed in BCDA-720 (this PR).  
See results [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/230/parameters/).


### Feedback Requested

Please review.
