### PR TITLE
BCDA-542: Add a simple http router that redirects http requests to https

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -100,6 +100,15 @@ func setUpApp() *cli.App {
 					autoMigrate()
 				}
 
+				// Accepts and redirects HTTP requests to HTTPS
+				srv := &http.Server{
+					Handler:      NewHTTPRouter(),
+					Addr:         ":3001",
+					ReadTimeout:  5 * time.Second,
+					WriteTimeout: 5 * time.Second,
+				}
+				go func() { log.Fatal(srv.ListenAndServe()) }()
+
 				api := &http.Server{
 					Handler:      NewAPIRouter(),
 					ReadTimeout:  time.Duration(getEnvInt("API_READ_TIMEOUT", 10)) * time.Second,

--- a/bcda/middleware.go
+++ b/bcda/middleware.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
+	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"net/http"
 )
 
@@ -43,6 +44,15 @@ func ValidateBulkRequestHeaders(next http.Handler) http.Handler {
 func ConnectionClose(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Connection", "close")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func HSTSHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if servicemux.IsHTTPS(r) {
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -56,8 +56,7 @@ func NewDataRouter() http.Handler {
 func NewHTTPRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(ConnectionClose)
-	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	r.With(logging.NewStructuredLogger(), ConnectionClose).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 		url := "https://" + req.Host + req.URL.String()
 		http.Redirect(w, req, url, http.StatusMovedPermanently)

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -53,6 +53,18 @@ func NewDataRouter() http.Handler {
 	return r
 }
 
+func NewHTTPRouter() http.Handler {
+	r := chi.NewRouter()
+	m := monitoring.GetMonitor()
+	r.Use(ConnectionClose)
+	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+		url := "https://" + req.Host + req.URL.String()
+		http.Redirect(w, req, url, http.StatusMovedPermanently)
+	})))
+	return r
+}
+
 // FileServer conveniently sets up a http.FileServer handler to serve
 // static files from a http.FileSystem.
 // stolen from https://github.com/go-chi/chi/blob/master/_examples/fileserver/main.go

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -87,6 +87,8 @@ func (suite *RouterTestSuite) TestHTTPServerRedirect() {
 	res, err := client.Get(suite.httpServer.URL + "/")
 	assert.Nil(suite.T(), err, "redirect GET http to https")
 	assert.Equal(suite.T(), 301, res.StatusCode, "http to https redirect return correct status code")
+	assert.NotEmpty(suite.T(), res.Header.Get("Strict-Transport-Security"), "http to https redirect sets HSTS header")
+	assert.Equal(suite.T(), "close", res.Header.Get("Connection"), "http to https redirect sets 'connection: close' header")
 	assert.Contains(suite.T(), res.Header.Get("Location"), "https://", "location response header contains 'https://'")
 
 	// Only respond to GET requests

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -85,14 +85,14 @@ func (suite *RouterTestSuite) TestHTTPServerRedirect() {
 
 	// Redirect GET http requests to https
 	res, err := client.Get(suite.httpServer.URL + "/")
-	assert.Nil(suite.T(), err, fmt.Sprintf("redirect GET http to https"))
+	assert.Nil(suite.T(), err, "redirect GET http to https")
 	assert.Equal(suite.T(), 301, res.StatusCode, "http to https redirect return correct status code")
 	assert.Contains(suite.T(), res.Header.Get("Location"), "https://", "location response header contains 'https://'")
 
 	// Only respond to GET requests
 	r := strings.NewReader("")
 	res, err = client.Post(suite.httpServer.URL+"/", "application/octet-stream", r)
-	assert.Nil(suite.T(), err, fmt.Sprintf("redirect POST http to https"))
+	assert.Nil(suite.T(), err, "redirect POST http to https")
 	assert.Equal(suite.T(), 405, res.StatusCode, "http to https redirect rejects POST requests")
 }
 

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -18,7 +18,6 @@ type RouterTestSuite struct {
 	suite.Suite
 	apiServer  *httptest.Server
 	dataServer *httptest.Server
-	httpServer *httptest.Server
 	rr         *httptest.ResponseRecorder
 }
 
@@ -26,14 +25,12 @@ func (suite *RouterTestSuite) SetupTest() {
 	os.Setenv("DEBUG", "true")
 	suite.apiServer = httptest.NewServer(NewAPIRouter())
 	suite.dataServer = httptest.NewServer(NewDataRouter())
-	suite.httpServer = httptest.NewServer(NewHTTPRouter())
 	suite.rr = httptest.NewRecorder()
 }
 
 func (suite *RouterTestSuite) TearDownTest() {
 	suite.apiServer.Close()
 	suite.dataServer.Close()
-	suite.httpServer.Close()
 }
 
 func (suite *RouterTestSuite) GetStringBody(url string) (string, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
      - .:/go/src/github.com/CMSgov/bcda-app
     ports:
       - "3000:3000"
+      - "3001:3001"
     depends_on:
       - queue
   worker:


### PR DESCRIPTION
### Fixes [BCDA-542](https://jira.cms.gov/browse/BCDA-542)

Adds an http server and router to enable redirection of all `http` requests to `https`.

### Proposed changes:

- Adds a simple `http.Server` definition, uses `NewHTTPRouter()` to define the server's handler.
- The `http.Server` is configured to listen on port `3001`.
- `NewHTTPRouter()` returns an http handler configured with:
    - New Relic APM transaction monitoring
    - Standard BCDA structured logging for http requests
    - BCDA's `ConnectionClose` middleware
    - Responds to `/*` requests
    - Sets `Strict-Transport-Security` header to instruct browsers to use `https` only going forward
    - Uses `301` status to indicate permanent redirect

### Change Details

The only way for this to be useful in any of our deployment environments is for the envs ELB to be configured to forward port `80` requests to the `http.Server` on port `3001`.


### Security Implications

Accepting `http` requests can open MITM attack vectors. For instance, if an API client first makes a request to BCDA using `http`, any request parameters including the access token used would be susceptible to interception. To mitigate this threat, we should not configure our ELBs to forward `http` requests to this redirector in environments where sensitive data resides (think: `prod`).

### Acceptance Validation

To test locally, run `docker-compose up` and make a request to `http://localhost:3001/`. The response should be a `301` with `Location` header that matches the original request URL completely except for the protocol, which should be changed to `https`. The response should also contain a `Strict-Transport-Security` header and `Connection: close` header. See:

![image](https://user-images.githubusercontent.com/72608/52057689-4c927980-252b-11e9-9095-56bc557ebf93.png)

### Feedback Requested

- Review and recommendations for testing strategy