### PR TITLE
BCDA-815: ValidateJWT() Implementation

### DIFF
--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -50,10 +50,10 @@ func (s *AlphaAuthPluginTestSuite) AfterTest(suiteName, testName string) {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRegisterClient() {
-	c, err := s.p.RegisterClient(KnownFixtureACO)
+	c, err := s.p.RegisterClient(auth.KnownFixtureACO)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), c)
-	assert.Equal(s.T(), KnownFixtureACO, c.ClientID)
+	assert.Equal(s.T(), auth.KnownFixtureACO, c.ClientID)
 
 	c, err = s.p.RegisterClient("")
 	assert.NotNil(s.T(), err)

--- a/bcda/auth/client/oktaclient.go
+++ b/bcda/auth/client/oktaclient.go
@@ -87,6 +87,10 @@ func NewOktaClient() *OktaClient {
 	return &OktaClient{}
 }
 
+func (oc *OktaClient) ServerID() string {
+	return oktaServerID
+}
+
 func (oc *OktaClient) PublicKeyFor(id string) (rsa.PublicKey, bool) {
 	key, ok := publicKeys[id]
 	if !ok {

--- a/bcda/auth/mokta.go
+++ b/bcda/auth/mokta.go
@@ -4,15 +4,18 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
 )
 
-type Mokta struct{
-	publicKey rsa.PublicKey
-	privateKey *rsa.PrivateKey
+type Mokta struct {
+	privateKey  *rsa.PrivateKey
+	publicKey   rsa.PublicKey
+	publicKeyID string
+	serverID    string
 }
 
 func NewMokta() *Mokta {
@@ -28,14 +31,18 @@ func NewMokta() *Mokta {
 	keys := make(map[string]rsa.PublicKey)
 	keys["mokta"] = publicKey
 
-	return &Mokta{publicKey,privateKey}
+	return &Mokta{privateKey, publicKey, "mokta", "mokta.fake.backend",}
 }
 
 func (m *Mokta) PublicKeyFor(id string) (rsa.PublicKey, bool) {
-	if (id != "mokta") {
+	if id != m.publicKeyID {
 		return rsa.PublicKey{}, false
 	}
 	return m.publicKey, true
+}
+
+func (m *Mokta) ServerID() string {
+	return m.serverID
 }
 
 func (m *Mokta) AddClientApplication(localId string) (string, string, error) {
@@ -51,6 +58,14 @@ func (m *Mokta) AddClientApplication(localId string) (string, string, error) {
 	return base64.URLEncoding.EncodeToString(id), base64.URLEncoding.EncodeToString(key), err
 }
 
+func randomClientID() string {
+	b, err := someRandomBytes(4)
+	if err != nil {
+		return "not_a_random_client_id"
+	}
+	return fmt.Sprintf("%x", b)
+}
+
 func someRandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
@@ -61,27 +76,89 @@ func someRandomBytes(n int) ([]byte, error) {
 }
 
 // Returns a new access token
-func (m *Mokta) NewToken(clientID, acoID string, expiresIn int) (string, error) {
+func (m *Mokta) NewToken(clientID string) (string, error) {
+	return m.NewCustomToken(OktaToken{
+		m.publicKeyID,
+		m.serverID,
+		500,
+		clientID,
+		[]string{"bcda_api"},
+		clientID,
+	})
+}
+
+type OktaToken struct {
+	KeyID     string   `json:"kid,omitempty"`
+	Issuer    string   `json:"iss,omitempty"`
+	ExpiresIn int64    `json:"exp,omitempty"`
+	ClientID  string   `json:"cid,omitempty"`
+	Scopes    []string `json:"scp,omitempty"`
+	Subject   string   `json:"sub,omitempty"`
+}
+
+func (m *Mokta) NewCustomToken(overrides OktaToken) (string, error) {
+	values := m.valuesWithOverrides(overrides)
 	tid, err := someRandomBytes(32)
-	if (err != nil) {
+	if err != nil {
 		return "", err
 	}
+
 	token := jwt.New(jwt.SigningMethodRS256)
-	token.Header["kid"] = "mokta"
+	token.Header["kid"] = values.KeyID
 	token.Claims = jwt.MapClaims{
 		"ver": 1,
 		"jti": base64.URLEncoding.EncodeToString(tid),
-		"iss": "mokta.fake.backend",
+		"iss": values.Issuer,
 		"iat": time.Now().Unix(),
-		"exp": time.Now().Add(time.Hour * time.Duration(expiresIn)).Unix(),
-		"cid": clientID,
-		"scp": []string{"bcda_api"},
-		"sub": clientID,
+		"exp": time.Now().Add(time.Hour * time.Duration(values.ExpiresIn)).Unix(),
+		"cid": values.ClientID,
+		"scp": values.Scopes,
+		"sub": values.Subject,
 	}
+
 	tokenString, err := token.SignedString(m.privateKey)
 	if err != nil {
 		return "", err
 	}
 
 	return tokenString, nil
+}
+
+func (m *Mokta) valuesWithOverrides(or OktaToken) OktaToken {
+	cid := randomClientID()
+	v := OktaToken{
+		m.publicKeyID,
+		m.serverID,
+		500,
+		cid,
+		[]string{"bcda_api"},
+		cid,
+	}
+
+	if or.ClientID != "" {
+		v.ClientID = or.ClientID
+	}
+
+	if or.ExpiresIn != 0 {
+		v.ExpiresIn = or.ExpiresIn
+	}
+
+	if or.Issuer != "" {
+		v.Issuer = or.Issuer
+	}
+
+	if or.KeyID != "" {
+		v.KeyID = or.KeyID
+	}
+
+	if len(or.Scopes) != 0 {
+		v.Scopes = make([]string, len(or.Scopes))
+		copy(v.Scopes, or.Scopes)
+	}
+
+	if or.Subject != "" {
+		v.Subject = or.Subject
+	}
+
+	return v
 }

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -6,11 +6,17 @@ import (
 	"fmt"
 
 	"github.com/dgrijalva/jwt-go"
+
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 )
 
 type OktaBackend interface {
 	// Returns the current set of public signing keys for the okta auth server
 	PublicKeyFor(id string) (rsa.PublicKey, bool)
+
+	// Returns the id of the authorization server
+	ServerID() string
 
 	// Adds an api client application to our Okta organization
 	AddClientApplication(string) (string, string, error)
@@ -62,7 +68,34 @@ func (o OktaAuthPlugin) RevokeAccessToken(tokenString string) error {
 }
 
 func (o OktaAuthPlugin) ValidateJWT(tokenString string) error {
-	return errors.New("not yet implemented")
+	t, err := o.DecodeJWT(tokenString)
+	if err != nil {
+		return err
+	}
+
+	c := t.Claims.(jwt.MapClaims)
+
+	ok := c["iss"].(string) == o.backend.ServerID()
+	if !ok {
+		return fmt.Errorf("invalid iss claim; %s <> %s", c["iss"].(string), o.backend.ServerID())
+	}
+
+	err = c.Valid()
+	if err != nil {
+		return err
+	}
+
+	// need to check revocation here, which is not yet implemented
+	// options:
+	// keep an in-memory cache of tokens we have revoked and check that
+	// use the introspection endpoint okta provides (expensive network call)
+
+	_, err = getACOByClientID(c["cid"].(string))
+	if err != nil {
+		return fmt.Errorf("invalid cid claim; %s", err)
+	}
+
+	return nil
 }
 
 func (o OktaAuthPlugin) DecodeJWT(tokenString string) (*jwt.Token, error) {
@@ -85,4 +118,18 @@ func (o OktaAuthPlugin) DecodeJWT(tokenString string) (*jwt.Token, error) {
 	}
 
 	return jwt.ParseWithClaims(tokenString, jwt.MapClaims{}, keyFinder)
+}
+
+func getACOByClientID(clientID string) (models.ACO, error) {
+	var (
+		db  = database.GetGORMDbConnection()
+		aco models.ACO
+		err error
+	)
+	defer database.Close(db)
+
+	if db.Find(&aco, "client_id = ?", clientID).RecordNotFound() {
+		err = errors.New("no ACO record found for " + clientID)
+	}
+	return aco, err
 }

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -1,77 +1,119 @@
-package auth_test
+package auth
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 )
 
 const KnownFixtureACO = "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+const KnownClientID = "0oajfkq1mc7O1fdrk0h7"					// not a valid Okta ID
 
 type OktaAuthPluginTestSuite struct {
 	suite.Suite
-	o auth.OktaAuthPlugin
-	m *auth.Mokta
+	o OktaAuthPlugin
+	m *Mokta
+}
+
+func (s *OktaAuthPluginTestSuite) SetupSuite() {
+	models.InitializeGormModels()
+	InitializeGormModels()
+
+	db := database.GetGORMDbConnection()
+	var aco models.ACO
+	if db.Find(&aco, "UUID = ?", uuid.Parse(KnownFixtureACO)).RecordNotFound() {
+		assert.NotNil(s.T(), fmt.Errorf("Unable to find ACO %s", KnownFixtureACO))
+		return
+	}
+	aco.ClientID = KnownClientID
+	if err := db.Save(aco).Error; err != nil {
+		assert.FailNow(s.T(), "Unable to update fixture ACO for Okta tests")
+	}
 }
 
 func (s *OktaAuthPluginTestSuite) SetupTest() {
-	s.m = auth.NewMokta()
-	s.o = auth.NewOktaAuthPlugin(s.m)
+	s.m = NewMokta()
+	s.o = NewOktaAuthPlugin(s.m)
 }
 
-func (s *OktaAuthPluginTestSuite) TestRegisterClient() {
+func (s *OktaAuthPluginTestSuite) TestOktaRegisterClient() {
 	c, err := s.o.RegisterClient(KnownFixtureACO)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), c)
 	assert.Regexp(s.T(), regexp.MustCompile("[!-~]+"), c.ClientID)
 }
 
-func (s *OktaAuthPluginTestSuite) TestUpdateClient() {
+func (s *OktaAuthPluginTestSuite) TestOktaUpdateClient() {
 	c, err := s.o.UpdateClient([]byte("{}"))
 	assert.Nil(s.T(), c)
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestDeleteClient() {
+func (s *OktaAuthPluginTestSuite) TestOktaDeleteClient() {
 	err := s.o.DeleteClient([]byte("{}"))
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestGenerateClientCredentials() {
+func (s *OktaAuthPluginTestSuite) TestOktaGenerateClientCredentials() {
 	r, err := s.o.GenerateClientCredentials([]byte("{}"))
 	assert.Nil(s.T(), r)
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestRevokeClientCredentials() {
+func (s *OktaAuthPluginTestSuite) TestOktaRevokeClientCredentials() {
 	err := s.o.RevokeClientCredentials([]byte("{}"))
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestRequestAccessToken() {
+func (s *OktaAuthPluginTestSuite) TestOktaRequestAccessToken() {
 	t, err := s.o.RequestAccessToken([]byte("{}"))
-	assert.IsType(s.T(), auth.Token{}, t)
+	assert.IsType(s.T(), Token{}, t)
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestRevokeAccessToken() {
+func (s *OktaAuthPluginTestSuite) TestOktaRevokeAccessToken() {
 	err := s.o.RevokeAccessToken("")
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
 func (s *OktaAuthPluginTestSuite) TestValidateJWT() {
-	err := s.o.ValidateJWT("")
-	assert.Equal(s.T(), "not yet implemented", err.Error())
+	// happy path
+	token, err := s.m.NewToken(KnownClientID)
+	require.Nil(s.T(), err)
+	err = s.o.ValidateJWT(token)
+	require.Nil(s.T(), err)
+
+	// a variety of unhappy paths
+	token, err = s.m.NewCustomToken(OktaToken{ClientID:randomClientID()})
+	require.Nil(s.T(), err)
+	err = s.o.ValidateJWT(token)
+	require.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "invalid cid")
+
+	token, err = s.m.NewCustomToken(OktaToken{ClientID:KnownClientID, Issuer: "not_our_okta_server"})
+	require.Nil(s.T(), err)
+	err = s.o.ValidateJWT(token)
+	require.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "invalid iss")
+
+	token, err = s.m.NewCustomToken(OktaToken{ClientID:KnownClientID, ExpiresIn: -1})
+	require.Nil(s.T(), err)
+	err = s.o.ValidateJWT(token)
+	require.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "expired")
 }
 
-func (s *OktaAuthPluginTestSuite) TestDecodeJWT() {
-	token, err := s.m.NewToken("12345", "54321", 3600)
+func (s *OktaAuthPluginTestSuite) TestOktaDecodeJWT() {
+	token, err := s.m.NewToken(KnownClientID)
 	require.Nil(s.T(), err, "could not create token")
 	t, err := s.o.DecodeJWT(token)
 	assert.IsType(s.T(), &jwt.Token{}, t)

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -29,6 +29,12 @@ func (s *OktaAuthPluginTestSuite) SetupSuite() {
 	InitializeGormModels()
 
 	db := database.GetGORMDbConnection()
+	defer func() {
+		if err := db.Close(); err != nil {
+			assert.Failf(s.T(), err.Error(), "okta plugin test")
+		}
+	}()
+
 	var aco models.ACO
 	if db.Find(&aco, "UUID = ?", uuid.Parse(KnownFixtureACO)).RecordNotFound() {
 		assert.NotNil(s.T(), fmt.Errorf("Unable to find ACO %s", KnownFixtureACO))


### PR DESCRIPTION
### Fixes [BCDA-815](https://jira.cms.gov/browse/BCDA-815)
Validate an access token issued by Okta.

### Change details:
1) Implements the ValidateJWT() method for Okta. Although mostly self-contained, it did need a method added to the OktaBackend interface to validate the issuer (the Okta server id).
2) Add testing support for manufacturing test tokens in Mokta
3) Move tests into auth package itself from auth_test. The auth_test package only exists to eliminate an otherwise cyclic import among the alpha test files.
4) Tests added for important Okta-specific token claims. 

### Future Considerations
* Unlike the alpha token, the Okta token does not carry around with it the ACO ID. Instead, the code looks the ID up every time it's needed. We want to address this with some kind of caching before going live.
* A related question is should we now start using the auth.Token wrapper around the JWT Token instead of using the JWT Token directly? If we do, it should be a separate ticket and PR.

### Security Implications
No change in security.

### Acceptance Validation
All unit, smoke, and integration tests run.

You can run just the tests for the Okta plugin at the command line as follows:

```
# make sure you have fixture data and a running db
make docker-bootstrap
docker-compose up
# from project root
cd bcda/auth
DATABASE_URL=postgresql://postgres:toor@localhost:5432/bcda?sslmode=disable go test -run 'Okta*' -v
```

### Feedback Requested
Any
