### PR TITLE
BCDA-973 Feature: Add /auth/token endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ postman:
 	# and if needed a token.
 	# Use env=local to bring up a local version of the app and test against it
 	# For example: make postman env=test token=<MY_TOKEN>
-	docker-compose -f docker-compose.test.yml run --rm postman_test test/postman_test/$(env).postman_environment.json --global-var "token=$(token)"
+	docker-compose -f docker-compose.test.yml run --rm postman_test test/postman_test/$(env).postman_environment.json --global-var "token=$(token)" "clientId=$(clientId)" "clientSecret=$(clientSecret)"
 
 performance-test:
 	docker-compose -f docker-compose.test.yml run --rm -w /go/src/github.com/CMSgov/bcda-app/test/performance_test tests sh performance_test.sh

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -17,16 +17,14 @@
      - application/json
 
      Security:
-	 - api_key:
-	 - basic_auth:
+     - api_key:
+
 
      SecurityDefinitions:
      api_key:
           type: apiKey
           name: Authorization
-		  in: header
-	 basic_auth:
-		  type: basic
+          in: header
  swagger:meta
 */
 package main

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -17,13 +17,16 @@
      - application/json
 
      Security:
-     - api_key:
+	 - api_key:
+	 - basic_auth:
 
      SecurityDefinitions:
      api_key:
           type: apiKey
           name: Authorization
-          in: header
+		  in: header
+	 basic_auth:
+		  type: basic
  swagger:meta
 */
 package main
