### PR TITLE
bcda-762 make sure all database connections are closed

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -46,8 +46,8 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
-	"github.com/bgentry/que-go"
-	"github.com/dgrijalva/jwt-go"
+	que "github.com/bgentry/que-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	fhirmodels "github.com/eug48/fhir/models"
 	"github.com/go-chi/chi"
 	"github.com/pborman/uuid"
@@ -111,7 +111,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 	)
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	if claims, err = readTokenClaims(r); err != nil {
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)
@@ -232,7 +232,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 func jobStatus(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "jobId")
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	i, err := strconv.Atoi(jobID)
 	if err != nil {
@@ -361,7 +361,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 	authBackend := auth.InitAuthBackend()
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	var user models.User
 	err := db.First(&user, "name = ?", "User One").Error

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
-	"github.com/bgentry/que-go"
-	"github.com/dgrijalva/jwt-go"
+	que "github.com/bgentry/que-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	fhirmodels "github.com/eug48/fhir/models"
 	"github.com/go-chi/chi"
 	"github.com/jackc/pgx"
@@ -37,6 +37,10 @@ func (s *APITestSuite) SetupTest() {
 	models.InitializeGormModels()
 	s.db = database.GetGORMDbConnection()
 	s.rr = httptest.NewRecorder()
+}
+
+func (s *APITestSuite) TearDownTest() {
+	s.db.Close()
 }
 
 func (s *APITestSuite) TestBulkEOBRequest() {

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -40,7 +40,7 @@ func (s *APITestSuite) SetupTest() {
 }
 
 func (s *APITestSuite) TearDownTest() {
-	s.db.Close()
+	database.Close(s.db)
 }
 
 func (s *APITestSuite) TestBulkEOBRequest() {

--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -13,7 +13,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/secutils"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 )
 
@@ -134,6 +134,7 @@ func (backend *JWTAuthenticationBackend) GetJWToken(tokenString string) (*jwt.To
 // Save a token to the DB for a user
 func (backend *JWTAuthenticationBackend) CreateToken(user models.User) (Token, string, error) {
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	tokenString, err := backend.GenerateTokenString(
 		user.UUID.String(),
 		user.AcoID.String(),

--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -78,7 +78,7 @@ func (backend *JWTAuthenticationBackend) GenerateTokenString(userID, acoID strin
 func (backend *JWTAuthenticationBackend) IsBlacklisted(jwtToken *jwt.Token) bool {
 	claims, _ := jwtToken.Claims.(jwt.MapClaims)
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	var token Token
 	// Look for an inactive token with the uuid; if found, it is blacklisted or otherwise revoked
@@ -134,7 +134,7 @@ func (backend *JWTAuthenticationBackend) GetJWToken(tokenString string) (*jwt.To
 // Save a token to the DB for a user
 func (backend *JWTAuthenticationBackend) CreateToken(user models.User) (Token, string, error) {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	tokenString, err := backend.GenerateTokenString(
 		user.UUID.String(),
 		user.AcoID.String(),

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -69,7 +69,7 @@ func (s *BackendTestSuite) TestGenerateToken() {
 func (s *BackendTestSuite) TestCreateToken() {
 	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	var user models.User
 	if db.Find(&user, "UUID = ?", userID).RecordNotFound() {
 		assert.NotNil(s.T(), errors.New("Unable to locate user"))
@@ -116,7 +116,7 @@ func (s *BackendTestSuite) TestIsBlacklisted() {
 	acoID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	var aco models.ACO
 	var user models.User

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -69,6 +69,7 @@ func (s *BackendTestSuite) TestGenerateToken() {
 func (s *BackendTestSuite) TestCreateToken() {
 	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	var user models.User
 	if db.Find(&user, "UUID = ?", userID).RecordNotFound() {
 		assert.NotNil(s.T(), errors.New("Unable to locate user"))
@@ -115,6 +116,7 @@ func (s *BackendTestSuite) TestIsBlacklisted() {
 	acoID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 
 	var aco models.ACO
 	var user models.User

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/dgrijalva/jwt-go/request"
 	"github.com/pborman/uuid"
 )

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -116,6 +116,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthBlackListed() {
 
 	// Blacklisted Token test
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	userID := "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73"
 	var user models.User
 	if db.Find(&user, "UUID = ?", userID).RecordNotFound() {

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -116,7 +116,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthBlackListed() {
 
 	// Blacklisted Token test
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	userID := "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73"
 	var user models.User
 	if db.Find(&user, "UUID = ?", userID).RecordNotFound() {

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/pborman/uuid"
@@ -12,7 +12,7 @@ import (
 
 func InitializeGormModels() *gorm.DB {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	// Migrate the schema
 	// Add your new models here
@@ -25,7 +25,7 @@ func InitializeGormModels() *gorm.DB {
 
 type Token struct {
 	gorm.Model
-	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` 				// uuid
+	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid
 	User        models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
 	UserID      uuid.UUID   `json:"user_id"`                                // user_id
 	Value       string      `gorm:"type:varchar(511); unique" json:"value"` // value

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -1,6 +1,8 @@
 package auth_test
 
 import (
+	"testing"
+
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
@@ -9,7 +11,6 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type ModelsTestSuite struct {
@@ -22,6 +23,10 @@ func (s *ModelsTestSuite) SetupTest() {
 	auth.InitializeGormModels()
 	s.db = database.GetGORMDbConnection()
 	s.SetupAuthBackend()
+}
+
+func (s *ModelsTestSuite) TearDownTest() {
+	s.db.Close()
 }
 
 func (s *ModelsTestSuite) TestTokenCreation() {

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -26,7 +26,7 @@ func (s *ModelsTestSuite) SetupTest() {
 }
 
 func (s *ModelsTestSuite) TearDownTest() {
-	s.db.Close()
+	database.Close(s.db)
 }
 
 func (s *ModelsTestSuite) TestTokenCreation() {

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -161,7 +161,7 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
 	backend := auth.InitAuthBackend()
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	jwtToken := jwt.Token{}
 
@@ -234,7 +234,7 @@ func (p *AlphaAuthPlugin) RevokeAccessToken(tokenString string) error {
 
 func revokeAccessTokenByID(tokenID uuid.UUID) error {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	var token auth.Token
 	if db.First(&token, "UUID = ? and active = true", tokenID).RecordNotFound() {
@@ -293,7 +293,7 @@ func isActive(token jwt.Token) bool {
 	c := token.Claims.(*AllClaims)
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	return !db.Find(&token, "UUID = ? AND active = ?", c.ID, true).RecordNotFound()
 }
@@ -318,7 +318,7 @@ func getACOFromDB(acoUUID string) (models.ACO, error) {
 		aco models.ACO
 		err error
 	)
-	defer db.Close()
+	defer database.Close(db)
 
 	if db.Find(&aco, "UUID = ?", acoUUID).RecordNotFound() {
 		err = errors.New("no ACO record found for " + acoUUID)

--- a/bcda/database/utils.go
+++ b/bcda/database/utils.go
@@ -1,0 +1,15 @@
+package database
+
+import (
+	"runtime"
+
+	"github.com/jinzhu/gorm"
+	log "github.com/sirupsen/logrus"
+)
+
+func Close(db *gorm.DB) {
+	if err := db.Close(); err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		log.Info("failed to close db connection at %s#%d because %s", file, line, err)
+	}
+}

--- a/bcda/encryption/encryption.go
+++ b/bcda/encryption/encryption.go
@@ -7,12 +7,13 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"errors"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	log "github.com/sirupsen/logrus"
 )
 
 // Code in this file borrows heavily from https://github.com/gtank/cryptopasta
@@ -88,6 +89,7 @@ func EncryptAndMove(fromPath, toPath, fileName string, key *rsa.PublicKey, jobID
 
 	// Save the encrypted key before trying anything dangerous
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	err = db.Create(&models.JobKey{JobID: jobID, EncryptedKey: encryptedKey, FileName: fileName}).Error
 	if err != nil {
 		log.Error(err)

--- a/bcda/encryption/encryption.go
+++ b/bcda/encryption/encryption.go
@@ -89,7 +89,7 @@ func EncryptAndMove(fromPath, toPath, fileName string, key *rsa.PublicKey, jobID
 
 	// Save the encrypted key before trying anything dangerous
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	err = db.Create(&models.JobKey{JobID: jobID, EncryptedKey: encryptedKey, FileName: fileName}).Error
 	if err != nil {
 		log.Error(err)

--- a/bcda/encryption/encryption_test.go
+++ b/bcda/encryption/encryption_test.go
@@ -35,7 +35,7 @@ func (s *EncryptionTestSuite) SetupTest() {
 }
 
 func (s *EncryptionTestSuite) TearDownTest() {
-	s.db.Close()
+	database.Close(s.db)
 }
 
 func (s *EncryptionTestSuite) TestEncryptBytes() {

--- a/bcda/encryption/encryption_test.go
+++ b/bcda/encryption/encryption_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"errors"
+
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
@@ -31,6 +32,10 @@ func (s *EncryptionTestSuite) SetupTest() {
 	s.db = database.GetGORMDbConnection()
 	os.Setenv("ATO_PUBLIC_KEY_FILE", "../../shared_files/ATO_public.pem")
 	os.Setenv("ATO_PRIVATE_KEY_FILE", "../../shared_files/ATO_private.pem")
+}
+
+func (s *EncryptionTestSuite) TearDownTest() {
+	s.db.Close()
 }
 
 func (s *EncryptionTestSuite) TestEncryptBytes() {

--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -5,14 +5,20 @@ import (
 	"os"
 
 	"github.com/CMSgov/bcda-app/bcda/client"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func IsDatabaseOK() bool {
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Info("failed to close db connection at bcda/health/health.go#IsDatabaseOK() because %s", err)
+		}
+	}()
 	if err != nil {
 		return false
 	}
-	defer db.Close()
 
 	return db.Ping() == nil
 }

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -401,7 +401,7 @@ func createAccessToken(userID string) (string, error) {
 	}
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	var user models.User
 
 	if db.First(&user, "UUID = ?", userID).RecordNotFound() {
@@ -463,7 +463,7 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 	}
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	err = db.Save(&aco).Error
 	if err != nil {
 		return "", fmt.Errorf("could not save ClientID %s to ACO %s (%s) because %s", aco.ClientID, aco.UUID.String(), aco.Name, err.Error())
@@ -505,7 +505,7 @@ func getEnvInt(varName string, defaultVal int) int {
 func archiveExpiring(hrThreshold int) error {
 	log.Info("Archiving expiring job files...")
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	var jobs []models.Job
 	err := db.Find(&jobs, "status = ?", "Completed").Error
@@ -554,7 +554,7 @@ func archiveExpiring(hrThreshold int) error {
 
 func cleanupArchive(hrThreshold int) error {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	expDir := os.Getenv("FHIR_ARCHIVE_DIR")
 	if _, err := os.Stat(expDir); os.IsNotExist(err) {
@@ -609,7 +609,7 @@ func cleanupArchive(hrThreshold int) error {
 
 func createAlphaEntities(acoSize string) (aco models.ACO, err error) {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	tx := db.Begin()
 	defer func() {
 		if r := recover(); r != nil {

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -81,7 +81,7 @@ func (s *MainTestSuite) TestCreateACO() {
 
 	// init
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	s.SetupAuthBackend()
 
 	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
@@ -140,7 +140,7 @@ func (s *MainTestSuite) TestCreateUser() {
 
 	// init
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	name, email := "Unit Test", "UnitTest@mail.com"
 
@@ -382,7 +382,7 @@ func (s *MainTestSuite) TestArchiveExpiring() {
 	// init
 	autoMigrate()
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	assert := assert.New(s.T())
 
@@ -450,7 +450,7 @@ func (s *MainTestSuite) TestArchiveExpiringWithThreshold() {
 	// init
 	autoMigrate()
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	// save a job to our db
 	j := models.Job{
@@ -507,7 +507,7 @@ func (s *MainTestSuite) TestArchiveExpiringWithThreshold() {
 
 func setupArchivedJob(s *MainTestSuite, email string, modified time.Time) int {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	s.SetupAuthBackend()
 	acoUUID, err := createACO("ACO " + email)
@@ -607,7 +607,7 @@ func (s *MainTestSuite) TestCleanArchive() {
 	}
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	var beforeJob models.Job
 	db.First(&beforeJob, "id = ?", beforeJobId)
@@ -727,7 +727,7 @@ func checkTTL(s *MainTestSuite, claims jwt.MapClaims, ttl int) {
 
 func checkStructure(s *MainTestSuite, ttl int, acoSize string) jwt.MapClaims {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	tokenInfo, err := createAlphaToken(ttl, acoSize)
 	lines := strings.Split(tokenInfo, "\n")
 	assert.Equal(s.T(), 3, len(lines))

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -81,6 +81,7 @@ func (s *MainTestSuite) TestCreateACO() {
 
 	// init
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	s.SetupAuthBackend()
 
 	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
@@ -139,6 +140,7 @@ func (s *MainTestSuite) TestCreateUser() {
 
 	// init
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	name, email := "Unit Test", "UnitTest@mail.com"
 
@@ -380,6 +382,7 @@ func (s *MainTestSuite) TestArchiveExpiring() {
 	// init
 	autoMigrate()
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 
 	assert := assert.New(s.T())
 
@@ -447,6 +450,7 @@ func (s *MainTestSuite) TestArchiveExpiringWithThreshold() {
 	// init
 	autoMigrate()
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 
 	// save a job to our db
 	j := models.Job{
@@ -723,6 +727,7 @@ func checkTTL(s *MainTestSuite, claims jwt.MapClaims, ttl int) {
 
 func checkStructure(s *MainTestSuite, ttl int, acoSize string) jwt.MapClaims {
 	db := database.GetGORMDbConnection()
+	defer db.Close()
 	tokenInfo, err := createAlphaToken(ttl, acoSize)
 	lines := strings.Split(tokenInfo, "\n")
 	assert.Equal(s.T(), 3, len(lines))

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -3,17 +3,18 @@ package models
 import (
 	"crypto/rsa"
 	"fmt"
+	"os"
+
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/secutils"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
-	"os"
 )
 
 func InitializeGormModels() *gorm.DB {
 	fmt.Print("Initialize bcda models")
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	// Migrate the schema
 	// Add your new models here
@@ -84,7 +85,7 @@ func GetATOPrivateKey() *rsa.PrivateKey {
 
 func CreateACO(name string) (uuid.UUID, error) {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	aco := ACO{Name: name, UUID: uuid.NewRandom()}
 	db.Create(&aco)
@@ -103,7 +104,7 @@ type User struct {
 
 func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 	var aco ACO
 	var user User
 	// If we don't find the ACO return a blank user and an error

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -1,12 +1,13 @@
 package models
 
 import (
+	"testing"
+
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type ModelsTestSuite struct {
@@ -17,6 +18,10 @@ type ModelsTestSuite struct {
 func (s *ModelsTestSuite) SetupTest() {
 	InitializeGormModels()
 	s.db = database.GetGORMDbConnection()
+}
+
+func (s *ModelsTestSuite) TearDownTest() {
+	s.db.Close()
 }
 
 func (s *ModelsTestSuite) TestCreateACO() {
@@ -38,7 +43,7 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	// we require that it be representable in a string of less than 255 characters
 	const ClientID = "Alpha client id"
 	aco.ClientID = ClientID
-	s.db.Save(aco);
+	s.db.Save(aco)
 	s.db.Find(&aco, "UUID = ?", acoUUID)
 	assert.NotNil(s.T(), aco)
 	assert.Equal(s.T(), ACOName, aco.Name)

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -21,7 +21,7 @@ func (s *ModelsTestSuite) SetupTest() {
 }
 
 func (s *ModelsTestSuite) TearDownTest() {
-	s.db.Close()
+	database.Close(s.db)
 }
 
 func (s *ModelsTestSuite) TestCreateACO() {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/monitoring"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
-	"github.com/bgentry/que-go"
+	que "github.com/bgentry/que-go"
 )
 
 var (
@@ -62,7 +62,7 @@ func processJob(j *que.Job) error {
 	log.Info("Worker started processing job ", j.ID)
 
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	jobArgs := jobEnqueueArgs{}
 	err := json.Unmarshal(j.Args, &jobArgs)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
-	"github.com/bgentry/que-go"
+	que "github.com/bgentry/que-go"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -166,7 +166,7 @@ func (bbc *MockBlueButtonClient) getData(endpoint, patientID string) (string, er
 
 func (s *MainTestSuite) TestProcessJobEOB() {
 	db := database.GetGORMDbConnection()
-	defer db.Close()
+	defer database.Close(db)
 
 	j := models.Job{
 		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),


### PR DESCRIPTION
### Fixes [BCDA-762](https://jira.cms.gov/browse/BCDA-762)
we don't always close db connections when we open them right now.  this closes them all and logs an error if we are unable to close the connection.

### Proposed changes:
add `utils.go` to the database package with a function that closes a db connection and logs an error if unable to do so.