### PR TITLE
Replace [most] uses of backend.CreateToken

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -363,17 +363,8 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 
-	var user models.User
-	err := db.First(&user, "name = ?", "User One").Error
-	if err != nil {
-		log.Error(err)
-		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
-		return
-	}
-
 	var aco models.ACO
-	err = db.First(&aco, "name = ?", "ACO Dev").Error
+	err := db.First(&aco, "name = ?", "ACO Dev").Error
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
@@ -381,15 +372,24 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generates a token for fake user and ACO combination
-	token, err := authBackend.GenerateTokenString(user.UUID.String(), aco.UUID.String())
+	// Generates a token for 'ACO Dev' and its first user
+	token, err := GetAuthProvider().RequestAccessToken([]byte(fmt.Sprintf(`{"clientID":"%s", "ttl": 72}`, aco.UUID.String())))
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)
 		responseutils.WriteError(oo, w, http.StatusInternalServerError)
 		return
 	}
-	_, err = w.Write([]byte(token))
+
+	tokenString, err := authBackend.SignJwtToken(token)
+	if err != nil {
+		log.Error(err)
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)
+		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		return
+	}
+
+	_, err = w.Write([]byte(tokenString))
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/encryption"
 
 	"github.com/CMSgov/bcda-app/bcda/database"