@@ -366,13 +369,12 @@ func serveData(w http.ResponseWriter, r *http.Request) {
 
 	Get access token
 
-	Verifies parameters client_id and secret, and returns a JWT token that can be presented to the other API endpoints.
-
-	Consumes:
-	- application/x-www-form-urlencoded
+	Verifies Basic authentication credentials, and returns a JWT token that can be presented to the other API endpoints.
 
 	Produces:
 	- application/json
+
+	Security: basic_auth
 
 	Schemes: https
 
@@ -383,10 +385,8 @@ func serveData(w http.ResponseWriter, r *http.Request) {
 		500: serverError
 */
 func getAuthToken(w http.ResponseWriter, r *http.Request) {
-	clientId := r.Header.Get("client_id")
-	secret := r.Header.Get("secret")
-
-	if clientId == "" || secret == "" {
+	clientId, secret, ok := r.BasicAuth()
+	if !ok {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -19,12 +19,16 @@
      Security:
      - api_key:
 
-
      SecurityDefinitions:
      api_key:
           type: apiKey
           name: Authorization
           in: header
+     basic_auth:
+          type: basic
+          name: Authorization
+          in: header
+
  swagger:meta
 */
 package main
@@ -367,14 +371,15 @@ func serveData(w http.ResponseWriter, r *http.Request) {
 
 	Get access token
 
-	Verifies Basic authentication credentials, and returns a JWT token that can be presented to the other API endpoints.
+	Verifies Basic authentication credentials, and returns a JWT bearer token that can be presented to the other API endpoints.
 
 	Produces:
 	- application/json
 
-	Security: basic_auth
-
 	Schemes: https
+
+	Security:
+		basic_auth:
 
 	Responses:
 		200: tokenResponse

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -656,9 +656,9 @@ func (s *APITestSuite) TestAuthToken() {
 
 	// // The following change in error status can be tested with alpha auth (presumably along with success paths)
 	// // once GetAccessToken() is implemented
-	//
-	// req.Header.Add("client_id", "not_a_client_id")
-	// req.Header.Add("secret", "not_a_secret")
+	// credential := base64.StdEncoding.EncodeToString([]byte("not_a_client_id:not_a_secret"))
+	// req.Header.Add("Authorization", "Basic "+credential)
+	// handler.ServeHTTP(s.rr, req)
 
 	// assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
 }

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -11,14 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/encryption"
-
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
-	"github.com/CMSgov/bcda-app/bcda/responseutils"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
-
 	"github.com/bgentry/que-go"
 	fhirmodels "github.com/eug48/fhir/models"
 	"github.com/go-chi/chi"
@@ -27,6 +19,13 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/encryption"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/responseutils"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
 )
 
 type APITestSuite struct {

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -654,13 +654,14 @@ func (s *APITestSuite) TestAuthToken() {
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
-	assert.Empty(s.T(), s.rr.Body)
 
-	req.Header.Add("client_id", "not_a_client_id")
-	req.Header.Add("secret", "not_a_secret")
+	// // The following change in error status can be tested with alpha auth (presumably along with success paths)
+	// // once GetAccessToken() is implemented
+	//
+	// req.Header.Add("client_id", "not_a_client_id")
+	// req.Header.Add("secret", "not_a_secret")
 
-	assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
-	assert.Empty(s.T(), s.rr.Body)
+	// assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
 }
 
 func (s *APITestSuite) TestMetadata() {

--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -148,6 +148,11 @@ func (p AlphaAuthPlugin) RevokeClientCredentials(clientID string) error {
 	return nil
 }
 
+// Verify credentials (client ID and secret) and return access token
+func (p AlphaAuthPlugin) GetAccessToken(creds Credentials) (Token, error) {
+	return Token{}, fmt.Errorf("GetAccessToken not implemented in Alpha")
+}
+
 // generate a token for the ACO, either for a specified UserID or (if not provided) any user in the ACO
 func (p AlphaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {
 	var userUUID, acoUUID uuid.UUID

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var mockHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {}
+var originalAuthProvider string
 
 type MiddlewareTestSuite struct {
 	testUtils.AuthTestSuite
@@ -44,6 +45,15 @@ func (s *MiddlewareTestSuite) CreateRouter() http.Handler {
 	})
 
 	return router
+}
+
+func (s *MiddlewareTestSuite) SetupSuite() {
+	originalAuthProvider = auth.GetProviderName()
+	auth.SetProvider("alpha")
+}
+
+func (s *MiddlewareTestSuite) TeardownSuite() {
+	auth.SetProvider(originalAuthProvider)
 }
 
 func (s *MiddlewareTestSuite) SetupTest() {

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -85,6 +85,10 @@ func (o OktaAuthPlugin) RevokeClientCredentials(clientID string) error {
 	return nil
 }
 
+func (o OktaAuthPlugin) GetAccessToken(creds Credentials) (Token, error) {
+	return o.RequestAccessToken(creds, 0)
+}
+
 func (o OktaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {
 	clientID := creds.ClientID
 	// Also accept clientID via creds.UserID to match alpha auth implementation

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -85,6 +85,9 @@ type Provider interface {
 	// Request an access token with a specific time-to-live for the given clientID
 	RequestAccessToken(creds Credentials, ttl int) (Token, error)
 
+	// Verify credentials and return access token
+	GetAccessToken(creds Credentials) (Token, error)
+
 	// Revoke a specific access token identified in a base64 encoded token string
 	RevokeAccessToken(tokenString string) error
 

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -234,8 +234,8 @@ func (s *MainTestSuite) TestCreateToken() {
 }
 
 func (s *MainTestSuite) TestCreateAlphaTokenCLI() {
-	originalAuthProvider := auth.GetProviderName()
-	defer auth.SetProvider(originalAuthProvider)
+	originalAuthProvider := auth.GetProviderName()  // remove with BCDA-1022
+	defer auth.SetProvider(originalAuthProvider)    // remove with BCDA-1022
 
 	// Due to the way the resulting token is returned to the user, not all scenarios can be executed via CLI
 

--- a/bcda/main_test.go
+++ b/bcda/main_test.go
@@ -234,6 +234,8 @@ func (s *MainTestSuite) TestCreateToken() {
 }
 
 func (s *MainTestSuite) TestCreateAlphaTokenCLI() {
+	originalAuthProvider := auth.GetProviderName()
+	defer auth.SetProvider(originalAuthProvider)
 
 	// Due to the way the resulting token is returned to the user, not all scenarios can be executed via CLI
 
@@ -242,6 +244,7 @@ func (s *MainTestSuite) TestCreateAlphaTokenCLI() {
 	s.testApp.Writer = buf
 
 	assert := assert.New(s.T())
+
 	outputPattern := regexp.MustCompile(`.+\n.+\n.+`)
 
 	// execute positive scenarios via CLI

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -136,17 +136,6 @@ type BulkRequestHeaders struct {
 	Prefer string
 }
 
-// swagger:parameters getAuthToken
-type AuthParams struct {
-	// required: true
-	// in: header
-	ClientID string `json:"client_id"`
-
-	// required: true
-	// in: header
-	Secret string `json:"secret"`
-}
-
 // JSON with a valid JWT
 // swagger:response tokenResponse
 type TokenResponse struct {

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -83,14 +83,14 @@ type VersionResponse struct {
 	}
 }
 
-// JSON object containing an auth_provider field 
+// JSON object containing an auth_provider field
 // swagger:response AuthResponse
 type AuthResponse struct {
-        // in: body
-        Body struct {
-                // Required: true
-                Version string `json:"auth_provider"`
-        }
+	// in: body
+	Body struct {
+		// Required: true
+		Version string `json:"auth_provider"`
+	}
 }
 
 // FHIR CapabilityStatement in JSON format
@@ -135,3 +135,36 @@ type BulkRequestHeaders struct {
 	// enum: respond-async
 	Prefer string
 }
+
+// swagger:parameters getAuthToken
+type AuthParams struct {
+	// required: true
+	// in: header
+	ClientID string `json:"client_id"`
+
+	// required: true
+	// in: header
+	Secret string `json:"secret"`
+}
+
+// JSON with a valid JWT
+// swagger:response tokenResponse
+type TokenResponse struct {
+	// in: body
+	Body struct {
+		// Required: true
+		AccessToken string `json:"access_token"`
+	}
+}
+
+// Missing credentials
+// swagger:response missingCredentials
+type MissingCredentials struct{}
+
+// Invalid credentials
+// swagger:response invalidCredentials
+type InvalidCredentials struct{}
+
+// Server error
+// swagger:response serverError
+type ServerError struct{}

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -143,6 +143,7 @@ type TokenResponse struct {
 	Body struct {
 		// Required: true
 		AccessToken string `json:"access_token"`
+		TokenType string `json:"token_type"`
 	}
 }
 

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -32,6 +32,7 @@ func NewAPIRouter() http.Handler {
 			r.Get(m.WrapHandler("/token", getToken))
 		}
 	})
+	r.Post(m.WrapHandler("/auth/token", getAuthToken))
 	r.Get(m.WrapHandler("/_version", getVersion))
 	r.Get(m.WrapHandler("/_health", healthCheck))
 	r.Get(m.WrapHandler("/_auth", getAuthInfo))

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -50,24 +50,25 @@ func (suite *RouterTestSuite) GetStringBody(url string) (string, error) {
 
 func (suite *RouterTestSuite) TestDefaultRoute() {
 	r, err := suite.GetStringBody(suite.apiServer.URL)
-	assert.Nil(suite.T(), err, fmt.Sprintf("Error when getting default route: %s", err))
+	assert.Nil(suite.T(), err, fmt.Sprintf("error when getting default route: %s", err))
 	assert.NotContains(suite.T(), r, "404 page not found", "Default route returned wrong body")
 	assert.Contains(suite.T(), r, "Beneficiary Claims Data API")
 }
 
 func (suite *RouterTestSuite) TestDataRoute() {
 	_, err := suite.GetStringBody(suite.dataServer.URL + "/data")
-	assert.Nil(suite.T(), err, fmt.Sprintf("Error when getting data route: %s", err))
+	assert.Nil(suite.T(), err, fmt.Sprintf("error when getting data route: %s", err))
 	//assert.Equal(suite.T(), "Hello world!", r, "Default route returned wrong body")
 }
 
 func (suite *RouterTestSuite) TestAuthTokenRoute() {
-	//	_, err := suite.GetStringBody(suite.)
+	_, err := suite.GetStringBody(suite.apiServer.URL + "/auth/token")
+	assert.Nil(suite.T(), err, fmt.Sprintf("error getting auth token route: %s", err))
 }
 
 func (suite *RouterTestSuite) TestFileServerRoute() {
 	_, err := suite.GetStringBody(suite.apiServer.URL + "/api/v1/swagger")
-	assert.Nil(suite.T(), err, fmt.Sprintf("Error when getting swagger route: %s", err))
+	assert.Nil(suite.T(), err, fmt.Sprintf("error when getting swagger route: %s", err))
 	r := chi.NewRouter()
 	// Set up a bad route.  DON'T do this in real life
 	assert.Panics(suite.T(), func() {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -61,6 +61,10 @@ func (suite *RouterTestSuite) TestDataRoute() {
 	//assert.Equal(suite.T(), "Hello world!", r, "Default route returned wrong body")
 }
 
+func (suite *RouterTestSuite) TestAuthTokenRoute() {
+	//	_, err := suite.GetStringBody(suite.)
+}
+
 func (suite *RouterTestSuite) TestFileServerRoute() {
 	_, err := suite.GetStringBody(suite.apiServer.URL + "/api/v1/swagger")
 	assert.Nil(suite.T(), err, fmt.Sprintf("Error when getting swagger route: %s", err))

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -474,6 +474,61 @@
 			"response": []
 		},
 		{
+			"name": "Get auth token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "242471cf-b883-4318-ab28-90181a59fd74",
+						"exec": [
+							"var env = pm.environment.get(\"env\");",
+							"pm.environment.set(\"clientId\", pm.globals.get(\"clientId\"));",
+							"pm.environment.set(\"clientSecret\", pm.globals.get(\"clientSecret\"));",
+							"pm.test(\"Status code is 401\", function() {",
+							"    pm.response.to.have.status(401);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{clientId}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{clientSecret}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}/auth/token",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"auth",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Get token",
 			"event": [
 				{


### PR DESCRIPTION
### Fixes [BCDA-973](https://jira.cms.gov/browse/BCDA-973)
We need an API endpoint for ACO's to get temporary access tokens.  They will present a client id and secret, and our auth provider(s) will verify and give a token if authorized.

### Proposed changes:
- A new function `GetAccessToken()` is used instead of `RequestAccessToken()` because `RequestAccessToken()` in alpha does not require a secret, and does require a TTL
- A number of testing updates solved issues that cropped up during development (especially trying to test with Okta as auth provider)
- Add endpoint to Swagger

### Security Implications
Since this will be open to all visitors in the public sandbox, and that token is the gateway to all data, any path that leads to releasing a token needs to be carefully reviewed.


### Acceptance Validation
<img width="545" alt="Screen Shot 2019-03-14 at 11 35 27 AM" src="https://user-images.githubusercontent.com/2533561/54370482-11b55280-464e-11e9-8fe1-5ce9ffb4e795.png">

### Feedback Requested
- Are we using the right return values and parameter names?
- Is there more test coverage that we could/should have?
- Are the testing changes appropriate?

