### PR TITLE
Make sure we're building daily 

### DIFF
--- a/ops/Jenkinsfile.build_trigger
+++ b/ops/Jenkinsfile.build_trigger
@@ -9,6 +9,7 @@ pipeline {
   }
   triggers {
      pollSCM 'H/2 * * * *'
+     cron 'H 8 * * 1-5'
   }
 
   stages {


### PR DESCRIPTION
Build and deploy daily, each morning, to serve as an early warning system for changes in dependencies (AWS, tools, etc).