### PR TITLE
Skeleton implementation of Okta plugin

### DIFF
--- a/bcda/auth/plugins/alpha.go
+++ b/bcda/auth/plugins/alpha.go
@@ -1,4 +1,4 @@
-package plugin
+package plugins
 
 import (
 	"encoding/json"

--- a/bcda/auth/plugins/alpha_test.go
+++ b/bcda/auth/plugins/alpha_test.go
@@ -1,4 +1,4 @@
-package plugin
+package plugins
 
 import (
 	"encoding/json"

--- a/bcda/auth/plugins/okta.go
+++ b/bcda/auth/plugins/okta.go
@@ -1,0 +1,46 @@
+package plugins
+
+import (
+	"errors"
+	"github.com/dgrijalva/jwt-go"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
+)
+
+type OktaAuthPlugin struct{}
+
+func (o *OktaAuthPlugin) RegisterClient(params []byte) ([]byte, error) {
+	return nil, errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
+	return nil, errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) DeleteClient(params []byte) error {
+	return errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, error) {
+	return nil, errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) RevokeClientCredentials(params []byte) error {
+	return errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) RequestAccessToken(params []byte) (auth.Token, error) {
+	return auth.Token{}, errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) RevokeAccessToken(tokenString string) error {
+	return errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) ValidateJWT(tokenString string) error {
+	return errors.New("not yet implemented")
+}
+
+func (o *OktaAuthPlugin) DecodeJWT(tokenString string) (jwt.Token, error) {
+	return jwt.Token{}, errors.New("not yet implemented")
+}

--- a/bcda/auth/plugins/okta_test.go
+++ b/bcda/auth/plugins/okta_test.go
@@ -1,0 +1,73 @@
+package plugins
+
+import (
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"testing"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type OktaAuthPluginTestSuite struct {
+	suite.Suite
+	o *OktaAuthPlugin
+}
+
+func (s *OktaAuthPluginTestSuite) SetupTest() {
+	s.o = new(OktaAuthPlugin)
+}
+
+func (s *OktaAuthPluginTestSuite) TestRegisterClient() {
+	c, err := s.o.RegisterClient([]byte("{}"))
+	assert.Nil(s.T(), c)
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestUpdateClient() {
+	c, err := s.o.UpdateClient([]byte("{}"))
+	assert.Nil(s.T(), c)
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestDeleteClient() {
+	err := s.o.DeleteClient([]byte("{}"))
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestGenerateClientCredentials() {
+	r, err := s.o.GenerateClientCredentials([]byte("{}"))
+	assert.Nil(s.T(), r)
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestRevokeClientCredentials() {
+	err := s.o.RevokeClientCredentials([]byte("{}"))
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestRequestAccessToken() {
+	t, err := s.o.RequestAccessToken([]byte("{}"))
+	assert.IsType(s.T(), auth.Token{}, t)
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestRevokeAccessToken() {
+	err := s.o.RevokeAccessToken("")
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestValidateJWT() {
+	err := s.o.ValidateJWT("")
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func (s *OktaAuthPluginTestSuite) TestDecodeJWT() {
+	t, err := s.o.DecodeJWT("")
+	assert.IsType(s.T(), jwt.Token{}, t)
+	assert.Equal(s.T(), "not yet implemented", err.Error())
+}
+
+func TestOktaAuthPluginSuite(t *testing.T) {
+	suite.Run(t, new(OktaAuthPluginTestSuite))
+}

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -4,16 +4,30 @@ import "github.com/dgrijalva/jwt-go"
 
 // Provider is an interface for operations performed through an authentication provider.
 type Provider interface {
+	// Ask the auth Provider to register a software client for the ACO identified by localID.
 	RegisterClient(params []byte) ([]byte, error)
+
+	// Update data associated with the registered software client identified by clientID
 	UpdateClient(params []byte) ([]byte, error)
+
+	// Delete the registered software client identified by clientID, revoking an active tokens
 	DeleteClient(params []byte) error
 
+	// Generate new or replace existing Credentials for the given clientID
 	GenerateClientCredentials(params []byte) ([]byte, error)
+
+	// Revoke any existing Credentials for the given clientID
 	RevokeClientCredentials(params []byte) error
 
+	// Request an access token with a specific time-to-live for the given clientID
 	RequestAccessToken(params []byte) (Token, error)
+
+	// Revoke a specific access token identified in a base64 encoded token string
 	RevokeAccessToken(tokenString string) error
 
+	// Assert that a base64 encoded token string is valid for accessing the BCDA API
 	ValidateJWT(tokenString string) error
+
+	// Decode a base64 encoded token string
 	DecodeJWT(tokenString string) (jwt.Token, error)
 }

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/auth/plugin"
+	"github.com/CMSgov/bcda-app/bcda/auth/plugins"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/monitoring"
@@ -93,9 +93,9 @@ func GetAuthProvider() auth.Provider {
 	v := os.Getenv("BCDA_AUTH_PROVIDER")
 	switch v {
 	case "Alpha":
-		return new(plugin.AlphaAuthPlugin) // could fallthrough here, but prefer to be explicit
+		return new(plugins.AlphaAuthPlugin) // could fallthrough here, but prefer to be explicit
 	default:
-		return new(plugin.AlphaAuthPlugin)
+		return new(plugins.AlphaAuthPlugin)
 	}
 }
 
@@ -456,7 +456,7 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("could not register client for %s (%s) because %s", aco.UUID.String(), aco.Name, err.Error())
 	}
-	aco.ClientID, err = plugin.GetParamString(result, "clientID")
+	aco.ClientID, err = plugins.GetParamString(result, "clientID")
 	if err != nil {
 		return "", fmt.Errorf("could not register client for %s (%s) because %s", aco.UUID.String(), aco.Name, err.Error())
 	}


### PR DESCRIPTION
### Completes [BCDA-809](https://jira.cms.gov/browse/BCDA-809)
Adds a skeleton implementation of the Okta auth plugin. All methods currently return a 'not yet implemented' error.

### Proposed changes:
Okta plugin with all provider methods implemented.

### Security Implications
None. All methods do is return a 'not yet implemented' error.

### Acceptance Validation
Tests included that prove all methods return an error.
