### PR TITLE
BCDA-882: Add /_auth endpoint to acquire the auth_provider mode.

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -495,6 +495,36 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+/*
+        swagger:route GET /_auth metadata getAuthInfo
+
+        Get details about auth
+
+        Returns the auth provider that is currently being used. Note that this endpoint is **not** prefixed with the base path (e.g. /api/v1).
+
+        Produces:
+        - application/json
+
+        Schemes: http, https
+
+        Responses:
+                200: AuthResponse
+*/
+func getAuthInfo(w http.ResponseWriter, r *http.Request) {
+        respMap := make(map[string]string)
+        respMap["auth_provider"] = auth.GetProviderName()
+        respBytes, err := json.Marshal(respMap)
+        if err != nil {
+                http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+        }
+
+        w.Header().Set("Content-Type", "application/json")
+        _, err = w.Write(respBytes)
+        if err != nil {
+                http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+        }
+}
+
 func readTokenClaims(r *http.Request) (jwt.MapClaims, error) {
 	var (
 		claims jwt.MapClaims

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -776,6 +776,75 @@ func (s *APITestSuite) TestHealthCheckWithBadDatabaseURL() {
 	assert.Equal(s.T(), http.StatusBadGateway, s.rr.Code)
 }
 
+func (s *APITestSuite) TestAuthInfoDefault() {
+
+	// get original provider so we can reset at the end of the test
+	originalProvider := auth.GetProviderName()
+
+	// set provider to bogus value and make sure default (alpha) is retrieved
+	auth.SetProvider("bogus")
+	req := httptest.NewRequest("GET", "/_auth", nil)
+	handler := http.HandlerFunc(getAuthInfo)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	respMap := make(map[string]string)
+	err := json.Unmarshal(s.rr.Body.Bytes(), &respMap)
+	if err != nil {
+		s.T().Error(err.Error())
+	}
+	assert.Equal(s.T(), "alpha", respMap["auth_provider"])
+
+	// set provider back to original value
+	auth.SetProvider(originalProvider)
+
+}
+
+func (s *APITestSuite) TestAuthInfoAlpha() {
+
+	// get original provider so we can reset at the end of the test
+	originalProvider := auth.GetProviderName()
+
+	// set provider to alpha and make sure alpha is retrieved
+	auth.SetProvider("alpha")
+	req := httptest.NewRequest("GET", "/_auth", nil)
+	handler := http.HandlerFunc(getAuthInfo)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	respMap := make(map[string]string)
+	err := json.Unmarshal(s.rr.Body.Bytes(), &respMap)
+	if err != nil {
+		s.T().Error(err.Error())
+	}
+	assert.Equal(s.T(), "alpha", respMap["auth_provider"])
+
+	// set provider back to original value
+	auth.SetProvider(originalProvider)
+
+}
+
+func (s *APITestSuite) TestAuthInfoOkta() {
+
+	// get original provider so we can reset at the end of the test
+	originalProvider := auth.GetProviderName()
+
+	// set provider to okta and make sure okta is retrieved
+	auth.SetProvider("okta")
+	req := httptest.NewRequest("GET", "/_auth", nil)
+	handler := http.HandlerFunc(getAuthInfo)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	respMap := make(map[string]string)
+	err := json.Unmarshal(s.rr.Body.Bytes(), &respMap)
+	if err != nil {
+		s.T().Error(err.Error())
+	}
+	assert.Equal(s.T(), "okta", respMap["auth_provider"])
+
+	// set provider back to original value
+	auth.SetProvider(originalProvider)
+
+}
+
 func TestAPITestSuite(t *testing.T) {
 	suite.Run(t, new(APITestSuite))
 }

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -36,6 +36,10 @@ func SetProvider(name string) {
 	log.Infof(`Auth is made possible by %s`, providerName)
 }
 
+func GetProviderName() string {
+	return providerName
+}
+
 func GetProvider() Provider {
 	switch providerName {
 	case Alpha:

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -83,6 +83,16 @@ type VersionResponse struct {
 	}
 }
 
+// JSON object containing an auth_provider field 
+// swagger:response AuthResponse
+type AuthResponse struct {
+        // in: body
+        Body struct {
+                // Required: true
+                Version string `json:"auth_provider"`
+        }
+}
+
 // FHIR CapabilityStatement in JSON format
 // swagger:response MetadataResponse
 type MetadataResponse struct {

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -34,6 +34,7 @@ func NewAPIRouter() http.Handler {
 	})
 	r.Get(m.WrapHandler("/_version", getVersion))
 	r.Get(m.WrapHandler("/_health", healthCheck))
+	r.Get(m.WrapHandler("/_auth", getAuthInfo))
 	return r
 }
 


### PR DESCRIPTION
### Fixes [BCDA-882](https://jira.cms.gov/browse/BCDA-882)

Since we are going to be adding an Ansible script to change the provider env var dynamically (for testing purposes), we will need a way to determine the auth provider at any point in real-time.  This new endpoint will give us that capability.

### Proposed changes:

Add a `/_auth` endpoint which gives us the `auth_provider` in real time.


### Change Details

- Added a new convenience function in `provider.go` to return the provider name.
- Added the `/_auth` route and accompanying handler function.
- Added unit tests for the new route and handler function,
- Updated the SwaggerStructs template to include details for the new route.


### Security Implications

None.


### Acceptance Validation

<img width="329" alt="screen shot 2019-02-27 at 10 39 16 am" src="https://user-images.githubusercontent.com/37818548/53502406-fbb76780-3a7b-11e9-8723-296c7e5bf360.png">

<img width="316" alt="screen shot 2019-02-27 at 10 41 48 am" src="https://user-images.githubusercontent.com/37818548/53502542-5224a600-3a7c-11e9-9263-93854b9cfc02.png">



### Feedback Requested

Please review.
