### PR TITLE
BCDA-534: Redact Bearer Token from URL Logs

### DIFF
--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -188,6 +188,20 @@ func (s *LoggingMiddlewareTestSuite) TestPanic() {
 	os.Setenv("BCDA_REQUEST_LOG", reqLogPathOrig)
 }
 
+func (s *LoggingMiddlewareTestSuite) TestRedact() {
+	uri := "https://www.example.com/api/endpoint?Authorization=Bearer%20abcdef.12345"
+	redacted := logging.Redact(uri)
+	assert.Equal(s.T(), "https://www.example.com/api/endpoint?Authorization=Bearer%20<redacted>", redacted)
+
+	uri = "https://www.example.com/api/endpoint?Authorization=Bearer%20abcdef.12345&Authorization=Bearer%2019dgks8gfasdf&foo=bar"
+	redacted = logging.Redact(uri)
+	assert.Equal(s.T(), "https://www.example.com/api/endpoint?Authorization=Bearer%20<redacted>&Authorization=Bearer%20<redacted>&foo=bar", redacted)
+
+	uri = "https://www.example.com/api/endpoint?foo=bar"
+	redacted = logging.Redact(uri)
+	assert.Equal(s.T(), uri, redacted)
+}
+
 func TestLoggingMiddlewareTestSuite(t *testing.T) {
 	suite.Run(t, new(LoggingMiddlewareTestSuite))
 }


### PR DESCRIPTION
### Fixes [BCDA-534](https://jira.cms.gov/browse/BCDA-534)
It's possible for Bearer tokens to end up in our Splunk logs if provided in the query string (malformed request).

### Proposed changes:
Replace `[string]` with `<redacted>` when `Bearer%20[string]` is found in a request URL before writing it to the log.

### Security Implications
This will prevent a security incident if a user places a Bearer token in the query string.

### Acceptance Validation
Includes tests and can be seen in log entries.
![Screen Shot 2019-03-20 at 5 20 24 PM](https://user-images.githubusercontent.com/1923441/54719915-7bdd6400-4b34-11e9-91b3-d1aaad771ace.png)

### Feedback Requested
Any
