### PR TITLE
BCDA-878: Make sure links to external sites open in a new page/tab

### DIFF
--- a/bcda-site-static/_includes/footer.html
+++ b/bcda-site-static/_includes/footer.html
@@ -10,23 +10,23 @@
       <div class="ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--3 ds-u-margin-bottom--2">
         <h6 class="ds-h4">CMS &amp; HHS Websites</h6>
         <ul class="ds-c-list ds-c-list--bare ds-u-font-size--small">
-          <li><a href="https://www.cms.gov/">CMS.gov</a></li>
-          <li><a href="https://www.medicare.gov/">Medicare.gov</a></li>
-          <li><a href="https://www.mymedicare.gov/">MyMedicare.gov</a></li>
-          <li><a href="https://www.medicaid.gov/">Medicaid.gov</a></li>
-          <li><a href="https://www.healthcare.gov/">Healthcare.gov</a></li>
-          <li><a href="https://www.hhs.gov/">HHS.gov</a></li>
+          <li><a target="_blank" href="https://www.cms.gov/">CMS.gov</a></li>
+          <li><a target="_blank" href="https://www.medicare.gov/">Medicare.gov</a></li>
+          <li><a target="_blank" href="https://www.mymedicare.gov/">MyMedicare.gov</a></li>
+          <li><a target="_blank" href="https://www.medicaid.gov/">Medicaid.gov</a></li>
+          <li><a target="_blank" href="https://www.healthcare.gov/">Healthcare.gov</a></li>
+          <li><a target="_blank" href="https://www.hhs.gov/">HHS.gov</a></li>
         </ul>
       </div>
       <div class="ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--3 ds-u-margin-bottom--2">
         <h6 class="ds-h4">Additional resources</h6>
         <ul class="ds-c-list ds-c-list--bare ds-u-font-size--small">
-          <li><a href="https://standards.usa.gov/">U.S. Web Design Standards</a></li>
-          <li><a href="https://www.foia.gov/">Freedom of Information Act</a></li>
-          <li><a href="https://oig.hhs.gov/">Inspector General</a></li>
-          <li><a href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/NoFearAct.html">No Fear Act</a></li>
-          <li><a href="https://www.medicare.gov/about-us/plain-writing/plain-writing.html">Plain Writing</a></li>
-          <li><a href="https://www.usa.gov/">USA.gov</a></li>
+          <li><a target="_blank" href="https://standards.usa.gov/">U.S. Web Design Standards</a></li>
+          <li><a target="_blank" href="https://www.foia.gov/">Freedom of Information Act</a></li>
+          <li><a target="_blank" href="https://oig.hhs.gov/">Inspector General</a></li>
+          <li><a target="_blank" href="https://www.cms.gov/About-CMS/Agency-Information/Aboutwebsite/NoFearAct.html">No Fear Act</a></li>
+          <li><a target="_blank" href="https://www.medicare.gov/about-us/plain-writing/plain-writing.html">Plain Writing</a></li>
+          <li><a target="_blank" href="https://www.usa.gov/">USA.gov</a></li>
         </ul>
       </div>
     </div>

--- a/bcda-site-static/index.md
+++ b/bcda-site-static/index.md
@@ -46,7 +46,7 @@ ctas:
 
 * {:.bcda_callout .no_list #how-can-i-learn-more} ![Google Groups Logo](assets/img/google_logo.png){:#google_logo} **How can I learn more about BCDA?** 
 
-   * {:.no_list} The BCDA is still in development. Please join the [Google Group](https://groups.google.com/forum/#!forum/bc-api) to receive updates.
+* {:.no_list} The BCDA is still in development. Please join the [Google Group](https://groups.google.com/forum/#!forum/bc-api){:target="_blank"} to receive updates.
 
    * {:.no_list} The BCDA Google Group is the best place to get your questions answered by the BCDA team. In this community you can sign up for feedback session opportunities, get answers to your questions, share your feedback and ideas, and get updates on the project.
 
@@ -72,5 +72,5 @@ ctas:
 
    How is BCDA different from Blue Button 2.0? 
 
-   * Blue Button 2.0 provides FHIR-formatted data for one individual Medicare beneficiary at a time, to registered applications with beneficiary authorization. See [https://bluebutton.cms.gov/](https://bluebutton.cms.gov/).
+   * Blue Button 2.0 provides FHIR-formatted data for one individual Medicare beneficiary at a time, to registered applications with beneficiary authorization. See [https://bluebutton.cms.gov/](https://bluebutton.cms.gov/){:target="_blank"}.
    * BCDA provides FHIR-formatted bulk data files to an ACO for all of the beneficiaries eligible to a given Shared Savings Program ACO. BCDA does not require individual beneficiary authorization. 


### PR DESCRIPTION
### Relates to [BCDA-878](https://jira.cms.gov/browse/BCDA-878)

Changes links that lead to external sites to use `target="_blank"`, ensuring they open in a new browser page/tab.