### PR TITLE
BCDA-957: Add CMS-format ID to ACOs

### DIFF
--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -19,15 +19,17 @@ func createACO(name, cmsID string) (string, error) {
 		return "", errors.New("ACO name (--name) must be provided")
 	}
 
+	var cmsIDPt *string
 	// ACO ID is not required, but must match `AXXXX` if provided
 	if cmsID != "" {
 		acoIDFmt := regexp.MustCompile(`^A\d{4}$`)
 		if !acoIDFmt.MatchString(cmsID) {
 			return "", errors.New("ACO CMS ID (--cms-id) is invalid")
 		}
+		cmsIDPt = &cmsID
 	}
 
-	acoUUID, err := models.CreateACO(name, cmsID)
+	acoUUID, err := models.CreateACO(name, cmsIDPt)
 	if err != nil {
 		return "", err
 	}

--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -20,7 +20,6 @@ func createACO(name, cmsID string) (string, error) {
 	}
 
 	var cmsIDPt *string
-	// ACO ID is not required, but must match `AXXXX` if provided
 	if cmsID != "" {
 		acoIDFmt := regexp.MustCompile(`^A\d{4}$`)
 		if !acoIDFmt.MatchString(cmsID) {

--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -10,7 +10,30 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/CMSgov/bcda-app/bcda/models"
 )
+
+func createACO(name, cmsID string) (string, error) {
+	if name == "" {
+		return "", errors.New("ACO name (--name) must be provided")
+	}
+
+	// ACO ID is not required, but must match `AXXXX` if provided
+	if cmsID != "" {
+		acoIDFmt := regexp.MustCompile(`^A\d{4}$`)
+		if !acoIDFmt.MatchString(cmsID) {
+			return "", errors.New("ACO CMS ID (--cms-id) is invalid")
+		}
+	}
+
+	acoUUID, err := models.CreateACO(name, cmsID)
+	if err != nil {
+		return "", err
+	}
+
+	return acoUUID.String(), nil
+}
 
 type cclfFileMetadata struct {
 	env       string

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -1,16 +1,21 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/urfave/cli"
 )
 
 type CLITestSuite struct {
-	suite.Suite
+	testUtils.AuthTestSuite
 	testApp *cli.App
 }
 
@@ -20,6 +25,81 @@ func (s *CLITestSuite) SetupTest() {
 
 func TestCLITestSuite(t *testing.T) {
 	suite.Run(t, new(CLITestSuite))
+}
+
+func (s *CLITestSuite) TestCreateACO() {
+
+	// init
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+	s.SetupAuthBackend()
+
+	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
+	buf := new(bytes.Buffer)
+	s.testApp.Writer = buf
+
+	assert := assert.New(s.T())
+
+	// Successful ACO creation
+	ACOName := "Unit Test ACO 1"
+	args := []string{"bcda", "create-aco", "--name", ACOName}
+	err := s.testApp.Run(args)
+	assert.Nil(err)
+	assert.NotNil(buf)
+	acoUUID := strings.TrimSpace(buf.String())
+	var testACO models.ACO
+	db.First(&testACO, "Name=?", ACOName)
+	assert.Equal(testACO.UUID.String(), acoUUID)
+	buf.Reset()
+
+	ACO2Name := "Unit Test ACO 2"
+	args = []string{"bcda", "create-aco", "--name", ACO2Name, "--cms-id", "A0000"}
+	err = s.testApp.Run(args)
+	assert.Nil(err)
+	assert.NotNil(buf)
+	acoUUID = strings.TrimSpace(buf.String())
+	var testACO2 models.ACO
+	db.First(&testACO2, "Name=?", ACO2Name)
+	assert.Equal(testACO2.UUID.String(), acoUUID)
+	buf.Reset()
+
+	// Negative tests
+
+	// No parameters
+	args = []string{"bcda", "create-aco"}
+	err = s.testApp.Run(args)
+	assert.Equal("ACO name (--name) must be provided", err.Error())
+	assert.Equal(0, buf.Len())
+	buf.Reset()
+
+	// No ACO Name
+	badACO := ""
+	args = []string{"bcda", "create-aco", "--name", badACO}
+	err = s.testApp.Run(args)
+	assert.Equal("ACO name (--name) must be provided", err.Error())
+	assert.Equal(0, buf.Len())
+	buf.Reset()
+
+	// ACO name without flag
+	args = []string{"bcda", "create-aco", ACOName}
+	err = s.testApp.Run(args)
+	assert.Equal("ACO name (--name) must be provided", err.Error())
+	assert.Equal(0, buf.Len())
+	buf.Reset()
+
+	// Unexpected flag
+	args = []string{"bcda", "create-aco", "--abcd", "efg"}
+	err = s.testApp.Run(args)
+	assert.Equal("flag provided but not defined: -abcd", err.Error())
+	assert.Contains(buf.String(), "Incorrect Usage: flag provided but not defined")
+	buf.Reset()
+
+	// Invalid CMS ID
+	args = []string{"bcda", "create-aco", "--name", ACOName, "--cms-id", "ABCDE"}
+	err = s.testApp.Run(args)
+	assert.Equal("ACO CMS ID (--cms-id) is invalid", err.Error())
+	assert.Equal(0, buf.Len())
+	buf.Reset()
 }
 
 func (s *CLITestSuite) TestImportCCLF8() {

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -53,7 +53,8 @@ func (s *CLITestSuite) TestCreateACO() {
 	buf.Reset()
 
 	ACO2Name := "Unit Test ACO 2"
-	args = []string{"bcda", "create-aco", "--name", ACO2Name, "--cms-id", "A0000"}
+	aco2ID := "A9999"
+	args = []string{"bcda", "create-aco", "--name", ACO2Name, "--cms-id", aco2ID}
 	err = s.testApp.Run(args)
 	assert.Nil(err)
 	assert.NotNil(buf)
@@ -61,6 +62,7 @@ func (s *CLITestSuite) TestCreateACO() {
 	var testACO2 models.ACO
 	db.First(&testACO2, "Name=?", ACO2Name)
 	assert.Equal(testACO2.UUID.String(), acoUUID)
+	assert.Equal(*testACO2.CMSID, aco2ID)
 	buf.Reset()
 
 	// Negative tests

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -25,7 +25,6 @@ import (
 // App Name and usage.  Edit them here to prevent breaking tests
 const Name = "bcda"
 const Usage = "Beneficiary Claims Data API CLI"
-const CreateACO = "create-aco"
 
 var (
 	qc      *que.Client
@@ -82,7 +81,7 @@ func setUpApp() *cli.App {
 	app.Name = Name
 	app.Usage = Usage
 	app.Version = version
-	var acoName, acoID, userName, userEmail, userID, accessToken, ttl, threshold, acoSize, filePath string
+	var acoName, acoCMSID, acoID, userName, userEmail, userID, accessToken, ttl, threshold, acoSize, filePath string
 	app.Commands = []cli.Command{
 		{
 			Name:  "start-api",
@@ -143,7 +142,7 @@ func setUpApp() *cli.App {
 			},
 		},
 		{
-			Name:     CreateACO,
+			Name:     "create-aco",
 			Category: "Authentication tools",
 			Usage:    "Create an ACO",
 			Flags: []cli.Flag{
@@ -152,9 +151,14 @@ func setUpApp() *cli.App {
 					Usage:       "Name of ACO",
 					Destination: &acoName,
 				},
+				cli.StringFlag{
+					Name:        "cms-id",
+					Usage:       "CMS ID of ACO",
+					Destination: &acoCMSID,
+				},
 			},
 			Action: func(c *cli.Context) error {
-				acoUUID, err := createACO(acoName)
+				acoUUID, err := createACO(acoName, acoCMSID)
 				if err != nil {
 					return err
 				}
@@ -343,19 +347,6 @@ func autoMigrate() {
 	models.InitializeGormModels()
 	auth.InitializeGormModels()
 	fmt.Println("Completed Database Initialization")
-}
-
-func createACO(name string) (string, error) {
-	if name == "" {
-		return "", errors.New("ACO name (--name) must be provided")
-	}
-
-	acoUUID, err := models.CreateACO(name)
-	if err != nil {
-		return "", err
-	}
-
-	return acoUUID.String(), nil
 }
 
 func createUser(acoID, name, email string) (string, error) {

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -52,10 +52,10 @@ type JobKey struct {
 
 type ACO struct {
 	gorm.Model
-	UUID     uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
-	CMSID    *string   `gorm:"type:char(5); unique" json:"cms_id"`
-	Name     string    `json:"name"`      // name
-	ClientID string    `json:"client_id"` // software client id
+	UUID     uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"`
+	CMSID    *string   `gorm:"type:char(5); unique"`
+	Name     string    `json:"name"`
+	ClientID string    `json:"client_id"`
 }
 
 func (aco *ACO) GetPublicKey() *rsa.PublicKey {

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -53,7 +53,7 @@ type JobKey struct {
 type ACO struct {
 	gorm.Model
 	UUID     uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
-	CMSID    string    `gorm:"type:char(5)" json:"cms_id"`
+	CMSID    *string   `gorm:"type:char(5); unique" json:"cms_id"`
 	Name     string    `json:"name"`      // name
 	ClientID string    `json:"client_id"` // software client id
 }
@@ -84,7 +84,7 @@ func GetATOPrivateKey() *rsa.PrivateKey {
 	return secutils.OpenPrivateKeyFile(atoPrivateKeyFile)
 }
 
-func CreateACO(name, cmsID string) (uuid.UUID, error) {
+func CreateACO(name string, cmsID *string) (uuid.UUID, error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -3,11 +3,12 @@ package models
 import (
 	"crypto/rsa"
 	"fmt"
+	"os"
+
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/secutils"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
-	"os"
 )
 
 func InitializeGormModels() *gorm.DB {
@@ -52,8 +53,9 @@ type JobKey struct {
 type ACO struct {
 	gorm.Model
 	UUID     uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
-	Name     string    `json:"name"`                                   // name
-	ClientID string    `json:"client_id"`                              // software client id
+	CMSID    string    `gorm:"type:char(5)" json:"cms_id"`
+	Name     string    `json:"name"`      // name
+	ClientID string    `json:"client_id"` // software client id
 }
 
 func (aco *ACO) GetPublicKey() *rsa.PublicKey {
@@ -82,11 +84,11 @@ func GetATOPrivateKey() *rsa.PrivateKey {
 	return secutils.OpenPrivateKeyFile(atoPrivateKeyFile)
 }
 
-func CreateACO(name string) (uuid.UUID, error) {
+func CreateACO(name, cmsID string) (uuid.UUID, error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
-	aco := ACO{Name: name, UUID: uuid.NewRandom()}
+	aco := ACO{Name: name, CMSID: cmsID, UUID: uuid.NewRandom()}
 	db.Create(&aco)
 
 	return aco.UUID, db.Error

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -28,7 +28,8 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	assert := s.Assert()
 
 	const ACOName = "ACO Name"
-	acoUUID, err := CreateACO(ACOName, "A0000")
+	cmsID := "A0000"
+	acoUUID, err := CreateACO(ACOName, &cmsID)
 
 	assert.Nil(err)
 	assert.NotNil(acoUUID)
@@ -38,7 +39,7 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	assert.NotNil(aco)
 	assert.Equal(ACOName, aco.Name)
 	assert.Equal("", aco.ClientID)
-	assert.Equal("A0000", aco.CMSID)
+	assert.Equal(cmsID, *aco.CMSID)
 	assert.NotNil(aco.GetPublicKey())
 	assert.NotNil(GetATOPrivateKey())
 	// should confirm the keys are a matched pair? i.e., encrypt something with one and decrypt with the other
@@ -57,6 +58,15 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	aco = ACO{
 		UUID: acoUUID,
 		Name: "Duplicate UUID Test",
+	}
+	err = s.db.Save(&aco).Error
+	assert.NotNil(err)
+
+	// Duplicate CMS ID
+	aco = ACO{
+		UUID:  uuid.NewRandom(),
+		CMSID: &cmsID,
+		Name:  "Duplicate CMS ID Test",
 	}
 	err = s.db.Save(&aco).Error
 	assert.NotNil(err)

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -25,19 +25,22 @@ func (s *ModelsTestSuite) TearDownTest() {
 }
 
 func (s *ModelsTestSuite) TestCreateACO() {
-	const ACOName = "ACO Name"
-	acoUUID, err := CreateACO(ACOName)
+	assert := s.Assert()
 
-	assert.Nil(s.T(), err)
-	assert.NotNil(s.T(), acoUUID)
+	const ACOName = "ACO Name"
+	acoUUID, err := CreateACO(ACOName, "A0000")
+
+	assert.Nil(err)
+	assert.NotNil(acoUUID)
 
 	var aco ACO
 	s.db.Find(&aco, "UUID = ?", acoUUID)
-	assert.NotNil(s.T(), aco)
-	assert.Equal(s.T(), ACOName, aco.Name)
-	assert.Equal(s.T(), "", aco.ClientID)
-	assert.NotNil(s.T(), aco.GetPublicKey())
-	assert.NotNil(s.T(), GetATOPrivateKey())
+	assert.NotNil(aco)
+	assert.Equal(ACOName, aco.Name)
+	assert.Equal("", aco.ClientID)
+	assert.Equal("A0000", aco.CMSID)
+	assert.NotNil(aco.GetPublicKey())
+	assert.NotNil(GetATOPrivateKey())
 	// should confirm the keys are a matched pair? i.e., encrypt something with one and decrypt with the other
 	// the auth provider determines what the clientID contains (formatting, alphabet used, etc).
 	// we require that it be representable in a string of less than 255 characters
@@ -45,10 +48,10 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	aco.ClientID = ClientID
 	s.db.Save(aco)
 	s.db.Find(&aco, "UUID = ?", acoUUID)
-	assert.NotNil(s.T(), aco)
-	assert.Equal(s.T(), ACOName, aco.Name)
-	assert.NotNil(s.T(), aco.ClientID)
-	assert.Equal(s.T(), ClientID, aco.ClientID)
+	assert.NotNil(aco)
+	assert.Equal(ACOName, aco.Name)
+	assert.NotNil(aco.ClientID)
+	assert.Equal(ClientID, aco.ClientID)
 
 	// make sure we can't duplicate the ACO UUID
 	aco = ACO{
@@ -56,7 +59,7 @@ func (s *ModelsTestSuite) TestCreateACO() {
 		Name: "Duplicate UUID Test",
 	}
 	err = s.db.Save(&aco).Error
-	assert.NotNil(s.T(), err)
+	assert.NotNil(err)
 }
 
 func (s *ModelsTestSuite) TestCreateUser() {

--- a/db/api.sql
+++ b/db/api.sql
@@ -1,6 +1,6 @@
 create table acos (
   uuid uuid not null primary key,
-  cms_id char(5),
+  cms_id char(5) unique null,
   name text not null,
   created_at timestamp with time zone not null default now(),
   updated_at timestamp with time zone not null default now()

--- a/db/api.sql
+++ b/db/api.sql
@@ -1,5 +1,6 @@
 create table acos (
   uuid uuid not null primary key,
+  cms_id char(5),
   name text not null,
   created_at timestamp with time zone not null default now(),
   updated_at timestamp with time zone not null default now()

--- a/db/fixtures.sql
+++ b/db/fixtures.sql
@@ -1,12 +1,12 @@
-insert into acos values ('DBBD1CE1-AE24-435C-807D-ED45953077D3', 'ACO Lorem Ipsum', default, default);
-insert into acos values ('A40404F7-1EF2-485A-9B71-40FE7ACDCBC2', 'ACO Sit Amet', default, default);
-insert into acos values ('c14822fa-19ee-402c-9248-32af98419fe3', 'ACO Revoked', default, default);
-insert into acos values ('82f55b6a-728e-4c8b-807e-535caad7b139', 'ACO Not Revoked', default, default);
-insert into acos values ('3461C774-B48F-11E8-96F8-529269fb1459', 'ACO Small', default,default),
-                        ('C74C008D-42F8-4ED9-BF88-CEE659C7F692', 'ACO Medium', default, default),
-                        ('8D80925A-027E-43DD-8AED-9A501CC4CD91', 'ACO Large', default, default),
-                        ('55954dba-d4d9-438d-bd03-453da4993fe9', 'ACO Extra Large', default, default);
-insert into acos values ('0c527d2e-2e8a-4808-b11d-0fa06baf8254', 'ACO Dev', default, default);
+insert into acos values ('DBBD1CE1-AE24-435C-807D-ED45953077D3', null, 'ACO Lorem Ipsum', default, default);
+insert into acos values ('A40404F7-1EF2-485A-9B71-40FE7ACDCBC2', null, 'ACO Sit Amet', default, default);
+insert into acos values ('c14822fa-19ee-402c-9248-32af98419fe3', null, 'ACO Revoked', default, default);
+insert into acos values ('82f55b6a-728e-4c8b-807e-535caad7b139', null, 'ACO Not Revoked', default, default);
+insert into acos values ('3461C774-B48F-11E8-96F8-529269fb1459', null, 'ACO Small', default,default),
+                        ('C74C008D-42F8-4ED9-BF88-CEE659C7F692', null, 'ACO Medium', default, default),
+                        ('8D80925A-027E-43DD-8AED-9A501CC4CD91', null, 'ACO Large', default, default),
+                        ('55954dba-d4d9-438d-bd03-453da4993fe9', null, 'ACO Extra Large', default, default);
+insert into acos values ('0c527d2e-2e8a-4808-b11d-0fa06baf8254', null, 'ACO Dev', default, default);
 
 insert into users values ('82503A18-BF3B-436D-BA7B-BAE09B7FFD2F', 'User One', 'userone@email.com', 'DBBD1CE1-AE24-435C-807D-ED45953077D3', default, default);
 insert into users values ('EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73', 'User Two', 'usertwo@email.com', 'DBBD1CE1-AE24-435C-807D-ED45953077D3', default, default);


### PR DESCRIPTION
### Fixes [BCDA-957](https://jira.cms.gov/browse/BCDA-957)
For attribution using CCLF8 and CCLF9, beneficiaries are associated with ACOs by their CMS IDs. We'll need to store this ACO ID value (AXXXX). (Beneficiary IDs handled by separate ticket.)

### Proposed changes:
Add CMS ID to ACO model while retaining our internal ACO UUID.

### Change Details
* Adds string/char(5) `CMSID` to `ACO` model/table
* Updates `create-aco` CLI command to accept optional CMS ID
* Moves `createACO()` from main.go to cli.go (recently added file for CLI functions)

### Security Implications
None

### Acceptance Validation
ACO can be created from CLI with or without CMS ID (if valid format).
<img width="783" alt="screen shot 2019-02-28 at 2 08 54 pm" src="https://user-images.githubusercontent.com/1923441/53591990-4f50b080-3b63-11e9-826f-fc40ff5c04a5.png">

### Feedback Requested
Any
