### PR TITLE
BCDA-956 Feature: add Okta token generation to cli "create-token" command

### DIFF
--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -140,39 +140,52 @@ func (p AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	return nil
 }
 
-// generate a token for the id (which user? just have a single "user" (alpha2, alpha3, ...) per test cycle?)
-// params are currently acoId and ttl; not going to introduce user until we have clear use cases
+// generate a token for the ACO, either for a specified UserID or (if not provided) any user in the ACO
 func (p AlphaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
-
+	var userUUID, acoUUID uuid.UUID
+	var user models.User
+	var err error
 	token := Token{}
 
-	acoUUID := creds.ClientID
-	if acoUUID == "" {
-		return token, errors.New("no ACO ID provided")
-	}
-
-	aco, err := getACOFromDB(acoUUID)
-	if err != nil {
-		return token, err
-	}
-
-	// I arbitrarily decided to use the first user. An alternative would be to make a specific user
-	// that represents the client. I have no strong opinion here other than not creating stuff in the db
-	// unless we're willing to live with it forever.
-	var user models.User
-	if err = db.First(&user, "aco_id = ?", aco.UUID).Error; err != nil {
-		return token, errors.New("no user found for " + aco.UUID.String())
+	if creds.UserID == "" && creds.ClientID == "" {
+		return token, fmt.Errorf("must provide either UserID or ClientID")
 	}
 
 	if ttl < 0 {
 		return token, fmt.Errorf("invalid TTL: %d", ttl)
 	}
 
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+
+	// Get both acoUUID and userUUID based on creds.UserID if provided
+	if creds.UserID != "" {
+		if db.First(&user, "UUID = ?", creds.UserID).RecordNotFound() {
+			return token, fmt.Errorf("unable to locate User with id of %s", creds.UserID)
+		}
+
+		userUUID = user.UUID
+		acoUUID = user.ACOID
+	} else {
+		aco, err := getACOFromDB(creds.ClientID)
+		if err != nil {
+			return token, err
+		}
+
+		// I arbitrarily decided to use the first user. An alternative would be to make a specific user
+		// that represents the client. I have no strong opinion here other than not creating stuff in the db
+		// unless we're willing to live with it forever.
+		if err = db.First(&user, "aco_id = ?", aco.UUID).Error; err != nil {
+			return token, errors.New("no user found for " + aco.UUID.String())
+		}
+
+		userUUID = user.UUID
+		acoUUID = aco.UUID
+	}
+
 	token.UUID = uuid.NewRandom()
-	token.UserID = user.UUID
-	token.ACOID = aco.UUID
+	token.UserID = userUUID
+	token.ACOID = acoUUID
 	token.IssuedAt = time.Now().Unix()
 	token.ExpiresOn = time.Now().Add(time.Hour * time.Duration(ttl)).Unix()
 	token.Active = true

--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -155,19 +155,30 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
-	t, err := s.p.RequestAccessToken(auth.Credentials{ClientID: "DBBD1CE1-AE24-435C-807D-ED45953077D3"}, 720)
+	const userID, acoID = "EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73", "DBBD1CE1-AE24-435C-807D-ED45953077D3"
+	t, err := s.p.RequestAccessToken(auth.Credentials{ClientID: acoID}, 720)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), auth.Token{}, t)
+	assert.NotEmpty(s.T(), t.TokenString)
 
 	t, err = s.p.RequestAccessToken(auth.Credentials{}, 720)
 	assert.NotNil(s.T(), err)
 	assert.IsType(s.T(), auth.Token{}, t)
-	assert.Contains(s.T(), err.Error(), "no ACO ID")
+	assert.Nil(s.T(), t.ACOID)
+	assert.Nil(s.T(), t.UserID)
+	assert.Contains(s.T(), err.Error(), "must provide either UserID or ClientID")
 
-	t, err = s.p.RequestAccessToken(auth.Credentials{ClientID: "DBBD1CE1-AE24-435C-807D-ED45953077D3"}, -1)
+	t, err = s.p.RequestAccessToken(auth.Credentials{ClientID: acoID}, -1)
 	assert.NotNil(s.T(), err)
 	assert.IsType(s.T(), auth.Token{}, t)
 	assert.Contains(s.T(), err.Error(), "invalid TTL")
