### PR TITLE
knollfear/BCDA-1068 adding decryption util files from gists to our repo

### DIFF
--- a/decryption_utils/Go/decrypt.go
+++ b/decryption_utils/Go/decrypt.go
@@ -68,8 +68,8 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 	if err != nil {
 		panic(err)
 	}
-
-	ciphertext, err := ioutil.ReadFile(fmt.Sprintf(filename))
+	/* #nosec -- Command line util requires reading a file that is passed via an argument */
+	ciphertext, err := ioutil.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -86,6 +86,7 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 }
 
 func getPrivateKey(loc string) *rsa.PrivateKey {
+	/* #nosec -- Command line util requires reading a file that is passed via an argument */
 	pkFile, err := os.Open(loc)
 	if err != nil {
 		panic(err)
@@ -102,7 +103,10 @@ func getPrivateKey(loc string) *rsa.PrivateKey {
 	}
 
 	data, _ := pem.Decode([]byte(pembytes))
-	pkFile.Close()
+	err = pkFile.Close()
+	if err != nil {
+		log.Panic(err)
+	}
 
 	imported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
 	if err != nil {

--- a/encryption_utils/C#/decrypt.cs
+++ b/encryption_utils/C#/decrypt.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using CommandLine;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Encodings;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+
+// Code based on https://www.codeproject.com/Articles/1265115/Cross-Platform-AES-256-GCM-Encryption-Decryption
+//           and https://gist.github.com/dziwoki/cc41b523c2bd43ee646b957f0aa91943
+
+namespace BCDA
+{
+    class Decrypt
+    {
+        public static readonly int NonceByteSize = 12;
+
+        public class Options
+        {
+            [Option('k', "key",
+                HelpText = "Encrypted symmetric key used for file decryption (hex encoded string).",
+                Required = true)]
+            public string Key { get; set; }
+
+            [Option('f', "file",
+                HelpText = "Location of encrypted file.",
+                Required = true)]
+            public string File { get; set; }
+
+            [Option('p', "pk",
+                HelpText = "Location of private key to use for decryption of symmetric key.",
+                Required = true)]
+            public string PrivateKey { get; set; }
+        }
+
+        static void Main(string[] args)
+        {
+            Parser.Default.ParseArguments<Options>(args)
+               .WithParsed<Options>(o =>
+               {
+                   string ndjson = PerformDecryption(o.File, o.PrivateKey, o.Key);
+                   Console.WriteLine(ndjson);
+               });
+        }
+
+        private static string PerformDecryption(string encryptedFilePath, string privateKeyPath, string encSymmetricKey)
+        {
+            // Use the encrypted file's name as the label in decrypting the private key.
+            // Note that this means you MUST save it with the filename given by the API.
+            string label = new FileInfo(encryptedFilePath).Name;
+            byte[] symmetricKey = DecodeSymmetricKey(label, privateKeyPath, encSymmetricKey);
+
+            byte[] fileText = File.ReadAllBytes(encryptedFilePath);
+            byte[] nonce = new ArraySegment<byte>(fileText, 0, NonceByteSize).ToArray();
+            byte[] encryptedText = new ArraySegment<byte>(fileText, NonceByteSize, fileText.Length - NonceByteSize).ToArray();
+
+            return DecryptFile(encryptedText, symmetricKey, nonce);
+        }
+
+        private static byte[] DecodeSymmetricKey(string label, string privateKeyPath, string ciphertext)
+        {
+            byte[] cipherTextBytes = HexToByte(ciphertext);
+            byte[] labelBytes = Encoding.UTF8.GetBytes(label);
+
+            PemReader pr = new PemReader(File.OpenText(privateKeyPath));
+            AsymmetricCipherKeyPair keys = (AsymmetricCipherKeyPair)pr.ReadObject();
+
+            OaepEncoding eng = new OaepEncoding(new RsaEngine(), new Sha256Digest(), new Sha256Digest(), labelBytes);
+            eng.Init(false, keys.Private);
+
+            int length = cipherTextBytes.Length;
+            int blockSize = eng.GetInputBlockSize();
+            List<byte> plainTextBytes = new List<byte>();
+            for (int chunkPosition = 0;
+                chunkPosition < length;
+                chunkPosition += blockSize)
+            {
+                int chunkSize = Math.Min(blockSize, length - chunkPosition);
+                plainTextBytes.AddRange(eng.ProcessBlock(
+                    cipherTextBytes, chunkPosition, chunkSize
+                ));
+            }
+            return plainTextBytes.ToArray();
+        }
+
+        private static string DecryptFile(byte[] encryptedText, byte[] key, byte[] nonce)
+        {
+            string plaintext = string.Empty;
+            try
+            {
+                GcmBlockCipher cipher = new GcmBlockCipher(new AesEngine());
+                AeadParameters parameters = new AeadParameters(new KeyParameter(key), 128, nonce);
+
+                cipher.Init(false, parameters);
+                byte[] plainBytes = new byte[cipher.GetOutputSize(encryptedText.Length)];
+                Int32 byteLen = cipher.ProcessBytes(encryptedText, 0, encryptedText.Length, plainBytes, 0);
+                cipher.DoFinal(plainBytes, byteLen);
+
+                plaintext = Encoding.UTF8.GetString(plainBytes);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+            }
+
+            return plaintext;
+        }
+
+        private static Byte[] HexToByte(string hexStr)
+        {
+            byte[] bArray = new byte[hexStr.Length / 2];
+            for (int i = 0; i < (hexStr.Length / 2); i++)
+            {
+                byte firstNibble = Byte.Parse(hexStr.Substring((2 * i), 1), System.Globalization.NumberStyles.HexNumber);
+                byte secondNibble = Byte.Parse(hexStr.Substring((2 * i) + 1, 1), System.Globalization.NumberStyles.HexNumber);
+                int finalByte = (secondNibble) | (firstNibble << 4);
+                bArray[i] = (byte)finalByte;
+            }
+            return bArray;
+        }
+    }
+}

--- a/encryption_utils/C#/decrypt.csproj
+++ b/encryption_utils/C#/decrypt.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
+    <PackageReference Include="CommandLineParser" Version="2.4.3" />
+  </ItemGroup>
+
+</Project>

--- a/encryption_utils/Go/decrypt.go
+++ b/encryption_utils/Go/decrypt.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bufio"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+var private, encryptedKey, filepath string
+
+func init() {
+	flag.StringVar(&encryptedKey, "key", "", "encrypted symmetric key used for file decryption (hex-encoded string)")
+	flag.StringVar(&filepath, "file", "", "location of encrypted file")
+	flag.StringVar(&private, "pk", "", "location of private key to use for decryption of symmetric key")
+	flag.Parse()
+
+	if encryptedKey == "" || filepath == "" || private == "" {
+		fmt.Println("missing argument(s)")
+		os.Exit(1)
+	}
+	r, _ := regexp.Compile("^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}")
+	filename := path.Base(filepath)
+	uuid := strings.Split(filename, ".")[0]
+	if !r.MatchString(uuid) {
+		fmt.Printf("File name does not appear to be valid.\nPlease use the exact file name from the job status endpoint (i.e., of the format: <UUID>.ndjson).\n")
+		os.Exit(1)
+	}
+}
+
+func decryptCipher(ciphertext []byte, key *[32]byte) (plaintext []byte, err error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, errors.New("malformed ciphertext")
+	}
+	return gcm.Open(nil,
+		ciphertext[:gcm.NonceSize()],
+		ciphertext[gcm.NonceSize():],
+		nil,
+	)
+}
+
+func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename string) {
+	base := path.Base(filename)
+	decryptedKey, err := rsa.DecryptOAEP(
+		sha256.New(), rand.Reader, privateKey, encryptedKey, []byte(base))
+	if err != nil {
+		panic(err)
+	}
+
+	ciphertext, err := ioutil.ReadFile(fmt.Sprintf(filename))
+	if err != nil {
+		panic(err)
+	}
+
+	var plaintext []byte
+	key := [32]byte{}
+	copy(key[:], decryptedKey[0:32])
+	plaintext, err = decryptCipher(ciphertext, &key)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s", plaintext)
+}
+
+func getPrivateKey(loc string) *rsa.PrivateKey {
+	pkFile, err := os.Open(loc)
+	if err != nil {
+		panic(err)
+	}
+
+	pemfileinfo, _ := pkFile.Stat()
+	var size int64 = pemfileinfo.Size()
+	pembytes := make([]byte, size)
+	buffer := bufio.NewReader(pkFile)
+
+	_, err = buffer.Read(pembytes)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	data, _ := pem.Decode([]byte(pembytes))
+	pkFile.Close()
+
+	imported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return imported
+}
+
+func main() {
+	ek, err := hex.DecodeString(encryptedKey)
+	if err != nil {
+		panic(err)
+	}
+	pk := getPrivateKey(private)
+	decryptFile(pk, ek, filepath)
+}

--- a/encryption_utils/Python/decrypt.py
+++ b/encryption_utils/Python/decrypt.py
@@ -1,0 +1,96 @@
+from __future__ import print_function
+
+import argparse
+import binascii
+import os
+import re
+import sys
+
+from argparse import RawTextHelpFormatter
+
+try:
+    from Crypto.Cipher import PKCS1_OAEP, AES
+    from Crypto.PublicKey import RSA
+    from Crypto.Hash import SHA256
+except ImportError:
+    print("Install requirements first: pip install -r requirements.txt", file=sys.stderr)
+    raise SystemExit
+
+# Match nonce and tag sizes used by BCDA
+# Golang defaults: https://golang.org/src/crypto/cipher/gcm.go#L146
+GCM_NONCE_SIZE = 12
+GCM_TAG_SIZE = 16
+
+
+def init():
+    parser = argparse.ArgumentParser(
+        description='Decrypt a BCDA payload.',
+        formatter_class=RawTextHelpFormatter
+    )
+    parser.add_argument(
+        '--key', dest='key', type=str,
+        help="encrypted symmetric key used for file decryption (hex-encoded string)"
+    )
+    parser.add_argument(
+        '--file', dest='file', type=str,
+        help="location of encrypted file"
+    )
+    parser.add_argument(
+        '--pk', dest='pk', type=str,
+        help="location of private key to use for decryption of symmetric key"
+    )
+
+    args = parser.parse_args()
+
+    if not args.key or not args.file or not args.pk:
+        print("missing argument(s)", file=sys.stderr)
+        raise SystemExit
+
+    if not valid_uuid(args.file):
+        print("""File name does not appear to be valid.
+Please use the exact file name from the job status endpoint (i.e., of the format: <UUID>.ndjson).""",
+              file=sys.stderr)
+        raise SystemExit
+
+    return args
+
+
+def decrypt_cipher(ct, key):
+    nonce = ct.read(GCM_NONCE_SIZE)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce, mac_len=GCM_TAG_SIZE)
+    ciphertext = ct.read()
+    return cipher.decrypt_and_verify(
+        ciphertext[:-GCM_TAG_SIZE],
+        ciphertext[-GCM_TAG_SIZE:]
+    )
+
+
+def decrypt_file(private_key, encrypted_key, filepath):
+    base = os.path.basename(filepath)
+    cipher = PKCS1_OAEP.new(key=private_key, hashAlgo=SHA256, label=base.encode('utf-8'))
+    decrypted_key = cipher.decrypt(encrypted_key)
+
+    with open(filepath, 'rb') as fh:
+        result = decrypt_cipher(fh, decrypted_key)
+
+    print(result.decode('utf-8'))
+
+
+def get_private_key(loc):
+    with open(loc, 'r') as fh:
+        return RSA.importKey(fh.read())
+
+def valid_uuid(filename):
+    uuid = filename.split("/")[-1].split(".")[0]
+    regex = re.compile('^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
+    match = regex.match(uuid)
+    return bool(match)
+
+def main():
+    args = init()
+    ek = binascii.unhexlify(args.key)
+    pk = get_private_key(args.pk)
+    decrypt_file(pk, ek, args.file)
+
+if __name__ == "__main__":
+    main()

--- a/encryption_utils/Python/requirements.txt
+++ b/encryption_utils/Python/requirements.txt
@@ -1,0 +1,1 @@
+pycryptodome==3.7.2


### PR DESCRIPTION
### Fixes [BCDA-1068](https://jira.cms.gov/browse/BCDA-1068)

<!-- describe the problem being solved here -->
Decryption utils are hosted in gists on people's personal github pages.  We should gasther those resources into our repo so that it instills more confidence in our users that the code is legit and the whole team can work on them as needed.
### Proposed changes:
<!-- List of changes with bullet points here: -->
copied gist files into decryption_utils folder

### Change Details
<!-- add detailed discussion of changes here: -->


### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
no PII is affected.  These are code samples that will not be executed by our application

### Acceptance Validation
<!-- were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
Just verify the necessary files are there and with the right names.
<!-- insert screenshots if applicable (drag images here) -->


### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
