### PR TITLE
BCDA-818 implement RevokeClientCredentials() for okta

### DIFF
--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -64,7 +64,7 @@ func (p AlphaAuthPlugin) GenerateClientCredentials(clientID string, ttl int) (Cr
 		return Credentials{}, fmt.Errorf("ACO %s does not have a registered client", clientID)
 	}
 
-	err = p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID":"%s"}`, clientID)))
+	err = p.RevokeClientCredentials(clientID)
 	if err != nil {
 		return Credentials{}, fmt.Errorf("unable to revoke existing credentials for ACO %s because %s", clientID, err)
 	}
@@ -82,12 +82,7 @@ func (p AlphaAuthPlugin) GenerateClientCredentials(clientID string, ttl int) (Cr
 }
 
 // look up the active access token associated with id, and call RevokeAccessToken
-func (p AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
-	clientID, err := GetParamString(params, "clientID")
-	if err != nil {
-		return err
-	}
-
+func (p AlphaAuthPlugin) RevokeClientCredentials(clientID string) error {
 	db := database.GetGORMDbConnection()
 	defer func() {
 		if err := db.Close(); err != nil {
@@ -96,7 +91,7 @@ func (p AlphaAuthPlugin) RevokeClientCredentials(params []byte) error {
 	}()
 
 	var aco models.ACO
-	err = db.First(&aco, "client_id = ?", clientID).Error
+	err := db.First(&aco, "client_id = ?", clientID).Error
 	if err != nil {
 		return errors.New("no ACO found for client ID")
 	}

--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -143,7 +143,7 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeClientCredentials() {
 
 	assert := assert.New(s.T())
 
-	err = s.p.RevokeClientCredentials([]byte(fmt.Sprintf(`{"clientID": "%s"}`, aco.ClientID)))
+	err = s.p.RevokeClientCredentials(aco.ClientID)
 	assert.Nil(err)
 
 	var token auth.Token

--- a/bcda/auth/client/oktaclient.go
+++ b/bcda/auth/client/oktaclient.go
@@ -345,6 +345,60 @@ func (oc *OktaClient) GenerateNewClientSecret(clientID string) (string, error) {
 	return cs, nil
 }
 
+func (oc *OktaClient) DeactivateApplication(clientID string) error {
+	url := oktaBaseUrl + "/api/v1/apps/" + clientID + "/lifecycle/deactivate"
+
+	reqID := uuid.NewRandom()
+	logRequest(reqID).WithFields(logrus.Fields{"url": url, "clientID": clientID}).Print()
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		logError(err, reqID)
+		return err
+	}
+
+	addRequestHeaders(req)
+
+	resp, err := client().Do(req)
+	if err != nil {
+		logError(err, reqID).Print()
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		logError(errors.New(resp.Status), reqID).Print()
+		return errors.New(resp.Status)
+	}
+	logResponse(resp.StatusCode, reqID).Print()
+
+	return nil
+}
+
+func (oc *OktaClient) RemoveClientApplication(clientID string) error {
+	url := oktaBaseUrl + "/oauth2/v1/clients/" + clientID
+
+	reqID := uuid.NewRandom()
+	logRequest(reqID).WithFields(logrus.Fields{"url": url, "clientID": clientID}).Print()
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		logError(err, reqID)
+		return err
+	}
+
+	addRequestHeaders(req)
+
+	resp, err := client().Do(req)
+	if err != nil {
+		logError(err, reqID).Print()
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		logError(errors.New(resp.Status), reqID).Print()
+		return errors.New(resp.Status)
+	}
+	logResponse(resp.StatusCode, reqID).Print()
+
+	return nil
+}
+
 func client() *http.Client {
 	return &http.Client{Timeout: time.Second * 10}
 }

--- a/bcda/auth/client/oktaclient_test.go
+++ b/bcda/auth/client/oktaclient_test.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/pborman/uuid"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -99,6 +101,16 @@ func (s *OTestSuite) TestGenerateNewClientSecret() {
 	invalidClientID := "IDontexist"
 	newSecret, err = s.oc.GenerateNewClientSecret(invalidClientID)
 	assert.Equal(s.T(), "404 Not Found", err.Error())
+}
+
+func (s *OTestSuite) TestDeactivateApplication() {
+	newClientID, _, _ := s.oc.AddClientApplication("TestDeactivate" + uuid.NewRandom().String())
+
+	err := s.oc.DeactivateApplication(newClientID)
+	assert.Nil(s.T(), err, fmt.Sprintf("failed to deactivate application with ID %s", newClientID))
+
+	err = s.oc.RemoveClientApplication(newClientID)
+	assert.Nil(s.T(), err, fmt.Sprintf("failed to remove client application with ID %s", newClientID))
 }
 
 func (s *OTestSuite) TearDownTest() {

--- a/bcda/auth/client/oktaclient_test.go
+++ b/bcda/auth/client/oktaclient_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/pborman/uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -66,14 +65,15 @@ func (s *OTestSuite) TestPublicKeyFor() {
 	assert.False(s.T(), ok)
 }
 
-// for manual verification, the clientID returned should be listed in the server's policy page under clients
-// also should be listed as a "BCDA <randomClientID>" in the apps page
 func (s *OTestSuite) TestAddClientApplication() {
 	rci := randomClientId(6)
-	clientID, secret, err := s.oc.AddClientApplication(rci)
+	clientID, secret, clientName, err := s.oc.AddClientApplication(rci)
 	assert.Nil(s.T(), err)
 	assert.NotEmpty(s.T(), clientID)
 	assert.NotEmpty(s.T(), secret)
+	assert.Equal(s.T(), "BCDA "+rci, clientName)
+
+	_ = s.oc.RemoveClientApplication(clientID)
 }
 
 func (s *OTestSuite) TestRequestAccessToken() {
@@ -104,13 +104,16 @@ func (s *OTestSuite) TestGenerateNewClientSecret() {
 }
 
 func (s *OTestSuite) TestDeactivateApplication() {
-	newClientID, _, _ := s.oc.AddClientApplication("TestDeactivate" + uuid.NewRandom().String())
+	newClientID, _, _, _ := s.oc.AddClientApplication("TestDeactivate" + uuid.NewRandom().String())
 
 	err := s.oc.DeactivateApplication(newClientID)
 	assert.Nil(s.T(), err, fmt.Sprintf("failed to deactivate application with ID %s", newClientID))
 
 	err = s.oc.RemoveClientApplication(newClientID)
 	assert.Nil(s.T(), err, fmt.Sprintf("failed to remove client application with ID %s", newClientID))
+
+	err = s.oc.RemoveClientApplication(newClientID)
+	assert.Equal(s.T(), "401 Unauthorized", err.Error())
 }
 
 func (s *OTestSuite) TearDownTest() {

--- a/bcda/auth/mokta.go
+++ b/bcda/auth/mokta.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/auth/client"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type Mokta struct {
@@ -91,6 +91,10 @@ func (m *Mokta) GenerateNewClientSecret(clientID string) (string, error) {
 
 	fakeClientSecret := "thisClientSecretIsFakeButIsCorrectLength"
 	return fakeClientSecret, nil
+}
+
+func (m *Mokta) DeactivateApplication(clientID string) error {
+	return nil
 }
 
 func randomClientID() string {

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -71,7 +71,7 @@ func (o OktaAuthPlugin) GenerateClientCredentials(clientID string, ttl int) (Cre
 	return c, nil
 }
 
-func (o OktaAuthPlugin) RevokeClientCredentials(params []byte) error {
+func (o OktaAuthPlugin) RevokeClientCredentials(clientID string) error {
 	return errors.New("not yet implemented")
 }
 

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -26,6 +26,9 @@ type OktaBackend interface {
 
 	// Renews client secret for an okta client
 	GenerateNewClientSecret(string) (string, error)
+
+	// Deactivates a client application so it cannot be used
+	DeactivateApplication(clientID string) error
 }
 
 type OktaAuthPlugin struct {
@@ -72,7 +75,12 @@ func (o OktaAuthPlugin) GenerateClientCredentials(clientID string, ttl int) (Cre
 }
 
 func (o OktaAuthPlugin) RevokeClientCredentials(clientID string) error {
-	return errors.New("not yet implemented")
+	err := o.backend.DeactivateApplication(clientID)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (o OktaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -80,8 +80,8 @@ func (s *OktaAuthPluginTestSuite) TestGenerateClientCredentials() {
 }
 
 func (s *OktaAuthPluginTestSuite) TestOktaRevokeClientCredentials() {
-	err := s.o.RevokeClientCredentials("")
-	assert.Equal(s.T(), "not yet implemented", err.Error())
+	err := s.o.RevokeClientCredentials("fakeClientID")
+	assert.Nil(s.T(), err)
 }
 
 func (s *OktaAuthPluginTestSuite) TestRequestAccessToken() {

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -79,7 +79,7 @@ func (s *OktaAuthPluginTestSuite) TestGenerateClientCredentials() {
 	assert.Equal(s.T(), "404 Not Found", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestOktaRevokeClientCredentials() {
+func (s *OktaAuthPluginTestSuite) TestRevokeClientCredentials() {
 	err := s.o.RevokeClientCredentials("fakeClientID")
 	assert.Nil(s.T(), err)
 }

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -80,7 +80,7 @@ func (s *OktaAuthPluginTestSuite) TestGenerateClientCredentials() {
 }
 
 func (s *OktaAuthPluginTestSuite) TestOktaRevokeClientCredentials() {
-	err := s.o.RevokeClientCredentials([]byte("{}"))
+	err := s.o.RevokeClientCredentials("")
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -72,7 +72,7 @@ type Provider interface {
 	GenerateClientCredentials(clientID string, ttl int) (Credentials, error)
 
 	// Revoke any existing Credentials for the given clientID
-	RevokeClientCredentials(params []byte) error
+	RevokeClientCredentials(clientID string) error
 
 	// Request an access token with a specific time-to-live for the given clientID
 	RequestAccessToken(creds Credentials, ttl int) (Token, error)


### PR DESCRIPTION
### Fixes [BCDA-818](https://jira.cms.gov/browse/BCDA-818)
implements a func to revoke a client application's access in okta and satisfy the provider interface

### Proposed changes:
- write a couple of funcs in `oktaclient.go` to deactivate and delete a client application in okta
- change `RevokeClientCredentials()` to accept a `clientID string` instead of a `params []byte`
- implement `RevokeClientCredentials()` in `okta.go`
- test everything

### Feedback requested:
the mokta method used for testing is very naive.  any feedback for improving the test?  oktaclient_test looks good and passes at least