### PR TITLE
Modify Okta create-alpha-token output to include client name

### DIFF
--- a/bcda/auth/mokta.go
+++ b/bcda/auth/mokta.go
@@ -47,18 +47,20 @@ func (m *Mokta) ServerID() string {
 	return m.serverID
 }
 
-func (m *Mokta) AddClientApplication(localId string) (string, string, string, error) {
+func (m *Mokta) AddClientApplication(localId string) (clientID string, clientSecret string, clientName string, err error) {
 	id, err := someRandomBytes(16)
 	if err != nil {
-		return "", "", "", nil
+		return
 	}
 	key, err := someRandomBytes(32)
 	if err != nil {
-		return "", "", "", nil
+		return
 	}
 
-	clientID := base64.URLEncoding.EncodeToString(id)
-	return clientID, base64.URLEncoding.EncodeToString(key), fmt.Sprintf("BCDA %s", clientID), err
+	clientID = base64.URLEncoding.EncodeToString(id)
+	clientSecret = base64.URLEncoding.EncodeToString(key)
+	clientName = fmt.Sprintf("BCDA %s", clientID)
+	return
 }
 
 func (m *Mokta) RequestAccessToken(creds client.Credentials) (client.OktaToken, error) {

--- a/bcda/auth/mokta.go
+++ b/bcda/auth/mokta.go
@@ -47,17 +47,18 @@ func (m *Mokta) ServerID() string {
 	return m.serverID
 }
 
-func (m *Mokta) AddClientApplication(localId string) (string, string, error) {
+func (m *Mokta) AddClientApplication(localId string) (string, string, string, error) {
 	id, err := someRandomBytes(16)
 	if err != nil {
-		return "", "", nil
+		return "", "", "", nil
 	}
 	key, err := someRandomBytes(32)
 	if err != nil {
-		return "", "", nil
+		return "", "", "", nil
 	}
 
-	return base64.URLEncoding.EncodeToString(id), base64.URLEncoding.EncodeToString(key), err
+	clientID := base64.URLEncoding.EncodeToString(id)
+	return clientID, base64.URLEncoding.EncodeToString(key), fmt.Sprintf("BCDA %s", clientID), err
 }
 
 func (m *Mokta) RequestAccessToken(creds client.Credentials) (client.OktaToken, error) {

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -19,7 +19,7 @@ type OktaBackend interface {
 	ServerID() string
 
 	// Adds an api client application to our Okta organization
-	AddClientApplication(string) (string, string, error)
+	AddClientApplication(string) (string, string, string, error)
 
 	// Gets a session token from Okta
 	RequestAccessToken(creds client.Credentials) (client.OktaToken, error)
@@ -42,10 +42,12 @@ func (o OktaAuthPlugin) RegisterClient(localID string) (Credentials, error) {
 		return Credentials{}, errors.New("you must provide a localID")
 	}
 
-	id, key, err := o.backend.AddClientApplication(localID)
+	id, key, name, err := o.backend.AddClientApplication(localID)
+
 	return Credentials{
 		ClientID:     id,
 		ClientSecret: key,
+		ClientName:   name,
 	}, err
 }
 

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -19,7 +19,7 @@ type OktaBackend interface {
 	ServerID() string
 
 	// Adds an api client application to our Okta organization
-	AddClientApplication(string) (string, string, string, error)
+	AddClientApplication(string) (clientID string, secret string, clientName string, err error)
 
 	// Gets a session token from Okta
 	RequestAccessToken(creds client.Credentials) (client.OktaToken, error)
@@ -42,11 +42,11 @@ func (o OktaAuthPlugin) RegisterClient(localID string) (Credentials, error) {
 		return Credentials{}, errors.New("you must provide a localID")
 	}
 
-	id, key, name, err := o.backend.AddClientApplication(localID)
+	id, secret, name, err := o.backend.AddClientApplication(localID)
 
 	return Credentials{
 		ClientID:     id,
-		ClientSecret: key,
+		ClientSecret: secret,
 		ClientName:   name,
 	}, err
 }

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -55,6 +55,7 @@ type Credentials struct {
 	ClientID     string
 	ClientSecret string
 	Token        Token
+	ClientName   string
 }
 
 // Provider defines operations performed through an authentication provider.

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -483,8 +483,7 @@ func createAlphaToken(ttl int, acoSize string) (s string, err error) {
 		result = fmt.Sprintf("%s\n%s\n%s", expiresOn, tokenId, token.TokenString)
 
 	case auth.OktaAuthPlugin:
-		expiresOn := time.Now().AddDate(1, 0, 0).Format(time.RFC850)
-		result = fmt.Sprintf("%s\n%s\n%s", expiresOn, creds.ClientID, creds.ClientSecret)
+		result = fmt.Sprintf("%s\n%s\n%s", creds.ClientName, creds.ClientID, creds.ClientSecret)
 	}
 
 	return result, err


### PR DESCRIPTION
### Fixes [BCDA-968](https://jira.cms.gov/browse/BCDA-968)
We need the client name in the output.

### Proposed changes:
For Okta, replaced first line of output with client name

### Security Implications
No change in security posture.

### Acceptance Validation
All unit and integration tests run.

To hand test:

`make docker-bootstrap`

edit docker-compose.yml and set these env variables:
BCDA_AUTH_PROVIDER=okta
OKTA_OAUTH_SERVER_ID=_server id_
OKTA_CLIENT_TOKEN=_token_

`docker-compose up`
`docker exec -it bcda-app_api_1 sh -c 'tmp/bcda create-alpha-token --size Dev'`

### Feedback Requested
Any.