+
+	t, err = s.p.RequestAccessToken(auth.Credentials{UserID: userID}, 720)
+	assert.Nil(s.T(), err)
+	assert.IsType(s.T(), auth.Token{}, t)
+	assert.NotEmpty(s.T(), t.TokenString)
+	assert.NotNil(s.T(), t.ACOID)
+	assert.NotNil(s.T(), t.UserID)
 }
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	db := connections["TestRevokeAccessToken"]

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -76,7 +76,13 @@ func (o OktaAuthPlugin) RevokeClientCredentials(params []byte) error {
 }
 
 func (o OktaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {
-	if creds.ClientID == "" {
+	clientID := creds.ClientID
+	// Also accept clientID via creds.UserID to match alpha auth implementation
+	if clientID == "" {
+		clientID = creds.UserID
+	}
+
+	if clientID == "" {
 		return Token{}, fmt.Errorf("client ID required")
 	}
 
@@ -84,7 +90,7 @@ func (o OktaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, e
 		return Token{}, fmt.Errorf("client secret required")
 	}
 
-	clientCreds := client.Credentials{ClientID: creds.ClientID, ClientSecret: creds.ClientSecret}
+	clientCreds := client.Credentials{ClientID: clientID, ClientSecret: creds.ClientSecret}
 	ot, err := o.backend.RequestAccessToken(clientCreds)
 
 	if err != nil {

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -94,6 +94,10 @@ func (s *OktaAuthPluginTestSuite) TestRequestAccessToken() {
 	t, err = s.o.RequestAccessToken(Credentials{ClientID: mockID, ClientSecret: mockSecret}, 0)
 	assert.IsType(s.T(), Token{}, t)
 	assert.Nil(s.T(), err)
+
+	t, err = s.o.RequestAccessToken(Credentials{UserID: mockID, ClientSecret: mockSecret}, 0)
+	assert.IsType(s.T(), Token{}, t)
+	assert.Nil(s.T(), err)
 }
 
 func (s *OktaAuthPluginTestSuite) TestOktaRevokeAccessToken() {

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -52,6 +52,7 @@ func GetProvider() Provider {
 }
 
 type Credentials struct {
+	UserID       string
 	ClientID     string
 	ClientSecret string
 	Token        Token

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -82,7 +82,7 @@ func setUpApp() *cli.App {
 	app.Name = Name
 	app.Usage = Usage
 	app.Version = version
-	var acoName, acoID, userName, userEmail, userID, accessToken, ttl, threshold, acoSize, filePath string
+	var acoName, acoID, userName, userEmail, tokenID, tokenSecret, accessToken, ttl, threshold, acoSize, filePath string
 	app.Commands = []cli.Command{
 		{
 			Name:  "start-api",
@@ -195,20 +195,23 @@ func setUpApp() *cli.App {
 		{
 			Name:     "create-token",
 			Category: "Authentication tools",
-			Usage:    "Create an access token",
+			Usage:    "Create an access/session token",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:        "user-id",
-					Usage:       "UUID of user",
-					Destination: &userID,
-				},
-			},
+					Name:        "id",
+					Usage:       "ID associated with token (either a user UUID, or client-id paired with the secret",
+					Destination: &tokenID,
+				}, cli.StringFlag{
+					Name:        "secret",
+					Usage:       "Credential secret for creating session tokens",
+					Destination: &tokenSecret,
+				}},
 			Action: func(c *cli.Context) error {
-				accessToken, err := createAccessToken(userID)
+				tokenValue, err := createAccessToken(tokenID, tokenSecret)
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(app.Writer, "%s\n", accessToken)
+				fmt.Fprintf(app.Writer, "%s\n", tokenValue)
 				return nil
 			},
 		},
@@ -390,16 +393,30 @@ func createUser(acoID, name, email string) (string, error) {
 	return user.UUID.String(), nil
 }
 
-func createAccessToken(userID string) (string, error) {
-	errMsgs := []string{}
+func createAccessToken(userID string, secret string) (string, error) {
+	var clientID string
 	var userUUID uuid.UUID
+	errMsgs := []string{}
 
-	if userID == "" {
-		errMsgs = append(errMsgs, "User ID (--user-id) must be provided")
-	} else {
-		userUUID = uuid.Parse(userID)
-		if userUUID == nil {
-			errMsgs = append(errMsgs, "User ID must be a UUID")
+	a := auth.GetProvider()
+
+	switch a.(type) {
+	case auth.AlphaAuthPlugin:
+		if userID == "" {
+			errMsgs = append(errMsgs, "User ID (--id) must be provided")
+		} else {
+			userUUID = uuid.Parse(userID)
+			if userUUID == nil {
+				errMsgs = append(errMsgs, "User ID must be a UUID")
+			}
+		}
+
+	case auth.OktaAuthPlugin:
+		if userID == "" {
+			errMsgs = append(errMsgs, "Client ID (--id) must be provided")
+		}
+		if secret == "" {
+			errMsgs = append(errMsgs, "Secret (--secret) must be provided")
 		}
 	}
 
@@ -407,15 +424,23 @@ func createAccessToken(userID string) (string, error) {
 		return "", errors.New(strings.Join(errMsgs, "\n"))
 	}
 
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
-	var user models.User
+	switch a.(type) {
+	case auth.AlphaAuthPlugin:
+		db := database.GetGORMDbConnection()
+		defer database.Close(db)
+		var user models.User
 
-	if db.First(&user, "UUID = ?", userID).RecordNotFound() {
-		return "", fmt.Errorf("unable to locate User with id of %s", userID)
+		if db.First(&user, "UUID = ?", userID).RecordNotFound() {
+			return "", fmt.Errorf("unable to locate User with id of %s", userID)
+		}
+
+		clientID = user.ACOID.String()
+
+	case auth.OktaAuthPlugin:
+		clientID = userID
 	}
 
-	token, err := auth.GetProvider().RequestAccessToken(auth.Credentials{ClientID: user.ACOID.String()}, 72)
+	token, err := auth.GetProvider().RequestAccessToken(auth.Credentials{ClientID: clientID, ClientSecret: secret}, 72)
 	if err != nil {
 		return "", err
 	}

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -393,18 +393,12 @@ func createUser(acoID, name, email string) (string, error) {
 	return user.UUID.String(), nil
 }
 
-func createAccessToken(userID string, secret string) (string, error) {
-	errMsgs := []string{}
-
-	if userID == "" {
-		errMsgs = append(errMsgs, "ID (--id) must be provided")
+func createAccessToken(ID string, secret string) (string, error) {
+	if ID == "" {
+		return "", errors.New("ID (--id) must be provided")
 	}
 
-	if len(errMsgs) > 0 {
-		return "", errors.New(strings.Join(errMsgs, "\n"))
-	}
-
-	token, err := auth.GetProvider().RequestAccessToken(auth.Credentials{UserID: userID, ClientSecret: secret}, 72)
+	token, err := auth.GetProvider().RequestAccessToken(auth.Credentials{UserID: ID, ClientSecret: secret}, 72)
 	if err != nil {
 		return "", err
 	}

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -33,12 +33,6 @@ type MainTestSuite struct {
 	expectedSizes map[string]int
 }
 
-type OktaAuthPluginTestSuite struct {
-	suite.Suite
-	o auth.OktaAuthPlugin
-	m *auth.Mokta
-}
-
 func (s *MainTestSuite) SetupSuite() {
 	s.expectedSizes = map[string]int{
 		"dev":    50,

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -33,6 +33,12 @@ type MainTestSuite struct {
 	expectedSizes map[string]int
 }
 
+type OktaAuthPluginTestSuite struct {
+	suite.Suite
+	o auth.OktaAuthPlugin
+	m *auth.Mokta
+}
+
 func (s *MainTestSuite) SetupSuite() {
 	s.expectedSizes = map[string]int{
 		"dev":    50,
@@ -243,13 +249,13 @@ func (s *MainTestSuite) TestCreateUser() {
 }
 
 func (s *MainTestSuite) TestCreateToken() {
-	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
+	// Set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
 	buf := new(bytes.Buffer)
 	s.testApp.Writer = buf
 
 	assert := assert.New(s.T())
 	userUUID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
-	clientID := "not_a_client"
+	badUUID := "not_a_uuid"
 	clientSecret := "not_a_secret"
 
 	// Unexpected flag
@@ -259,59 +265,43 @@ func (s *MainTestSuite) TestCreateToken() {
 	assert.Contains(buf.String(), "Incorrect Usage: flag provided but not defined")
 	buf.Reset()
 
-	switch auth.GetProvider().(type) {
-	case auth.OktaAuthPlugin:
-		// No parameters
-		args = []string{"bcda", "create-token"}
-		err = s.testApp.Run(args)
-		assert.Equal("Client ID (--id) must be provided\nSecret (--secret) must be provided", err.Error())
-		assert.Equal(0, buf.Len())
-		buf.Reset()
+	// No parameters
+	args = []string{"bcda", "create-token"}
+	err = s.testApp.Run(args)
+	assert.Equal("ID (--id) must be provided", err.Error())
+	assert.Equal(0, buf.Len())
+	buf.Reset()
 
-		// Blank Client ID
-		args = []string{"bcda", "create-token", "--id", "", "--secret", clientSecret}
-		err = s.testApp.Run(args)
-		assert.Equal("Client ID (--id) must be provided", err.Error())
-		assert.Equal(0, buf.Len())
-		buf.Reset()
+	// Blank ID
+	args = []string{"bcda", "create-token", "--id", "", "--secret", clientSecret}
+	err = s.testApp.Run(args)
+	assert.Equal("ID (--id) must be provided", err.Error())
+	assert.Equal(0, buf.Len())
+	buf.Reset()
 
-		// Blank Client Secret
-		args = []string{"bcda", "create-token", "--id", clientID, "--secret", ""}
-		err = s.testApp.Run(args)
-		assert.Equal("Secret (--secret) must be provided", err.Error())
-		assert.Equal(0, buf.Len())
-		buf.Reset()
-	case auth.AlphaAuthPlugin:
-		// No parameters
-		args := []string{"bcda", "create-token"}
-		err := s.testApp.Run(args)
-		assert.Equal("User ID (--id) must be provided", err.Error())
-		assert.Equal(0, buf.Len())
-		buf.Reset()
+	// Alpha auth section
+	originalAuthProvider := auth.GetProviderName()
+	auth.SetProvider("alpha")
+	// Test alpha auth bad ID
+	args = []string{"bcda", "create-token", "--id", badUUID}
+	err = s.testApp.Run(args)
+	assert.NotNil(err)
+	buf.Reset()
 
-		// Test successful creation
-		args = []string{"bcda", "create-token", "--id", userUUID}
-		err = s.testApp.Run(args)
-		assert.Nil(err)
-		assert.NotNil(buf)
-		accessTokenString := strings.TrimSpace(buf.String())
-		assert.NotNil(accessTokenString)
-		buf.Reset()
+	// Test alpha auth successful creation
+	args = []string{"bcda", "create-token", "--id", userUUID}
+	err = s.testApp.Run(args)
+	assert.Nil(err)
+	assert.NotNil(buf)
+	accessTokenString := strings.TrimSpace(buf.String())
+	assert.Nil(err)
+	assert.NotEmpty(accessTokenString)
+	buf.Reset()
 
-		// Blank User UUID
-		args = []string{"bcda", "create-token", "--id", ""}
-		err = s.testApp.Run(args)
-		assert.Equal("User ID (--id) must be provided", err.Error())
-		assert.Equal(0, buf.Len())
-		buf.Reset()
+	// Okta auth section
+	auth.SetProvider("okta")
 
-		// Bad User UUID
-		args = []string{"bcda", "create-token", "--id", BADUUID}
-		err = s.testApp.Run(args)
-		assert.Equal("User ID must be a UUID", err.Error())
-		assert.Equal(0, buf.Len())
-		buf.Reset()
-	}
+	auth.SetProvider(originalAuthProvider)
 }
 
 func checkTokenInfo(s *MainTestSuite, tokenInfo string) {


### PR DESCRIPTION
### Fixes [BCDA-956](https://jira.cms.gov/browse/BCDA-956)

For ops purposes, we need to be able to get an Okta token.  This PR extends the existing CLI command `create-token` to work when using an OktaAuthPlugin auth provider.

### Proposed changes:

- Change the `--user-id` argument to `--id` to account for both user-id's and client-id's
- Add a `--secret` argument, which is ignored when using the AlphaAuthPlugin auth provider.
- Too many `switch` statements in the code and tests!


### Security Implications
This is strictly a dev-only tool.  There should be no change to the security posture with this PR.


### Acceptance Validation
<img width="977" alt="screen shot 2019-02-28 at 2 44 02 pm" src="https://user-images.githubusercontent.com/2533561/53593905-ba03eb00-3b67-11e9-981e-cc7b2115da57.png">

### Testing
Get a token by running:
`docker exec -it bcda-app_api_1 sh -c 'BCDA_AUTH_PROVIDER=okta OKTA_OAUTH_SERVER_ID=<okta_server_id> OKTA_CLIENT_TOKEN=token_not_used_but_required tmp/bcda create-token --id <a_valid_client_id> --secret <this_client_secret>'`

and (using an alpha token included in the test suite)
`docker exec -it bcda-app_api_1 sh -c 'tmp/bcda create-token --id 82503A18-BF3B-436D-BA7B-BAE09B7FFD2F'`

### Feedback Requested
- Does it work with both auth providers?
- Were the switch statements or other code smells acceptable compromises?
- Is there adequate test coverage for this stage of development?