@@ -35,13 +36,12 @@ type APITestSuite struct {
 
 func (s *APITestSuite) SetupTest() {
 	models.InitializeGormModels()
+	auth.InitializeGormModels()
 	s.db = database.GetGORMDbConnection()
 	s.rr = httptest.NewRecorder()
 }
 
 func (s *APITestSuite) TestBulkEOBRequest() {
-	//s.SetupAuthBackend()
-
 	acoID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
 	user, err := models.CreateUser("api.go Test User", "testbulkeobrequest@example.com", uuid.Parse(acoID))
 	if err != nil {

--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
+	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/secutils"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/pborman/uuid"
 )
 
 var (
@@ -131,7 +131,7 @@ func (backend *JWTAuthenticationBackend) GetJWToken(tokenString string) (*jwt.To
 	return token, err
 }
 
-// Save a token to the DB for a user
+// should be removed during BCDA-764; must be left in place until then
 func (backend *JWTAuthenticationBackend) CreateToken(user models.User) (Token, string, error) {
 	db := database.GetGORMDbConnection()
 	tokenString, err := backend.GenerateTokenString(

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -66,6 +66,7 @@ func (s *BackendTestSuite) TestGenerateToken() {
 	assert.Panics(s.T(), func() { _, _ = s.AuthBackend.GenerateTokenString(userUUIDString, acoUUIDString) })
 }
 
+// remove with BCDA-764
 func (s *BackendTestSuite) TestCreateToken() {
 	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
 	db := database.GetGORMDbConnection()

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -7,14 +7,14 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
-
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 )
 
 type AlphaAuthPlugin struct{}

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -189,20 +189,20 @@ func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	db := connections["TestRevokeAccessToken"]
 
-	const UserID, AcoID = "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+	const userID, acoID = "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	assert := assert.New(s.T())
 
 	// Good Revoke test
-	jwtToken, err := s.p.RequestAccessToken([]byte(fmt.Sprintf(`{"clientID": "%s", "ttl": 720}`, AcoID)))
+	jwtToken, err := s.p.RequestAccessToken([]byte(fmt.Sprintf(`{"clientID": "%s", "ttl": 720}`, acoID)))
 	if err != nil {
-		assert.FailNow("no access token for %s because %s", AcoID, err.Error())
+		assert.FailNow("no access token for %s because %s", acoID, err.Error())
 	}
 	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
 	if err != nil {
-		assert.FailNow("no token string for %s because %s", AcoID, err.Error())
+		assert.FailNow("no token string for %s because %s", acoID, err.Error())
 	}
 
-	err = s.p.RevokeAccessToken(UserID)
+	err = s.p.RevokeAccessToken(userID)
 	assert.NotNil(err)
 
 	err = s.p.RevokeAccessToken(tokenString)
@@ -219,7 +219,7 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	assert.NotNil(err)
 
 	// Revoke a token that doesn't exist
-	tokenString, _ = s.AuthBackend.GenerateTokenString(uuid.NewRandom().String(), AcoID)
+	tokenString, _ = s.AuthBackend.GenerateTokenString(uuid.NewRandom().String(), acoID)
 	err = s.p.RevokeAccessToken(tokenString)
 	assert.NotNil(err)
 	assert.True(gorm.IsRecordNotFoundError(err))

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
-
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
 )
 
 const KnownFixtureACO = "DBBD1CE1-AE24-435C-807D-ED45953077D3"
@@ -133,11 +134,10 @@ func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
 
 func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 	acoID := uuid.NewRandom()
-	clientID := uuid.NewRandom().String()
 	var aco = models.ACO{
 		UUID:     acoID,
 		Name:     "RevokeClientCredentials Test ACO",
-		ClientID: clientID,
+		ClientID: acoID.String(),
 	}
 	db := connections["TestRevokeClientCredentials"]
 	db.Save(&aco)
@@ -151,14 +151,20 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 	}
 	db.Save(&user)
 
-	token, _, _ := s.AuthBackend.CreateToken(user)
+	params := fmt.Sprintf(`{"clientID":"%s", "ttl":720}`, user.AcoID.String())
+	_, err := s.p.GenerateClientCredentials([]byte(params))
+	if err != nil {
+		assert.FailNow(s.T(), fmt.Sprintf(`can't create client credentials for %s because %s`, user.AcoID.String(), err))
+	}
 
 	assert := assert.New(s.T())
 
-	err := s.p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID": "%s"}`, clientID)))
+	err = s.p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID": "%s"}`, aco.ClientID)))
 	assert.Nil(err)
 
-	db.First(&token, "UUID = ?", token.UUID)
+	var token auth.Token
+	err = db.First(&token, "user_id = ?", user.UUID).Error
+	require.Nil(s.T(), err)
 	assert.False(token.Active)
 
 	db.Delete(&token, &user, &aco)
@@ -183,22 +189,28 @@ func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	db := connections["TestRevokeAccessToken"]
 
-	userID, acoID := "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
-	var user models.User
-	db.Find(&user, "UUID = ? AND aco_id = ?", userID, acoID)
-	// Good Revoke test
-	_, tokenString, _ := s.AuthBackend.CreateToken(user)
-
+	const UserID, AcoID = "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	assert := assert.New(s.T())
 
-	err := s.p.RevokeAccessToken(userID)
+	// Good Revoke test
+	jwtToken, err := s.p.RequestAccessToken([]byte(fmt.Sprintf(`{"clientID": "%s", "ttl": 720}`, AcoID)))
+	if err != nil {
+		assert.FailNow("no access token for %s because %s", AcoID, err.Error())
+	}
+	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
+	if err != nil {
+		assert.FailNow("no token string for %s because %s", AcoID, err.Error())
+	}
+
+	err = s.p.RevokeAccessToken(UserID)
 	assert.NotNil(err)
 
 	err = s.p.RevokeAccessToken(tokenString)
 	assert.Nil(err)
-	jwtToken, err := s.p.DecodeAccessToken(tokenString)
+	jwtToken, err = s.p.DecodeAccessToken(tokenString)
 	assert.Nil(err)
 	c, _ := jwtToken.Claims.(AllClaims)
+
 	var tokenFromDB jwt.Token
 	assert.False(db.Find(&tokenFromDB, "UUID = ? AND active = false", c.ID).RecordNotFound())
 
@@ -207,7 +219,7 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	assert.NotNil(err)
 
 	// Revoke a token that doesn't exist
-	tokenString, _ = s.AuthBackend.GenerateTokenString(uuid.NewRandom().String(), acoID)
+	tokenString, _ = s.AuthBackend.GenerateTokenString(uuid.NewRandom().String(), AcoID)
 	err = s.p.RevokeAccessToken(tokenString)
 	assert.NotNil(err)
 	assert.True(gorm.IsRecordNotFoundError(err))

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -408,11 +408,16 @@ func createAccessToken(userID string) (string, error) {
 		return "", fmt.Errorf("unable to locate User with id of %s", userID)
 	}
 
-	authBackend := auth.InitAuthBackend()
-	_, tokenString, err := authBackend.CreateToken(user)
+	params := fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, user.AcoID.String(), 72)
+	jwtToken, err := GetAuthProvider().RequestAccessToken([]byte(params))
 	if err != nil {
 		return "", err
 	}
+	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
+	if err != nil {
+		return "", err
+	}
+
 	return tokenString, nil
 }
 

--- a/db/fixtures.sql
+++ b/db/fixtures.sql
@@ -20,5 +20,8 @@ insert into users values ('1ec70f78-7bb1-434b-9024-1d88c253ccec', 'User toNotRev
 insert into users values ('8c5f7cca-6ecd-4c18-83f8-15e59db3337b', 'User toRevoke', 'userrevoked2@email.com', '82f55b6a-728e-4c8b-807e-535caad7b139', default, default);
 insert into users values ('f85b3fc7-9d4e-49e1-8e7b-9feb3fb9f01b', 'User toNotRevoke', 'usernotrevoked2@email.com', '82f55b6a-728e-4c8b-807e-535caad7b139', default, default);
 
+insert into users values ('6baf8254-2e8a-4808-b11d-0fa00c527d2e', 'Dev User', 'devuser@acodev.com', '0c527d2e-2e8a-4808-b11d-0fa06baf8254', default, default);
+
 insert into tokens values ('d63205a8-d923-456b-a01b-0992fcb40968', '82503A18-BF3B-436D-BA7B-BAE09B7FFD2F', 'fake.token.value', 'true');
 insert into tokens values ('f5bd210a-5f95-4ba6-a167-2e9c95b5fbc1', 'EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73', 'fake.token.value', 'false');
+


### PR DESCRIPTION
### Fixes [BCDA-761](https://jira.cms.gov/browse/BCDA-761)
Replaces uses of auth/backend.CreateToken function with the auth/Provider.RequestAccessToken function.

### Proposed changes:
CLI and /api/v1/token endpoint now use auth provider method.
middleware uses of backend will be addressed by BCDA-764.

### Change Details
CLI and token end point.

### Security Implications
No new security concerns

### Acceptance Validation
All tests continue to pass.

### Reviewer Notes
* added a fixture user that is assigned to 'ACO Dev'
* reworked some tests because RequestAccessToken() requires that the User be associated with the ACO (CreateToken did not).