### PR TITLE
BCDA-763 Improve handling of auth tokens with auth.Token type

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -132,7 +132,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 	}
 
 	newJob := models.Job{
-		AcoID:      uuid.Parse(acoId),
+		ACOID:      uuid.Parse(acoId),
 		UserID:     uuid.Parse(userId),
 		RequestURL: fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL),
 		Status:     "Pending",
@@ -177,7 +177,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 
 	args, err := json.Marshal(jobEnqueueArgs{
 		ID:             int(newJob.ID),
-		AcoID:          acoId,
+		ACOID:          acoId,
 		UserID:         userId,
 		BeneficiaryIDs: beneficiaryIds,
 		ResourceType:   t,
@@ -287,7 +287,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 
 		fi := fileItem{
 			Type: resourceType,
-			URL:  fmt.Sprintf("%s://%s/data/%s/%s.ndjson", scheme, r.Host, jobID, job.AcoID),
+			URL:  fmt.Sprintf("%s://%s/data/%s/%s.ndjson", scheme, r.Host, jobID, job.ACOID),
 		}
 
 		keyMap := make(map[string]string)
@@ -307,11 +307,11 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 			JobID:               job.ID,
 		}
 
-		errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), jobID, job.AcoID)
+		errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), jobID, job.ACOID)
 		if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
 			errFI := fileItem{
 				Type: "OperationOutcome",
-				URL:  fmt.Sprintf("%s://%s/data/%s/%s-error.ndjson", scheme, r.Host, jobID, job.AcoID),
+				URL:  fmt.Sprintf("%s://%s/data/%s/%s-error.ndjson", scheme, r.Host, jobID, job.ACOID),
 			}
 			rb.Errors = append(rb.Errors, errFI)
 		}

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -363,8 +363,6 @@ func serveData(w http.ResponseWriter, r *http.Request) {
 }
 
 func getToken(w http.ResponseWriter, r *http.Request) {
-	authBackend := auth.InitAuthBackend()
-
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
@@ -386,15 +384,7 @@ func getToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenString, err := authBackend.SignJwtToken(token)
-	if err != nil {
-		log.Error(err)
-		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
-		return
-	}
-
-	_, err = w.Write([]byte(tokenString))
+	_, err = w.Write([]byte(token.TokenString))
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -382,7 +382,7 @@ func (s *APITestSuite) TestJobStatusJobDoesNotExist() {
 
 func (s *APITestSuite) TestJobStatusPending() {
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Pending",
@@ -410,7 +410,7 @@ func (s *APITestSuite) TestJobStatusPending() {
 
 func (s *APITestSuite) TestJobStatusInProgress() {
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "In Progress",
@@ -437,7 +437,7 @@ func (s *APITestSuite) TestJobStatusInProgress() {
 
 func (s *APITestSuite) TestJobStatusFailed() {
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Failed",
@@ -464,7 +464,7 @@ func (s *APITestSuite) TestJobStatusFailed() {
 
 func (s *APITestSuite) TestJobStatusCompleted() {
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Completed",
@@ -513,7 +513,7 @@ func (s *APITestSuite) TestJobStatusCompleted() {
 
 func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Completed",
@@ -539,7 +539,7 @@ func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
 		}
 	}
 
-	errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID), j.AcoID)
+	errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID), j.ACOID)
 	_, err := os.Create(errFilePath)
 	if err != nil {
 		s.T().Error(err)
@@ -636,7 +636,7 @@ func makeJWT(acoId, userId string) *jwt.Token {
 
 func (s *APITestSuite) TestJobStatusWithWrongACO() {
 	j := models.Job{
-		AcoID:      uuid.Parse("dbbd1ce1-ae24-435c-807d-ed45953077d3"),
+		ACOID:      uuid.Parse("dbbd1ce1-ae24-435c-807d-ed45953077d3"),
 		UserID:     uuid.Parse("82503a18-bf3b-436d-ba7b-bae09b7ffd2f"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Pending",

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -339,7 +339,7 @@ func (s *APITestSuite) TestJobStatusInvalidJobID() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", "test")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)
@@ -364,7 +364,7 @@ func (s *APITestSuite) TestJobStatusJobDoesNotExist() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", jobID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)
@@ -397,7 +397,7 @@ func (s *APITestSuite) TestJobStatusPending() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", fmt.Sprint(j.ID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)
@@ -424,7 +424,7 @@ func (s *APITestSuite) TestJobStatusInProgress() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", fmt.Sprint(j.ID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)
@@ -452,7 +452,7 @@ func (s *APITestSuite) TestJobStatusFailed() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", fmt.Sprint(j.ID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)
@@ -485,7 +485,7 @@ func (s *APITestSuite) TestJobStatusCompleted() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", fmt.Sprint(j.ID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)
@@ -528,7 +528,7 @@ func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", fmt.Sprint(j.ID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	token := makeJWT("DBBD1CE1-AE24-435C-807D-ED45953077D3", "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	f := fmt.Sprintf("%s/%s", os.Getenv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID))
@@ -623,7 +623,7 @@ func (s *APITestSuite) TestGetVersion() {
 	assert.Equal(s.T(), "latest", respMap["version"])
 }
 
-func makeToken(acoId, userId string) *jwt.Token {
+func makeJWT(acoId, userId string) *jwt.Token {
 	token := jwt.New(jwt.SigningMethodRS512)
 	token.Claims = jwt.MapClaims{
 		"sub": userId,
@@ -651,7 +651,7 @@ func (s *APITestSuite) TestJobStatusWithWrongACO() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobId", fmt.Sprint(j.ID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	token := makeToken("a40404f7-1ef2-485a-9b71-40fe7acdcbc2", "82503a18-bf3b-436d-ba7b-bae09b7ffd2f")
+	token := makeJWT("a40404f7-1ef2-485a-9b71-40fe7acdcbc2", "82503a18-bf3b-436d-ba7b-bae09b7ffd2f")
 	req = req.WithContext(context.WithValue(req.Context(), "token", token))
 
 	handler.ServeHTTP(s.rr, req)

--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -137,7 +137,7 @@ func (backend *JWTAuthenticationBackend) CreateToken(user models.User) (Token, s
 	defer database.Close(db)
 	tokenString, err := backend.GenerateTokenString(
 		user.UUID.String(),
-		user.AcoID.String(),
+		user.ACOID.String(),
 	)
 	if err != nil {
 		panic(err)

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -26,17 +26,18 @@ func InitializeGormModels() *gorm.DB {
 type Token struct {
 	gorm.Model
 	// even though gorm.Model has an `id` field declared as the primary key, the following definition overrides that
-	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid (primary key)
-	User        models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
-	UserID      uuid.UUID   `json:"user_id"`                                // user_id
-	Value       string      `gorm:"type:varchar(511); unique" json:"value"` // value
-	Active      bool        `json:"active"`                                 // active
-	Aco         models.ACO  `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
-	AcoID       uuid.UUID   `json:"aco_id"`     // aco_id
-	IssuedAt    int64       `json:"issued_at"`  // standard token claim; unix date
-	ExpiresOn   int64       `json:"expires_on"` // standard token claim; unix date
-	Token       jwt.Token   `gorm:"-"`          // ignore; not for database
-	TokenString string      `gorm:"-"`          // ignore; not for database
+	UUID   uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid (primary key)
+	User   models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
+	UserID uuid.UUID   `json:"user_id"` // user_id
+	// use of Value is being retired. when can we drop it without hurting existing alpha tokens?
+	Value     string     `gorm:"type:varchar(511); unique" json:"value"` // value
+	Active    bool       `json:"active"`                                 // active
+	Aco       models.ACO `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
+	AcoID     uuid.UUID  `json:"aco_id"`     // aco_id
+	IssuedAt  int64      `json:"issued_at"`  // standard token claim; unix date
+	ExpiresOn int64      `json:"expires_on"` // standard token claim; unix date
+	// Token       jwt.Token   `gorm:"-"`                                      // ignore; not for database
+	TokenString string `gorm:"-"` // ignore; not for database
 	// we store AcoID on the token because a user can belong to multiple ACOs
 	// unix time converter here: http://unixepoch.com
 }

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -26,53 +26,29 @@ func InitializeGormModels() *gorm.DB {
 type Token struct {
 	gorm.Model
 	// even though gorm.Model has an `id` field declared as the primary key, the following definition overrides that
-	UUID   uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid (primary key)
-	User   models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
-	UserID uuid.UUID   `json:"user_id"` // user_id
-	// use of Value is being retired. when can we drop it without hurting existing alpha tokens?
-	Value     string     `gorm:"type:varchar(511); unique" json:"value"` // value
-	Active    bool       `json:"active"`                                 // active
-	Aco       models.ACO `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
-	AcoID     uuid.UUID  `json:"aco_id"`     // aco_id
-	IssuedAt  int64      `json:"issued_at"`  // standard token claim; unix date
-	ExpiresOn int64      `json:"expires_on"` // standard token claim; unix date
-	// Token       jwt.Token   `gorm:"-"`                                      // ignore; not for database
-	TokenString string `gorm:"-"` // ignore; not for database
+	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid (primary key)
+	User        models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
+	UserID      uuid.UUID   `json:"user_id"`                                // user_id
+	Value       string      `gorm:"type:varchar(511); unique" json:"value"` // use of Value is being retired. when can we drop it without hurting existing alpha tokens?
+	Active      bool        `json:"active"`                                 // active
+	ACO         models.ACO  `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
+	ACOID       uuid.UUID   `json:"aco_id"`     // aco_id
+	IssuedAt    int64       `json:"issued_at"`  // standard token claim; unix date
+	ExpiresOn   int64       `json:"expires_on"` // standard token claim; unix date
+	TokenString string      `gorm:"-"`          // ignore; not for database
 	// we store AcoID on the token because a user can belong to multiple ACOs
 	// unix time converter here: http://unixepoch.com
 }
 
 // When getting a Token out of the DB, reconstruct its tokenString
 func (t *Token) AfterFind() error {
-	s, err := GenerateTokenString(t.UUID, t.UserID, t.AcoID, t.IssuedAt, t.ExpiresOn)
+	s, err := GenerateTokenString(t.UUID, t.UserID, t.ACOID, t.IssuedAt, t.ExpiresOn)
 	if err == nil {
 		t.TokenString = s
 		return nil
 	}
 	return err
 }
-
-// func (t *Token) BeforeSave() error {
-// 	backend := InitAuthBackend()
-// 	// Parse the value into a t.  If this method does not return an error, the t needs to be hashed before saving
-// 	jwtToken, err := backend.GetJWToken(t.Value)
-// 	// If we got an error, the t is already hashed (or not valid for other reasons) and no need to rehash it
-// 	if err != nil {
-// 		return nil
-// 	}
-// 	hash := Hash{}
-// 	// If the token is valid hash it. If not, mark it inactive and clear out the value
-// 	// Why do we do this? all the data in the token is in the db already, so there's no data that is precious
-// 	// moreover, it may not be possible to reconstruct the token string if we need it
-// 	if jwtToken.Valid {
-// 		t.Value = hash.Generate(t.Value)
-// 	} else {
-// 		t.Value = hash.Generate("INVALID")
-// 		t.Active = false
-// 	}
-//
-// 	return nil
-// }
 
 // Given all claim values, construct a token string. This is mostly a helper method for testing (we think)
 func GenerateTokenString(id, userID, acoID uuid.UUID, issuedAt int64, expiresOn int64) (string, error) {

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -29,7 +29,7 @@ type Token struct {
 	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid (primary key)
 	User        models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
 	UserID      uuid.UUID   `json:"user_id"`                                      // user_id
-	Value       string      `gorm:"type:varchar(511); unique" json:"value"`       // use of Value is being retired. when can we drop it without hurting existing alpha tokens?
+	Value       string      `gorm:"type:varchar(511); unique" json:"value"`       // Deprecated: When can we drop Value without hurting existing alpha tokens?
 	Active      bool        `json:"active"`                                       // active
 	ACO         models.ACO  `gorm:"foreignkey:ACOID;association_foreignkey:UUID"` // ACO needed here because user can belong to multiple ACOs
 	ACOID       uuid.UUID   `json:"aco_id"`                                       // aco_id

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -25,34 +25,63 @@ func InitializeGormModels() *gorm.DB {
 
 type Token struct {
 	gorm.Model
-	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid
+	// even though gorm.Model has an `id` field declared as the primary key, the following definition overrides that
+	UUID        uuid.UUID   `gorm:"primary_key" json:"uuid"` // uuid (primary key)
 	User        models.User `gorm:"foreignkey:UserID;association_foreignkey:UUID"`
 	UserID      uuid.UUID   `json:"user_id"`                                // user_id
 	Value       string      `gorm:"type:varchar(511); unique" json:"value"` // value
 	Active      bool        `json:"active"`                                 // active
-	Token       jwt.Token   `gorm:"-"`                                      // ignore; not for database
-	TokenString string      `gorm:"-"`                                      // ignore; not for database
-	// why are we not storing the AcoID on token?
+	Aco         models.ACO  `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
+	AcoID       uuid.UUID   `json:"aco_id"`     // aco_id
+	IssuedAt    int64       `json:"issued_at"`  // standard token claim; unix date
+	ExpiresOn   int64       `json:"expires_on"` // standard token claim; unix date
+	Token       jwt.Token   `gorm:"-"`          // ignore; not for database
+	TokenString string      `gorm:"-"`          // ignore; not for database
+	// we store AcoID on the token because a user can belong to multiple ACOs
+	// unix time converter here: http://unixepoch.com
 }
 
-func (token *Token) BeforeSave() error {
-	backend := InitAuthBackend()
-	// Parse the value into a token.  If this method does not return an error, the token needs to be hashed before saving
-	jwtToken, err := backend.GetJWToken(token.Value)
-	// If we got an error, the token is already hashed (or not valid for other reasons) and no need to rehash it
-	if err != nil {
+// When getting a Token out of the DB, reconstruct its tokenString
+func (t *Token) AfterFind() error {
+	s, err := GenerateTokenString(t.UUID, t.UserID, t.AcoID, t.IssuedAt, t.ExpiresOn)
+	if err == nil {
+		t.TokenString = s
 		return nil
 	}
-	hash := Hash{}
-	// If the token is valid hash it. If not, mark it inactive and clear out the value
-	// Why do we do this? all the data in the token is in the db already, so there's no data that is precious
-	// moreover, it may not be possible to reconstruct the token string if we need it
-	if jwtToken.Valid {
-		token.Value = hash.Generate(token.Value)
-	} else {
-		token.Value = hash.Generate("INVALID")
-		token.Active = false
-	}
+	return err
+}
 
-	return nil
+// func (t *Token) BeforeSave() error {
+// 	backend := InitAuthBackend()
+// 	// Parse the value into a t.  If this method does not return an error, the t needs to be hashed before saving
+// 	jwtToken, err := backend.GetJWToken(t.Value)
+// 	// If we got an error, the t is already hashed (or not valid for other reasons) and no need to rehash it
+// 	if err != nil {
+// 		return nil
+// 	}
+// 	hash := Hash{}
+// 	// If the token is valid hash it. If not, mark it inactive and clear out the value
+// 	// Why do we do this? all the data in the token is in the db already, so there's no data that is precious
+// 	// moreover, it may not be possible to reconstruct the token string if we need it
+// 	if jwtToken.Valid {
+// 		t.Value = hash.Generate(t.Value)
+// 	} else {
+// 		t.Value = hash.Generate("INVALID")
+// 		t.Active = false
+// 	}
+//
+// 	return nil
+// }
+
+// Given all claim values, construct a token string. This is mostly a helper method for testing (we think)
+func GenerateTokenString(id, userID, acoID uuid.UUID, issuedAt int64, expiresOn int64) (string, error) {
+	token := jwt.New(jwt.SigningMethodRS512)
+	token.Claims = jwt.MapClaims{
+		"exp": expiresOn,
+		"iat": issuedAt,
+		"sub": userID.String(),
+		"aco": acoID.String(),
+		"id":  id.String(),
+	}
+	return token.SignedString(InitAuthBackend().PrivateKey)
 }

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -66,6 +66,26 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 	assert.Equal(s.T(), tokenString, savedToken.TokenString)
 }
 
+func (s *BackendTestSuite) TestGenerateTokenString() {
+	var (
+		userUUID = uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+		acoUUID  = uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3")
+	)
+	token, err := auth.GenerateTokenString(uuid.NewRandom(), userUUID, acoUUID, time.Now().Unix(), time.Now().Add(time.Hour).Unix())
+
+	// No errors, token is not nil
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), token)
+
+	// Wipe the keys
+	s.AuthBackend.PrivateKey = nil
+	s.AuthBackend.PublicKey = nil
+	defer s.AuthBackend.ResetAuthBackend()
+	assert.Panics(s.T(), func() {
+		_, _ = auth.GenerateTokenString(uuid.NewRandom(), userUUID, acoUUID, time.Now().Unix(), time.Now().Add(time.Hour).Unix())
+	})
+}
+
 func TestModelsTestSuite(t *testing.T) {
 	suite.Run(t, new(ModelsTestSuite))
 }

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -2,15 +2,16 @@ package auth_test
 
 import (
 	"testing"
+	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
 )
 
 type ModelsTestSuite struct {
@@ -30,35 +31,42 @@ func (s *ModelsTestSuite) TearDownTest() {
 }
 
 func (s *ModelsTestSuite) TestTokenCreation() {
-	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
-	userUUID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
+	tokenUUID := uuid.NewRandom()
+	acoUUID := uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3")
+	userUUID := uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F")
+	issuedAt := time.Now().Unix()
+	expiresOn := time.Now().Add(time.Hour * time.Duration(72)).Unix()
 
-	tokenString, err := s.AuthBackend.GenerateTokenString(
+	tokenString, err := auth.GenerateTokenString(
+		tokenUUID,
 		userUUID,
 		acoUUID,
+		issuedAt,
+		expiresOn,
 	)
 
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), tokenString)
 
-	var user models.User
-	s.db.Find(&user, "UUID = ?", userUUID)
+	// var user models.User
+	// s.db.Find(&user, "UUID = ?", userUUID)
 
 	// Get the claims of the token to find the token ID that was created
-	claims := s.AuthBackend.GetJWTClaims(tokenString)
-	tokenUUID := claims["id"].(string)
 	token := auth.Token{
-		UUID:   uuid.Parse(tokenUUID),
-		UserID: user.UUID,
-		Value:  tokenString,
-		Active: true,
+		UUID:      tokenUUID,
+		UserID:    userUUID,
+		Value:     tokenString,
+		Active:    true,
+		AcoID:     acoUUID,
+		IssuedAt:  issuedAt,
+		ExpiresOn: expiresOn,
 	}
 	s.db.Create(&token)
 
 	var savedToken auth.Token
 	s.db.Find(&savedToken, "UUID = ?", tokenUUID)
 	assert.NotNil(s.T(), savedToken)
-	assert.Equal(s.T(), token.Value, savedToken.Value)
+	assert.Equal(s.T(), tokenString, savedToken.TokenString)
 }
 
 func TestModelsTestSuite(t *testing.T) {

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -57,7 +57,7 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 		UserID:    userUUID,
 		Value:     tokenString,
 		Active:    true,
-		AcoID:     acoUUID,
+		ACOID:     acoUUID,
 		IssuedAt:  issuedAt,
 		ExpiresOn: expiresOn,
 	}

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -48,9 +48,6 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), tokenString)
 
-	// var user models.User
-	// s.db.Find(&user, "UUID = ?", userUUID)
-
 	// Get the claims of the token to find the token ID that was created
 	token := auth.Token{
 		UUID:      tokenUUID,

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -85,16 +85,12 @@ func (p *AlphaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, erro
 		return nil, fmt.Errorf("unable to revoke existing credentials for ACO %s because %s", clientID, err)
 	}
 
-	jwtToken, err := p.RequestAccessToken([]byte(params))
+	token, err := p.RequestAccessToken([]byte(params))
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate new credentials for ACO %s because %s", clientID, err)
 	}
-	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
-	if err != nil {
-		return nil, fmt.Errorf("unable to generate tokenString because %s", err)
-	}
 
-	return []byte(fmt.Sprintf(`{"tokenString":"%s"}`, tokenString)), err
+	return []byte(fmt.Sprintf(`{"tokenString":"%s"}`, token.TokenString)), err
 }
 
 // look up the active access token associated with id, and call RevokeAccessToken
@@ -158,21 +154,20 @@ func (p *AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 
 // generate a token for the id (which user? just have a single "user" (alpha2, alpha3, ...) per test cycle?)
 // params are currently acoId and ttl; not going to introduce user until we have clear use cases
-func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
-	backend := auth.InitAuthBackend()
+func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (auth.Token, error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
-	jwtToken := jwt.Token{}
+	token := auth.Token{}
 
 	acoUUID, err := GetParamString(params, "clientID")
 	if err != nil {
-		return jwtToken, err
+		return token, err
 	}
 
 	aco, err := getACOFromDB(acoUUID)
 	if err != nil {
-		return jwtToken, err
+		return token, err
 	}
 
 	// I arbitrarily decided to use the first user. An alternative would be to make a specific user
@@ -180,47 +175,35 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (jwt.Token, error) {
 	// unless we're willing to live with it forever.
 	var user models.User
 	if err = db.First(&user, "aco_id = ?", aco.UUID).Error; err != nil {
-		return jwtToken, errors.New("no user found for " + aco.UUID.String())
+		return token, errors.New("no user found for " + aco.UUID.String())
 	}
 
 	ttl, err := GetParamPositiveInt(params, "ttl")
 	if err != nil {
-		return jwtToken, errors.New("no valid ttl found because " + err.Error())
+		return token, errors.New("no valid ttl found because " + err.Error())
 	}
 
-	tokenUUID := uuid.NewRandom()
-	jwtToken = *jwt.New(jwt.SigningMethodRS512)
-	jwtToken.Claims = jwt.MapClaims{
-		"exp": time.Now().Add(time.Hour * time.Duration(ttl)).Unix(),
-		"iat": time.Now().Unix(),
-		"sub": user.UUID.String(),
-		"aco": aco.UUID.String(),
-		"id":  tokenUUID.String(),
-	}
-
-	tokenString, err := backend.SignJwtToken(jwtToken)
-	if err != nil {
-		return jwtToken, err
-	}
-
-	token := auth.Token{
-		UUID:        tokenUUID,
-		UserID:      user.UUID,
-		Value:       tokenString, // replaced with hash when saved to db
-		Active:      true,
-		Token:       jwtToken,
-		TokenString: tokenString,
-	}
+	token.UUID = uuid.NewRandom()
+	token.UserID = user.UUID
+	token.AcoID = aco.UUID
+	token.IssuedAt = time.Now().Unix()
+	token.ExpiresOn = time.Now().Add(time.Hour * time.Duration(ttl)).Unix()
+	token.Active = true
 
 	if err = db.Create(&token).Error; err != nil {
-		return jwtToken, err
+		return auth.Token{}, err
 	}
 
-	return jwtToken, err // really want to return auth.Token here, but first let's get this all working
+	token.TokenString, err = auth.GenerateTokenString(token.UUID, token.UserID, token.AcoID, token.IssuedAt, token.ExpiresOn)
+	if err != nil {
+		return auth.Token{}, err
+	}
+
+	return token, nil // really want to return auth.Token here, but first let's get this all working
 }
 
 func (p *AlphaAuthPlugin) RevokeAccessToken(tokenString string) error {
-	t, err := p.DecodeAccessToken(tokenString)
+	t, err := p.DecodeJwtToken(tokenString)
 	if err != nil {
 		return err
 	}
@@ -247,8 +230,8 @@ func revokeAccessTokenByID(tokenID uuid.UUID) error {
 	return db.Error
 }
 
-func (p *AlphaAuthPlugin) ValidateAccessToken(tokenString string) error {
-	t, err := p.DecodeAccessToken(tokenString)
+func (p *AlphaAuthPlugin) ValidateJwtToken(tokenString string) error {
+	t, err := p.DecodeJwtToken(tokenString)
 	if err != nil {
 		return err
 	}
@@ -298,7 +281,7 @@ func isActive(token jwt.Token) bool {
 	return !db.Find(&token, "UUID = ? AND active = ?", c.ID, true).RecordNotFound()
 }
 
-func (p *AlphaAuthPlugin) DecodeAccessToken(tokenString string) (jwt.Token, error) {
+func (p *AlphaAuthPlugin) DecodeJwtToken(tokenString string) (jwt.Token, error) {
 	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -178,7 +178,7 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (auth.Token, error) 
 		return token, errors.New("no user found for " + aco.UUID.String())
 	}
 
-	ttl, err := GetParamPositiveInt(params, "ttl")
+	ttl, err := getParamPositiveInt(params, "ttl")
 	if err != nil {
 		return token, errors.New("no valid ttl found because " + err.Error())
 	}
@@ -203,7 +203,7 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (auth.Token, error) 
 }
 
 func (p *AlphaAuthPlugin) RevokeAccessToken(tokenString string) error {
-	t, err := p.DecodeJwtToken(tokenString)
+	t, err := p.DecodeJWT(tokenString)
 	if err != nil {
 		return err
 	}
@@ -230,8 +230,8 @@ func revokeAccessTokenByID(tokenID uuid.UUID) error {
 	return db.Error
 }
 
-func (p *AlphaAuthPlugin) ValidateJwtToken(tokenString string) error {
-	t, err := p.DecodeJwtToken(tokenString)
+func (p *AlphaAuthPlugin) ValidateJWT(tokenString string) error {
+	t, err := p.DecodeJWT(tokenString)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func isActive(token jwt.Token) bool {
 	return !db.Find(&token, "UUID = ? AND active = ?", c.ID, true).RecordNotFound()
 }
 
-func (p *AlphaAuthPlugin) DecodeJwtToken(tokenString string) (jwt.Token, error) {
+func (p *AlphaAuthPlugin) DecodeJWT(tokenString string) (jwt.Token, error) {
 	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -328,7 +328,7 @@ func GetParamString(params []byte, name string) (string, error) {
 	return stringForName, err
 }
 
-func GetParamPositiveInt(params []byte, name string) (int, error) {
+func getParamPositiveInt(params []byte, name string) (int, error) {
 	var (
 		j   interface{}
 		err error

--- a/bcda/auth/plugin/alpha.go
+++ b/bcda/auth/plugin/alpha.go
@@ -185,7 +185,7 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (auth.Token, error) 
 
 	token.UUID = uuid.NewRandom()
 	token.UserID = user.UUID
-	token.AcoID = aco.UUID
+	token.ACOID = aco.UUID
 	token.IssuedAt = time.Now().Unix()
 	token.ExpiresOn = time.Now().Add(time.Hour * time.Duration(ttl)).Unix()
 	token.Active = true
@@ -194,7 +194,7 @@ func (p *AlphaAuthPlugin) RequestAccessToken(params []byte) (auth.Token, error) 
 		return auth.Token{}, err
 	}
 
-	token.TokenString, err = auth.GenerateTokenString(token.UUID, token.UserID, token.AcoID, token.IssuedAt, token.ExpiresOn)
+	token.TokenString, err = auth.GenerateTokenString(token.UUID, token.UserID, token.ACOID, token.IssuedAt, token.ExpiresOn)
 	if err != nil {
 		return auth.Token{}, err
 	}

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -146,15 +146,15 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 		UUID:  uuid.NewRandom(),
 		Name:  "RevokeClientCredentials Test User",
 		Email: "revokeclientcredentialstest@example.com",
-		Aco:   aco,
-		AcoID: aco.UUID,
+		ACO:   aco,
+		ACOID: aco.UUID,
 	}
 	db.Save(&user)
 
-	params := fmt.Sprintf(`{"clientID":"%s", "ttl":720}`, user.AcoID.String())
+	params := fmt.Sprintf(`{"clientID":"%s", "ttl":720}`, user.ACOID.String())
 	_, err := s.p.GenerateClientCredentials([]byte(params))
 	if err != nil {
-		assert.FailNow(s.T(), fmt.Sprintf(`can't create client credentials for %s because %s`, user.AcoID.String(), err))
+		assert.FailNow(s.T(), fmt.Sprintf(`can't create client credentials for %s because %s`, user.ACOID.String(), err))
 	}
 
 	assert := assert.New(s.T())

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -231,7 +231,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 	validToken := *jwt.New(jwt.SigningMethodRS512)
 	validToken.Claims = validClaims
 	validTokenString, _ := s.AuthBackend.SignJwtToken(validToken)
-	err := s.p.ValidateJwtToken(validTokenString)
+	err := s.p.ValidateJWT(validTokenString)
 	assert.Nil(s.T(), err)
 
 	unknownAco := *jwt.New(jwt.SigningMethodRS512)
@@ -243,15 +243,15 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	unknownAcoString, _ := s.AuthBackend.SignJwtToken(unknownAco)
-	err = s.p.ValidateJwtToken(unknownAcoString)
+	err = s.p.ValidateJWT(unknownAcoString)
 	assert.Contains(s.T(), err.Error(), "no ACO record found")
 
 	badSigningMethod := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImlUcVhYSTB6YkFuSkNLRGFvYmZoa00xZi02ck1TcFRmeVpNUnBfMnRLSTgifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.cJOP_w-hBqnyTsBm3T6lOE5WpcHaAkLuQGAs1QO-lg2eWs8yyGW8p9WagGjxgvx7h9X72H7pXmXqej3GdlVbFmhuzj45A9SXDOAHZ7bJXwM1VidcPi7ZcrsMSCtP1hiN"
-	err = s.p.ValidateJwtToken(badSigningMethod)
+	err = s.p.ValidateJWT(badSigningMethod)
 	assert.Contains(s.T(), err.Error(), "unexpected signing method")
 
 	wrongKey := "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.MejLezWY6hjGgbIXkq6Qbvx_-q5vWaTR6qPiNHphvla-XaZD3up1DN6Ib5AEOVtuB3fC9l-0L36noK4qQA79lhpSK3gozXO6XPIcCp4C8MU_ACzGtYe7IwGnnK3Emr6IHQE0bpGinHX1Ak1pAuwJNawaQ6Nvmz2ozZPsyxmiwoo"
-	err = s.p.ValidateJwtToken(wrongKey)
+	err = s.p.ValidateJWT(wrongKey)
 	assert.Contains(s.T(), err.Error(), "crypto/rsa: verification error")
 
 	missingClaims := *jwt.New(jwt.SigningMethodRS512)
@@ -261,7 +261,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"id":  "d63205a8-d923-456b-a01b-0992fcb40968",
 	}
 	missingClaimsString, _ := s.AuthBackend.SignJwtToken(missingClaims)
-	err = s.p.ValidateJwtToken(missingClaimsString)
+	err = s.p.ValidateJWT(missingClaimsString)
 	assert.Contains(s.T(), err.Error(), "missing one or more required claims")
 
 	noSuchTokenID := *jwt.New(jwt.SigningMethodRS512)
@@ -273,7 +273,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	noSuchTokenIDString, _ := s.AuthBackend.SignJwtToken(noSuchTokenID)
-	err = s.p.ValidateJwtToken(noSuchTokenIDString)
+	err = s.p.ValidateJWT(noSuchTokenIDString)
 	assert.Contains(s.T(), err.Error(), "is not active")
 
 	invalidTokenID := *jwt.New(jwt.SigningMethodRS512)
@@ -285,15 +285,15 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	invalidTokenIDString, _ := s.AuthBackend.SignJwtToken(invalidTokenID)
-	err = s.p.ValidateJwtToken(invalidTokenIDString)
+	err = s.p.ValidateJWT(invalidTokenIDString)
 	assert.Contains(s.T(), err.Error(), "is not active")
 }
 
-func (s *AlphaAuthPluginTestSuite) TestDecodeJwtToken() {
+func (s *AlphaAuthPluginTestSuite) TestDecodeJWT() {
 	userID := uuid.NewRandom().String()
 	acoID := uuid.NewRandom().String()
 	ts, _ := s.AuthBackend.GenerateTokenString(userID, acoID)
-	t, err := s.p.DecodeJwtToken(ts)
+	t, err := s.p.DecodeJWT(ts)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), jwt.Token{}, t)
 	assert.Equal(s.T(), userID, t.Claims.(*AllClaims).Subject)

--- a/bcda/auth/plugin/alpha_test.go
+++ b/bcda/auth/plugin/alpha_test.go
@@ -173,16 +173,16 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
 	t, err := s.p.RequestAccessToken([]byte(`{"clientID": "DBBD1CE1-AE24-435C-807D-ED45953077D3", "ttl": 720}`))
 	assert.Nil(s.T(), err)
-	assert.IsType(s.T(), jwt.Token{}, t)
+	assert.IsType(s.T(), auth.Token{}, t)
 
 	t, err = s.p.RequestAccessToken([]byte(`{ "ttl": 720}`))
 	assert.NotNil(s.T(), err)
-	assert.IsType(s.T(), jwt.Token{}, t)
+	assert.IsType(s.T(), auth.Token{}, t)
 	assert.Contains(s.T(), err.Error(), "invalid string value")
 
 	t, err = s.p.RequestAccessToken([]byte(`{"clientID": "DBBD1CE1-AE24-435C-807D-ED45953077D3"}`))
 	assert.NotNil(s.T(), err)
-	assert.IsType(s.T(), jwt.Token{}, t)
+	assert.IsType(s.T(), auth.Token{}, t)
 	assert.Contains(s.T(), err.Error(), "invalid int value")
 }
 
@@ -193,33 +193,25 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	assert := assert.New(s.T())
 
 	// Good Revoke test
-	jwtToken, err := s.p.RequestAccessToken([]byte(fmt.Sprintf(`{"clientID": "%s", "ttl": 720}`, acoID)))
+	token, err := s.p.RequestAccessToken([]byte(fmt.Sprintf(`{"clientID": "%s", "ttl": 720}`, acoID)))
 	if err != nil {
 		assert.FailNow("no access token for %s because %s", acoID, err.Error())
-	}
-	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
-	if err != nil {
-		assert.FailNow("no token string for %s because %s", acoID, err.Error())
 	}
 
 	err = s.p.RevokeAccessToken(userID)
 	assert.NotNil(err)
 
-	err = s.p.RevokeAccessToken(tokenString)
+	err = s.p.RevokeAccessToken(token.TokenString)
 	assert.Nil(err)
-	jwtToken, err = s.p.DecodeAccessToken(tokenString)
-	assert.Nil(err)
-	c, _ := jwtToken.Claims.(AllClaims)
-
 	var tokenFromDB jwt.Token
-	assert.False(db.Find(&tokenFromDB, "UUID = ? AND active = false", c.ID).RecordNotFound())
+	assert.False(db.Find(&tokenFromDB, "UUID = ? AND active = false", token.UUID).RecordNotFound())
 
 	// Revoke the token again, you can't
-	err = s.p.RevokeAccessToken(tokenString)
+	err = s.p.RevokeAccessToken(token.TokenString)
 	assert.NotNil(err)
 
 	// Revoke a token that doesn't exist
-	tokenString, _ = s.AuthBackend.GenerateTokenString(uuid.NewRandom().String(), acoID)
+	tokenString, _ := s.AuthBackend.GenerateTokenString(uuid.NewRandom().String(), acoID)
 	err = s.p.RevokeAccessToken(tokenString)
 	assert.NotNil(err)
 	assert.True(gorm.IsRecordNotFoundError(err))
@@ -239,7 +231,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 	validToken := *jwt.New(jwt.SigningMethodRS512)
 	validToken.Claims = validClaims
 	validTokenString, _ := s.AuthBackend.SignJwtToken(validToken)
-	err := s.p.ValidateAccessToken(validTokenString)
+	err := s.p.ValidateJwtToken(validTokenString)
 	assert.Nil(s.T(), err)
 
 	unknownAco := *jwt.New(jwt.SigningMethodRS512)
@@ -251,15 +243,15 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	unknownAcoString, _ := s.AuthBackend.SignJwtToken(unknownAco)
-	err = s.p.ValidateAccessToken(unknownAcoString)
+	err = s.p.ValidateJwtToken(unknownAcoString)
 	assert.Contains(s.T(), err.Error(), "no ACO record found")
 
 	badSigningMethod := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImlUcVhYSTB6YkFuSkNLRGFvYmZoa00xZi02ck1TcFRmeVpNUnBfMnRLSTgifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.cJOP_w-hBqnyTsBm3T6lOE5WpcHaAkLuQGAs1QO-lg2eWs8yyGW8p9WagGjxgvx7h9X72H7pXmXqej3GdlVbFmhuzj45A9SXDOAHZ7bJXwM1VidcPi7ZcrsMSCtP1hiN"
-	err = s.p.ValidateAccessToken(badSigningMethod)
+	err = s.p.ValidateJwtToken(badSigningMethod)
 	assert.Contains(s.T(), err.Error(), "unexpected signing method")
 
 	wrongKey := "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.MejLezWY6hjGgbIXkq6Qbvx_-q5vWaTR6qPiNHphvla-XaZD3up1DN6Ib5AEOVtuB3fC9l-0L36noK4qQA79lhpSK3gozXO6XPIcCp4C8MU_ACzGtYe7IwGnnK3Emr6IHQE0bpGinHX1Ak1pAuwJNawaQ6Nvmz2ozZPsyxmiwoo"
-	err = s.p.ValidateAccessToken(wrongKey)
+	err = s.p.ValidateJwtToken(wrongKey)
 	assert.Contains(s.T(), err.Error(), "crypto/rsa: verification error")
 
 	missingClaims := *jwt.New(jwt.SigningMethodRS512)
@@ -269,7 +261,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"id":  "d63205a8-d923-456b-a01b-0992fcb40968",
 	}
 	missingClaimsString, _ := s.AuthBackend.SignJwtToken(missingClaims)
-	err = s.p.ValidateAccessToken(missingClaimsString)
+	err = s.p.ValidateJwtToken(missingClaimsString)
 	assert.Contains(s.T(), err.Error(), "missing one or more required claims")
 
 	noSuchTokenID := *jwt.New(jwt.SigningMethodRS512)
@@ -281,7 +273,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	noSuchTokenIDString, _ := s.AuthBackend.SignJwtToken(noSuchTokenID)
-	err = s.p.ValidateAccessToken(noSuchTokenIDString)
+	err = s.p.ValidateJwtToken(noSuchTokenIDString)
 	assert.Contains(s.T(), err.Error(), "is not active")
 
 	invalidTokenID := *jwt.New(jwt.SigningMethodRS512)
@@ -293,15 +285,15 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	invalidTokenIDString, _ := s.AuthBackend.SignJwtToken(invalidTokenID)
-	err = s.p.ValidateAccessToken(invalidTokenIDString)
+	err = s.p.ValidateJwtToken(invalidTokenIDString)
 	assert.Contains(s.T(), err.Error(), "is not active")
 }
 
-func (s *AlphaAuthPluginTestSuite) TestDecodeAccessToken() {
+func (s *AlphaAuthPluginTestSuite) TestDecodeJwtToken() {
 	userID := uuid.NewRandom().String()
 	acoID := uuid.NewRandom().String()
 	ts, _ := s.AuthBackend.GenerateTokenString(userID, acoID)
-	t, err := s.p.DecodeAccessToken(ts)
+	t, err := s.p.DecodeJwtToken(ts)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), jwt.Token{}, t)
 	assert.Equal(s.T(), userID, t.Claims.(*AllClaims).Subject)

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -14,6 +14,6 @@ type Provider interface {
 	RequestAccessToken(params []byte) (Token, error)
 	RevokeAccessToken(tokenString string) error
 
-	ValidateJwtToken(tokenString string) error
-	DecodeJwtToken(tokenString string) (jwt.Token, error)
+	ValidateJWT(tokenString string) error
+	DecodeJWT(tokenString string) (jwt.Token, error)
 }

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -1,8 +1,6 @@
 package auth
 
-import (
-	"github.com/dgrijalva/jwt-go"
-)
+import "github.com/dgrijalva/jwt-go"
 
 // Provider is an interface for operations performed through an authentication provider.
 type Provider interface {
@@ -13,9 +11,9 @@ type Provider interface {
 	GenerateClientCredentials(params []byte) ([]byte, error)
 	RevokeClientCredentials(params []byte) error
 
-	RequestAccessToken(params []byte) (jwt.Token, error)
+	RequestAccessToken(params []byte) (Token, error)
 	RevokeAccessToken(tokenString string) error
 
-	ValidateAccessToken(tokenString string) error
-	DecodeAccessToken(tokenString string) (jwt.Token, error)
+	ValidateJwtToken(tokenString string) error
+	DecodeJwtToken(tokenString string) (jwt.Token, error)
 }

--- a/bcda/encryption/encryption_test.go
+++ b/bcda/encryption/encryption_test.go
@@ -77,7 +77,7 @@ func (s *EncryptionTestSuite) TestEncryptAndMove() {
 	}
 	fileName := "Coverage"
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Pending",

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -36,7 +36,7 @@ var (
 // swagger:ignore
 type jobEnqueueArgs struct {
 	ID             int
-	AcoID          string
+	ACOID          string
 	UserID         string
 	BeneficiaryIDs []string
 	ResourceType   string
@@ -406,7 +406,7 @@ func createAccessToken(userID string) (string, error) {
 		return "", fmt.Errorf("unable to locate User with id of %s", userID)
 	}
 
-	params := fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, user.AcoID.String(), 72)
+	params := fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, user.ACOID.String(), 72)
 	token, err := GetAuthProvider().RequestAccessToken([]byte(params))
 	if err != nil {
 		return "", err

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
-
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/auth/plugin"
 	"github.com/CMSgov/bcda-app/bcda/database"
@@ -409,16 +407,12 @@ func createAccessToken(userID string) (string, error) {
 	}
 
 	params := fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, user.AcoID.String(), 72)
-	jwtToken, err := GetAuthProvider().RequestAccessToken([]byte(params))
-	if err != nil {
-		return "", err
-	}
-	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
+	token, err := GetAuthProvider().RequestAccessToken([]byte(params))
 	if err != nil {
 		return "", err
 	}
 
-	return tokenString, nil
+	return token.TokenString, nil
 }
 
 func revokeAccessToken(accessToken string) error {
@@ -457,7 +451,7 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 
 	authProvider := GetAuthProvider()
 
-	params := fmt.Sprintf("{\"clientID\" : \"%s\"}", aco.UUID.String())
+	params := fmt.Sprintf(`{"clientID" : "%s"}`, aco.UUID.String())
 	result, err := authProvider.RegisterClient([]byte(params))
 	if err != nil {
 		return "", fmt.Errorf("could not register client for %s (%s) because %s", aco.UUID.String(), aco.Name, err.Error())
@@ -474,26 +468,15 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 		return "", fmt.Errorf("could not save ClientID %s to ACO %s (%s) because %s", aco.ClientID, aco.UUID.String(), aco.Name, err.Error())
 	}
 
-	params = fmt.Sprintf("{\"clientID\" : \"%s\", \"ttl\" : %d}", aco.ClientID, ttl)
-	jwtToken, err := authProvider.RequestAccessToken([]byte(params))
-	if err != nil {
-		return "", err
-	}
-	// (re)produce the tokenString; JwtToken seems to only store the tokenString when it's been used to decode an incoming token
-	// TBD: have RequestAccessToken return the token string and decode the string here, or have it return a wrapped Token that has both?
-	tokenString, err := jwtToken.SignedString(auth.InitAuthBackend().PrivateKey)
+	params = fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, aco.ClientID, ttl)
+	token, err := authProvider.RequestAccessToken([]byte(params))
 	if err != nil {
 		return "", err
 	}
 
-	// this code can get cleaned up with DecodeToken
-	claims := jwtToken.Claims.(jwt.MapClaims)
-	if claims == nil {
-		return "", errors.New("could not read any token claims")
-	}
-	expiresOn := time.Unix(claims["exp"].(int64), 0).Format(time.RFC850)
-	tokenId := claims["id"].(string)
-	return fmt.Sprintf("%s\n%s\n%s", expiresOn, tokenId, tokenString), err
+	expiresOn := time.Unix(token.ExpiresOn, 0).Format(time.RFC850)
+	tokenId := token.UUID.String()
+	return fmt.Sprintf("%s\n%s\n%s", expiresOn, tokenId, token.TokenString), err
 }
 
 func getEnvInt(varName string, defaultVal int) int {

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -393,7 +393,7 @@ func (s *MainTestSuite) TestArchiveExpiring() {
 
 	// save a job to our db
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Completed",
@@ -454,7 +454,7 @@ func (s *MainTestSuite) TestArchiveExpiringWithThreshold() {
 
 	// save a job to our db
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Completed",
@@ -518,7 +518,7 @@ func setupArchivedJob(s *MainTestSuite, email string, modified time.Time) int {
 
 	// save a job to our db
 	j := models.Job{
-		AcoID:      uuid.Parse(acoUUID),
+		ACOID:      uuid.Parse(acoUUID),
 		UserID:     uuid.Parse(userUUID),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Archived",

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -33,8 +33,8 @@ func InitializeGormModels() *gorm.DB {
 
 type Job struct {
 	gorm.Model
-	Aco        ACO       `gorm:"foreignkey:AcoID;association_foreignkey:UUID"` // aco
-	AcoID      uuid.UUID `gorm:"primary_key; type:char(36)" json:"aco_id"`
+	ACO        ACO       `gorm:"foreignkey:ACOID;association_foreignkey:UUID"` // aco
+	ACOID      uuid.UUID `gorm:"primary_key; type:char(36)" json:"aco_id"`
 	User       User      `gorm:"foreignkey:UserID;association_foreignkey:UUID"` // user
 	UserID     uuid.UUID `gorm:"type:char(36)"`
 	RequestURL string    `json:"request_url"` // request_url
@@ -98,8 +98,8 @@ type User struct {
 	UUID  uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
 	Name  string    `json:"name"`                                   // name
 	Email string    `json:"email"`                                  // email
-	Aco   ACO       `gorm:"foreignkey:AcoID;association_foreignkey:UUID"`
-	AcoID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` // aco_id
+	ACO   ACO       `gorm:"foreignkey:ACOID;association_foreignkey:UUID"`
+	ACOID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` // aco_id
 }
 
 func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
@@ -113,7 +113,7 @@ func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
 	}
 	// check for duplicate email addresses and only make one if it isn't found
 	if db.First(&user, "email = ?", email).RecordNotFound() {
-		user = User{UUID: uuid.NewRandom(), Name: name, Email: email, AcoID: aco.UUID}
+		user = User{UUID: uuid.NewRandom(), Name: name, Email: email, ACOID: aco.UUID}
 		db.Create(&user)
 		return user, nil
 	} else {
@@ -143,7 +143,7 @@ func CreateAlphaUser(db *gorm.DB, aco ACO) (User, error) {
 	db.Table("users").Count(&count)
 	user := User{UUID: uuid.NewRandom(),
 		Name:  fmt.Sprintf("Alpha User%d", count),
-		Email: fmt.Sprintf("alpha.user.%d@nosuchdomain.com", count), AcoID: aco.UUID}
+		Email: fmt.Sprintf("alpha.user.%d@nosuchdomain.com", count), ACOID: aco.UUID}
 	db.Create(&user)
 
 	return user, db.Error

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -33,7 +33,7 @@ var (
 
 type jobEnqueueArgs struct {
 	ID             int
-	AcoID          string
+	ACOID          string
 	UserID         string
 	BeneficiaryIDs []string
 	ResourceType   string
@@ -100,7 +100,7 @@ func processJob(j *que.Job) error {
 		}
 	}
 
-	err = writeBBDataToFile(bb, jobArgs.AcoID, jobArgs.BeneficiaryIDs, jobID, jobArgs.ResourceType)
+	err = writeBBDataToFile(bb, jobArgs.ACOID, jobArgs.BeneficiaryIDs, jobID, jobArgs.ResourceType)
 
 	if err != nil {
 		exportJob.Status = "Failed"
@@ -131,11 +131,11 @@ func processJob(j *que.Job) error {
 				}
 			} else {
 				// this will be the only code path after ATO
-				publicKey := exportJob.Aco.GetPublicKey()
+				publicKey := exportJob.ACO.GetPublicKey()
 				if publicKey == nil {
 					fmt.Println("NO KEY EXISTS  THIS IS BAD")
 				}
-				err := encryption.EncryptAndMove(staging, data, f.Name(), exportJob.Aco.GetPublicKey(), exportJob.ID)
+				err := encryption.EncryptAndMove(staging, data, f.Name(), exportJob.ACO.GetPublicKey(), exportJob.ID)
 				if err != nil {
 					log.Error(err)
 					return err

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -169,7 +169,7 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 	defer database.Close(db)
 
 	j := models.Job{
-		AcoID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
 		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
 		Status:     "Pending",
@@ -178,7 +178,7 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 
 	jobArgs := jobEnqueueArgs{
 		ID:             int(j.ID),
-		AcoID:          j.AcoID.String(),
+		ACOID:          j.ACOID.String(),
 		UserID:         j.UserID.String(),
 		BeneficiaryIDs: []string{"10000", "11000"},
 		ResourceType:   "ExplanationOfBenefit",


### PR DESCRIPTION
### Fixes [BCDA-763](https://jira.cms.gov/browse/BCDA-763)
Tokens would be easier for us to work with if we had more fields than those provided by `jwt.Token`. NB: Work related to this is being done in https://jira.cms.gov/browse/BCDA-764, so the move to using `auth.Token` is ongoing, particularly as it relates to middlewares.

### Proposed changes:
Expand our own `auth.Token` model and replace current usage of `jwt.Token` where appropriate.

### Change Details
* Adds `IssuedAt` and `ExpiresOn` fields to `auth.Token` so we can recreate JWT strings
* Changes `RequestAccessToken()` to return `auth.Token`
* Creates new `GenerateTokenString()` in auth/models.go that accepts additional fields
* `RequestAccessToken()` now uses new `GenerateTokenString()`
* Removes `auth.Token` model `BeforeSave()` because we will no longer store the value and add new `AfterFind()` for recreating the string after retrieval of token fields from database
* Renames some functions and fields for clarity and convention (mainly `AcoID` to `ACOID`)

### Security Implications
This changes how the token information is stored. We have all the claims needed to recreate the token, but no longer store the value (hashed or otherwise).

### Acceptance Validation
Tests continue to pass.

### Feedback Requested
Any
