### PR TITLE
BCDA-963: (Part 3) Remove Preload() from ACO/Beneficiary retrieval

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -146,17 +146,17 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 
 	var acoBeneficiaries []models.ACOBeneficiary
 	if err = db.Find(&acoBeneficiaries, "aco_id = ?", acoID).Error; err != nil {
-		log.Error(err.Error())
+		log.Errorf("Error retrieving ACO-beneficiary with ACO ID %s: %s", acoID, err.Error())
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
 		responseutils.WriteError(oo, w, http.StatusInternalServerError)
 		return
 	}
 
-	var beneficiary models.Beneficiary
 	beneficiaryIDs := []string{}
 	for _, acoBeneficiary := range acoBeneficiaries {
-		if err = db.First(&beneficiary, "id = ?", acoBeneficiary.BeneficiaryID).Error; err != nil {
-			log.Error(err.Error())
+		var beneficiary models.Beneficiary
+		if err = db.First(&beneficiary, acoBeneficiary.BeneficiaryID).Error; err != nil {
+			log.Errorf("Error retrieving beneficiary with ID %d: %s", acoBeneficiary.BeneficiaryID, err.Error())
 			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
 			responseutils.WriteError(oo, w, http.StatusInternalServerError)
 			return

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -138,23 +138,30 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		Status:     "Pending",
 	}
 	if result := db.Save(&newJob); result.Error != nil {
-		log.Error(err)
+		log.Error(result.Error.Error())
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
 		responseutils.WriteError(oo, w, http.StatusInternalServerError)
 		return
 	}
 
 	var acoBeneficiaries []models.ACOBeneficiary
-	if db.Preload("Beneficiary").Find(&acoBeneficiaries, "aco_id = ?", acoID).RecordNotFound() {
-		log.Error(err)
+	if err = db.Find(&acoBeneficiaries, "aco_id = ?", acoID).Error; err != nil {
+		log.Error(err.Error())
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
 		responseutils.WriteError(oo, w, http.StatusInternalServerError)
 		return
 	}
 
+	var beneficiary models.Beneficiary
 	beneficiaryIDs := []string{}
 	for _, acoBeneficiary := range acoBeneficiaries {
-		beneficiaryIDs = append(beneficiaryIDs, acoBeneficiary.Beneficiary.BlueButtonID)
+		if err = db.First(&beneficiary, "id = ?", acoBeneficiary.BeneficiaryID).Error; err != nil {
+			log.Error(err.Error())
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.DbErr)
+			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			return
+		}
+		beneficiaryIDs = append(beneficiaryIDs, beneficiary.BlueButtonID)
 	}
 
 	// TODO: this checks for ?encrypt=false appended to the bulk data request URL

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -135,7 +135,7 @@ func (s *APITestSuite) TestBulkEOBRequestUserDoesNotExist() {
 	acoID := "dbbd1ce1-ae24-435c-807d-ed45953077d3"
 	userID := "82503a18-bf3b-436d-ba7b-bae09b7ffdff"
 	tokenID := "665341c9-7d0c-4844-b66f-5910d9d0822f"
-	ad := auth.AuthData{acoID, userID, tokenID}
+	ad := auth.AuthData{ACOID: acoID, UserID: userID, TokenID: tokenID}
 
 	req := httptest.NewRequest("GET", "/api/v1/ExplanationOfBenefit/$export", nil)
 	req = req.WithContext(context.WithValue(req.Context(), "ad", ad))
@@ -795,5 +795,5 @@ func TestAPITestSuite(t *testing.T) {
 }
 
 func makeContextValues(acoID string, userID string) (data auth.AuthData) {
-	return auth.AuthData{acoID, userID, uuid.NewRandom().String()}
+	return auth.AuthData{ACOID: acoID, UserID: userID, TokenID: uuid.NewRandom().String()}
 }


### PR DESCRIPTION
### Fixes [BCDA-963](https://jira.cms.gov/browse/BCDA-963)
Adjustment to query for beneficiaries in `bulkRequest()` to improve performance.

### Proposed changes:
Replace GORM `Preload()` for beneficiaries with separate queries per ACO-Beneficiary relationship. Includes some corrections to error logging.

### Acceptance Validation
Tests continue to pass. @msnook confirmed that the timeout we previously saw is no longer happening in dev with this branch.

### Feedback Requested
Any
