### PR TITLE
BCDA-812: implement registerClient() method for Okta auth plugin

### DIFF
--- a/bcda/auth/moktaclient.go
+++ b/bcda/auth/moktaclient.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+// adds a client application, returning the client_id and secret_key
+func addClientApplication(localId string) (string, string, error) {
+	id, err := someRandomBytes(16)
+	if err != nil {
+		return "", "", nil
+	}
+	key, err := someRandomBytes(32)
+	if err != nil {
+		return "", "", nil
+	}
+
+	return base64.URLEncoding.EncodeToString(id), base64.URLEncoding.EncodeToString(key), err
+}
+
+func someRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -3,43 +3,52 @@ package auth
 import (
 	"errors"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 )
 
 type OktaAuthPlugin struct{}
 
-func (o *OktaAuthPlugin) RegisterClient(params []byte) ([]byte, error) {
+func (o OktaAuthPlugin) RegisterClient(localID string) (Credentials, error) {
+	if localID == "" {
+		return Credentials{}, errors.New("you must provide a localID")
+	}
+
+	// using the mocktaclient here for now
+	id, key, err := addClientApplication(localID)
+	return Credentials{
+		ClientID:     id,
+		ClientSecret: key,
+	}, err
+}
+
+func (o OktaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
 	return nil, errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
-	return nil, errors.New("not yet implemented")
-}
-
-func (o *OktaAuthPlugin) DeleteClient(params []byte) error {
+func (o OktaAuthPlugin) DeleteClient(params []byte) error {
 	return errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, error) {
+func (o OktaAuthPlugin) GenerateClientCredentials(params []byte) ([]byte, error) {
 	return nil, errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) RevokeClientCredentials(params []byte) error {
+func (o OktaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	return errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) RequestAccessToken(params []byte) (Token, error) {
+func (o OktaAuthPlugin) RequestAccessToken(params []byte) (Token, error) {
 	return Token{}, errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) RevokeAccessToken(tokenString string) error {
+func (o OktaAuthPlugin) RevokeAccessToken(tokenString string) error {
 	return errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) ValidateJWT(tokenString string) error {
+func (o OktaAuthPlugin) ValidateJWT(tokenString string) error {
 	return errors.New("not yet implemented")
 }
 
-func (o *OktaAuthPlugin) DecodeJWT(tokenString string) (jwt.Token, error) {
+func (o OktaAuthPlugin) DecodeJWT(tokenString string) (jwt.Token, error) {
 	return jwt.Token{}, errors.New("not yet implemented")
 }

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -1,26 +1,32 @@
-package auth
+package auth_test
 
 import (
+	"regexp"
 	"testing"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
 )
+
+const KnownFixtureACO = "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 
 type OktaAuthPluginTestSuite struct {
 	suite.Suite
-	o *OktaAuthPlugin
+	o auth.OktaAuthPlugin
 }
 
 func (s *OktaAuthPluginTestSuite) SetupTest() {
-	s.o = new(OktaAuthPlugin)
+	s.o = auth.OktaAuthPlugin{}
 }
 
 func (s *OktaAuthPluginTestSuite) TestRegisterClient() {
-	c, err := s.o.RegisterClient([]byte("{}"))
-	assert.Nil(s.T(), c)
-	assert.Equal(s.T(), "not yet implemented", err.Error())
+	c, err := s.o.RegisterClient(KnownFixtureACO)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), c)
+	assert.Regexp(s.T(), regexp.MustCompile("[!-~]"), c.ClientID)
 }
 
 func (s *OktaAuthPluginTestSuite) TestUpdateClient() {
@@ -47,7 +53,7 @@ func (s *OktaAuthPluginTestSuite) TestRevokeClientCredentials() {
 
 func (s *OktaAuthPluginTestSuite) TestRequestAccessToken() {
 	t, err := s.o.RequestAccessToken([]byte("{}"))
-	assert.IsType(s.T(), Token{}, t)
+	assert.IsType(s.T(), auth.Token{}, t)
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -16,6 +16,7 @@ const (
 var providerName = Alpha
 
 func init () {
+	log.SetFormatter(&log.JSONFormatter{})
 	SetProvider(strings.ToLower(os.Getenv(`BCDA_AUTH_PROVIDER`)))
 }
 

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -56,6 +57,7 @@ func init() {
 		log.Info("Failed to open error log file; using default stderr")
 	}
 	monitoring.GetMonitor()
+	log.Info(fmt.Sprintf(`Auth is made possible by %T`, reflect.TypeOf(auth.GetProvider())))
 }
 
 func main() {
@@ -388,9 +390,7 @@ func revokeAccessToken(accessToken string) error {
 		return errors.New("Access token (--access-token) must be provided")
 	}
 
-	authProvider := auth.GetProvider()
-
-	return authProvider.RevokeAccessToken(accessToken)
+	return auth.GetProvider().RevokeAccessToken(accessToken)
 }
 
 func validateAlphaTokenInputs(ttl, acoSize string) (int, error) {
@@ -417,18 +417,13 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 		return
 	}
 
-	authProvider := auth.GetProvider()
+	// authProvider := auth.GetProvider()
 
-	params := fmt.Sprintf(`{"clientID" : "%s"}`, aco.UUID.String())
-	result, err := authProvider.RegisterClient([]byte(params))
+	creds, err := auth.GetProvider().RegisterClient(aco.UUID.String())
 	if err != nil {
 		return "", fmt.Errorf("could not register client for %s (%s) because %s", aco.UUID.String(), aco.Name, err.Error())
 	}
-	aco.ClientID, err = auth.GetParamString(result, "clientID")
-	if err != nil {
-		return "", fmt.Errorf("could not register client for %s (%s) because %s", aco.UUID.String(), aco.Name, err.Error())
-	}
-
+	aco.ClientID = creds.ClientID
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 	err = db.Save(&aco).Error
@@ -436,15 +431,27 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 		return "", fmt.Errorf("could not save ClientID %s to ACO %s (%s) because %s", aco.ClientID, aco.UUID.String(), aco.Name, err.Error())
 	}
 
-	params = fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, aco.ClientID, ttl)
-	token, err := authProvider.RequestAccessToken([]byte(params))
-	if err != nil {
-		return "", err
+	// only Okta returns ClientSecret. Should be able to switch on concrete type
+	var result string
+
+	switch auth.GetProvider().(type) {
+
+	case auth.AlphaAuthPlugin:
+		params := fmt.Sprintf(`{"clientID" : "%s", "ttl" : %d}`, creds.ClientID, ttl)
+		token, err := auth.GetProvider().RequestAccessToken([]byte(params))
+		if err != nil {
+			return "", err
+		}
+		expiresOn := time.Unix(token.ExpiresOn, 0).Format(time.RFC850)
+		tokenId := token.UUID.String()
+		result = fmt.Sprintf("%s\n%s\n%s", expiresOn, tokenId, token.TokenString)
+
+	case auth.OktaAuthPlugin:
+		expiresOn := time.Now().AddDate(1, 0, 0).Format(time.RFC850)
+		result = fmt.Sprintf("%s\n%s\n%s", expiresOn, creds.ClientID, creds.ClientSecret)
 	}
 
-	expiresOn := time.Unix(token.ExpiresOn, 0).Format(time.RFC850)
-	tokenId := token.UUID.String()
-	return fmt.Sprintf("%s\n%s\n%s", expiresOn, tokenId, token.TokenString), err
+	return result, err
 }
 
 func getEnvInt(varName string, defaultVal int) int {

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -16,7 +15,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/monitoring"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 
-	que "github.com/bgentry/que-go"
+	"github.com/bgentry/que-go"
 	"github.com/jackc/pgx"
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
@@ -57,7 +56,7 @@ func init() {
 		log.Info("Failed to open error log file; using default stderr")
 	}
 	monitoring.GetMonitor()
-	log.Info(fmt.Sprintf(`Auth is made possible by %T`, reflect.TypeOf(auth.GetProvider())))
+	log.Info(fmt.Sprintf(`Auth is made possible by %T`, auth.GetProvider()))
 }
 
 func main() {
@@ -416,8 +415,6 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 	if err != nil {
 		return
 	}
-
-	// authProvider := auth.GetProvider()
 
 	creds, err := auth.GetProvider().RegisterClient(aco.UUID.String())
 	if err != nil {

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -49,6 +49,14 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	assert.Equal(s.T(), ACOName, aco.Name)
 	assert.NotNil(s.T(), aco.ClientID)
 	assert.Equal(s.T(), ClientID, aco.ClientID)
+
+	// make sure we can't duplicate the ACO UUID
+	aco = ACO{
+		UUID: acoUUID,
+		Name: "Duplicate UUID Test",
+	}
+	err = s.db.Save(&aco).Error
+	assert.NotNil(s.T(), err)
 }
 
 func (s *ModelsTestSuite) TestCreateUser() {


### PR DESCRIPTION
### Implements [BCDA-812](https://jira.cms.gov/browse/BCDA-812)
This is the first method of the auth Provider interface to be given a working implementation in the Okta Plugin. All other tickets are dependent on it, as one must have credentials in order to acquire a token.

### Proposed changes:
1. Changed method signature to use specific typed parameters. Originally we thought the arguments might vary with plugin, so we used json for parameters. However, the parameters won't vary.
2. Use value semantics for the receiver in plugin implementations. The types are based on the empty struct so there is nothing to modify, hence no need for pointer receivers.
3. CreateAlphaToken() handles either plugin.
4. Simple support for changing the plugin at runtime added to Provider. This is done for testing support. See BCDA-882 for more details.
5. Because the okta client (BCDA-808) is not ready yet, and because testing will probably benefit from a mock, adds a simple mocktaclient.

### Dependencies
BCDA-809, for the real Okta client
BCDA-668, to add the BCDA_AUTH_PROVIDER env var 

### Security Implications
Register client returns credentials. The secret key is not saved to the database, cached in application memory or logged. This is similar to alpha handling of access tokens.

### Acceptance Validation
Existing tests continue to work.
Okta plugin and unit tests continue to work.
If the BCDA_AUTH_PROVIDER env variable is set to 'okta' (any casing), the okta plugin will be used for all unit tests that call GetProvider() (main, api, middleware, router), smoke test, and postman tests. Most will fail at this time, but without panics and with error messages.
Return from create-alpha-token CLI command should be usable by existing ansible playbook.

### Feedback Requested
Any