### PR TITLE
BCDA-738: Review and add detail to job status responses in Swagger

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -68,9 +68,9 @@ import (
 		api_key
 
 	Responses:
-		202:BulkRequestResponse
-		400:ErrorModel
-		500:FHIRResponse
+		202: BulkRequestResponse
+		400: badRequestResponse
+		500: errorResponse
 */
 func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("ExplanationOfBenefit", w, r)
@@ -90,9 +90,9 @@ func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 		api_key
 
 	Responses:
-		202:BulkRequestResponse
-		400:ErrorModel
-		500:FHIRResponse
+		202: BulkRequestResponse
+		400: badRequestResponse
+		500: errorResponse
 */
 func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 	bulkRequest("Patient", w, r)
@@ -228,11 +228,11 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		api_key:
 
 	Responses:
-		202:JobStatus
-		200:completedJobResponse
-		400:FHIRResponse
-        404:FHIRResponse
-		500:FHIRResponse
+		202: jobStatusResponse
+		200: completedJobResponse
+		400: badRequestResponse
+        404: notFoundResponse
+		500: errorResponse
 */
 func jobStatus(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "jobId")
@@ -350,10 +350,10 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 		api_key:
 
 	Responses:
-		200:ExplanationOfBenefitNDJSON
-		400:ErrorModel
-        404:ErrorModel
-		500:FHIRResponse
+		200: ExplanationOfBenefitNDJSON
+		400: badRequestResponse
+        404: notFoundResponse
+		500: errorResponse
 */
 func serveData(w http.ResponseWriter, r *http.Request) {
 	dataDir := os.Getenv("FHIR_PAYLOAD_DIR")

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -229,9 +229,9 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 
 	Responses:
 		202:JobStatus
-		200:bulkResponseBody
-		400:ErrorModel
-        404:ErrorModel
+		200:completedJobResponse
+		400:FHIRResponse
+        404:FHIRResponse
 		500:FHIRResponse
 */
 func jobStatus(w http.ResponseWriter, r *http.Request) {
@@ -503,4 +503,36 @@ func readTokenClaims(r *http.Request) (jwt.MapClaims, error) {
 
 func GetJobTimeout() time.Duration {
 	return time.Hour * time.Duration(getEnvInt("ARCHIVE_THRESHOLD_HR", 24))
+}
+
+// swagger:model fileItem
+type fileItem struct {
+	// FHIR resource type of file contents
+	Type string `json:"type"`
+	// URL of the file
+	URL string `json:"url"`
+}
+
+/*
+Data export job has completed successfully. The response body will contain a JSON object providing metadata about the transaction.
+swagger:response completedJobResponse
+*/
+type completedJobResponse struct {
+	// in: body
+	Body bulkResponseBody
+}
+
+type bulkResponseBody struct {
+	// Server time when the query was run
+	TransactionTime time.Time `json:"transactionTime"`
+	// URL of the bulk data export request
+	RequestURL string `json:"request"`
+	// Indicates whether an access token is required to download generated data files
+	RequiresAccessToken bool `json:"requiresAccessToken"`
+	// Information about generated data files, including URLs for downloading
+	Files []fileItem `json:"output"`
+	// Information about error files, including URLs for downloading
+	Errors []fileItem        `json:"error"`
+	KeyMap map[string]string `json:"KeyMap"`
+	JobID  uint
 }

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -531,7 +531,8 @@ type fileItem struct {
 Data export job has completed successfully. The response body will contain a JSON object providing metadata about the transaction.
 swagger:response completedJobResponse
 */
-type completedJobResponse struct {
+//nolint
+type CompletedJobResponse struct {
 	// in: body
 	Body bulkResponseBody
 }

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -231,7 +231,8 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		202: jobStatusResponse
 		200: completedJobResponse
 		400: badRequestResponse
-        404: notFoundResponse
+		404: notFoundResponse
+		410: goneResponse
 		500: errorResponse
 */
 func jobStatus(w http.ResponseWriter, r *http.Request) {

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -44,35 +44,6 @@ type jobEnqueueArgs struct {
 	Encrypt bool
 }
 
-// swagger:model fileItem
-type fileItem struct {
-	// KNOLL the type of File returned
-	Type string `json:"type"`
-	// The URL of the file
-	URL string `json:"url"`
-}
-
-/*
-Bulk Response Body for a completed Bulk Status Request
-swagger:response bulkResponseBody
-*/
-type bulkResponseBody struct {
-	// The Time of the Transaction Request
-	TransactionTime time.Time `json:"transactionTime"`
-	// The URL of the Response
-	RequestURL string `json:"request"`
-	// Is a token required for this response
-	RequiresAccessToken bool `json:"requiresAccessToken"`
-	// Files included in the payload
-	// collection format: csv
-	Files []fileItem `json:"output"`
-	// Errors encountered during processing
-	// collection format: csv
-	Errors []fileItem        `json:"error"`
-	KeyMap map[string]string `json:"KeyMap"`
-	JobID  uint
-}
-
 func init() {
 	log.SetFormatter(&log.JSONFormatter{})
 	filePath := os.Getenv("BCDA_ERROR_LOG")

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -11,49 +11,57 @@ type BulkRequestResponse struct {
 	ContentLocation string `json:"Content-Location"`
 }
 
-// The action returned an error, warning, or information. This response will be a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
-// swagger:response FHIRResponse
-type OperationOutcome struct {
-	// A Valid FHIR Response
-	// in:body
-	FHIRResponse struct {
-		// OperationOutcome
-		ResourceType string
-		// A single issue associated with the action
+type operationOutcomeResponse struct {
+	// OperationOutcome
+	ResourceType string
+	// A single issue associated with the action
 
-		Issue struct {
-			// Severity of the outcome: fatal | error | warning | information
-			// Required: true
-			Severity string
-			//Error or warning code
-			// Required: true
-			Code string
-			// Additional details about the error
-			// Required: true
-			Details string
-			// Additional diagnostic information about the issue
-			// Required: true
-			Diagnostics string
-			// Path of element(s) related to issue
-			// Required: true
-			Location string
-			// FHIRPath of element(s) related to issue
-			// Required: true
-			Expression string
-		}
+	Issue struct {
+		// Severity of the outcome: fatal | error | warning | information
+		// Required: true
+		Severity string
+		//Error or warning code
+		// Required: true
+		Code string
+		// Additional details about the error
+		// Required: true
+		Details string
+		// Additional diagnostic information about the issue
+		// Required: true
+		Diagnostics string
+		// Path of element(s) related to issue
+		// Required: true
+		Location string
+		// FHIRPath of element(s) related to issue
+		// Required: true
+		Expression string
 	}
 }
 
-// A generic HTTP error Model.  Should only be used for well documented error types such as 404
-// swagger:response ErrorModel
-type ErrorModel struct {
-	// Message contains additional information about this error
-	Message string
+// The requested path was not found. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html
+// swagger:response notFoundResponse
+type notFoundResponse struct {
+	// in: body
+	Body operationOutcomeResponse
+}
+
+// There was a problem with the request. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
+// swagger:response badRequestResponse
+type badRequestResponse struct {
+	// in: body
+	Body operationOutcomeResponse
+}
+
+// An error occurred. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
+// swagger:response errorResponse
+type errorResponse struct {
+	// in: body
+	Body operationOutcomeResponse
 }
 
 // Data export job is in progress.
-// swagger:response JobStatus
-type JobStatus struct {
+// swagger:response jobStatusResponse
+type jobStatusResponse struct {
 	// The status of the job progress
 	XProgress string `json:"X-Progress"`
 }

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -11,7 +11,7 @@ type BulkRequestResponse struct {
 	ContentLocation string `json:"Content-Location"`
 }
 
-type operationOutcomeResponse struct {
+type OperationOutcomeResponse struct {
 	// OperationOutcome
 	ResourceType string
 	// A single issue associated with the action
@@ -40,35 +40,35 @@ type operationOutcomeResponse struct {
 
 // The requested path was not found. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html
 // swagger:response notFoundResponse
-type notFoundResponse struct {
+type NotFoundResponse struct {
 	// in: body
-	Body operationOutcomeResponse
+	Body OperationOutcomeResponse
 }
 
 // There was a problem with the request. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
 // swagger:response badRequestResponse
-type badRequestResponse struct {
+type BadRequestResponse struct {
 	// in: body
-	Body operationOutcomeResponse
+	Body OperationOutcomeResponse
 }
 
 // The requested resource is no longer available. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html
 // swagger:response goneResponse
-type goneResponse struct {
+type GoneResponse struct {
 	// in: body
-	Body operationOutcomeResponse
+	Body OperationOutcomeResponse
 }
 
 // An error occurred. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
 // swagger:response errorResponse
-type errorResponse struct {
+type ErrorResponse struct {
 	// in: body
-	Body operationOutcomeResponse
+	Body OperationOutcomeResponse
 }
 
 // Data export job is in progress.
 // swagger:response jobStatusResponse
-type jobStatusResponse struct {
+type JobStatusResponse struct {
 	// The status of the job progress
 	XProgress string `json:"X-Progress"`
 }

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -11,7 +11,7 @@ type BulkRequestResponse struct {
 	ContentLocation string `json:"Content-Location"`
 }
 
-// Operation Outcome follows HL7 FHIR Spec https://www.hl7.org/fhir/operationoutcome.html
+// The action returned an error, warning, or information. This response will be a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
 // swagger:response FHIRResponse
 type OperationOutcome struct {
 	// A Valid FHIR Response
@@ -51,7 +51,7 @@ type ErrorModel struct {
 	Message string
 }
 
-// JobStatus defines the status of a specific Job defined by the ID
+// Data export job is in progress.
 // swagger:response JobStatus
 type JobStatus struct {
 	// The status of the job progress
@@ -103,8 +103,7 @@ type FileParam struct {
 	Filename string `json:"filename"`
 }
 
-// swagger:parameters bulkPatientRequest
-// swagger:parameters bulkEOBRequest
+// swagger:parameters bulkPatientRequest bulkEOBRequest
 type BulkRequestHeaders struct {
 	// required: true
 	// in: header

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -52,6 +52,13 @@ type badRequestResponse struct {
 	Body operationOutcomeResponse
 }
 
+// The requested resource is no longer available. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html
+// swagger:response goneResponse
+type goneResponse struct {
+	// in: body
+	Body operationOutcomeResponse
+}
+
 // An error occurred. The body will contain a FHIR OperationOutcome resource in JSON format. https://www.hl7.org/fhir/operationoutcome.html Please refer to the body of the response for details.
 // swagger:response errorResponse
 type errorResponse struct {


### PR DESCRIPTION
### Fixes [BCDA-738](https://jira.cms.gov/browse/BCDA-738)
We'd like to make it clearer to users what each response to the job status endpoint means.

### Proposed changes:
Add more detail to job status response descriptions in the Swagger documentation.

### Change Details
* Adds some new Swagger response models for specific HTTP response codes that share the OperationOutcome model for body content
* Uses new models in job status endpoint and others where applicable

### Security Implications
None

### Acceptance Validation
Changes can be reviewed in the Swagger UI at /api/v1/swagger

### Feedback Requested
Any
