### PR TITLE
BCDA-336: Check Blue Button backend certificate

### DIFF
--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -36,6 +36,130 @@ func (s *BBTestSuite) SetupTest() {
 	}
 }
 
+func (s *BBTestSuite) TestNewBlueButtonClientNoCertFile() {
+	origCertFile := os.Getenv("BB_CLIENT_CERT_FILE")
+	defer os.Setenv("BB_CLIENT_CERT_FILE", origCertFile)
+
+	assert := assert.New(s.T())
+
+	os.Unsetenv("BB_CLIENT_CERT_FILE")
+	bbc, err := client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+
+	os.Setenv("BB_CLIENT_CERT_FILE", "foo.pem")
+	bbc, err = client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+}
+
+func (s *BBTestSuite) TestNewBlueButtonClientInvalidCertFile() {
+	origCertFile := os.Getenv("BB_CLIENT_CERT_FILE")
+	defer os.Setenv("BB_CLIENT_CERT_FILE", origCertFile)
+
+	assert := assert.New(s.T())
+
+	os.Setenv("BB_CLIENT_CERT_FILE", "../static/emptyFile.pem")
+	bbc, err := client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+
+	os.Setenv("BB_CLIENT_CERT_FILE", "../static/badPublic.pem")
+	bbc, err = client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+}
+
+func (s *BBTestSuite) TestNewBlueButtonClientNoKeyFile() {
+	origKeyFile := os.Getenv("BB_CLIENT_KEY_FILE")
+	defer os.Setenv("BB_CLIENT_KEY_FILE", origKeyFile)
+
+	assert := assert.New(s.T())
+
+	os.Unsetenv("BB_CLIENT_KEY_FILE")
+	bbc, err := client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+
+	os.Setenv("BB_CLIENT_KEY_FILE", "foo.pem")
+	bbc, err = client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+}
+
+func (s *BBTestSuite) TestNewBlueButtonClientInvalidKeyFile() {
+	origKeyFile := os.Getenv("BB_CLIENT_KEY_FILE")
+	defer os.Setenv("BB_CLIENT_KEY_FILE", origKeyFile)
+
+	assert := assert.New(s.T())
+
+	os.Setenv("BB_CLIENT_KEY_FILE", "../static/emptyFile.pem")
+	bbc, err := client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+
+	os.Setenv("BB_CLIENT_KEY_FILE", "../static/badPublic.pem")
+	bbc, err = client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not load Blue Button keypair")
+}
+
+func (s *BBTestSuite) TestNewBlueButtonClientNoCAFile() {
+	origCAFile := os.Getenv("BB_CLIENT_CA_FILE")
+	origCheckCert := os.Getenv("BB_CHECK_CERT")
+	defer func() {
+		os.Setenv("BB_CLIENT_CA_FILE", origCAFile)
+		os.Setenv("BB_CHECK_CERT", origCheckCert)
+	}()
+
+	assert := assert.New(s.T())
+
+	os.Unsetenv("BB_CLIENT_CA_FILE")
+	os.Unsetenv("BB_CHECK_CERT")
+	bbc, err := client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not read CA file")
+
+	os.Setenv("BB_CLIENT_CA_FILE", "foo.pem")
+	bbc, err = client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "could not read CA file")
+}
+
+func (s *BBTestSuite) TestNewBlueButtonClientInvalidCAFile() {
+	origCAFile := os.Getenv("BB_CLIENT_CA_FILE")
+	origCheckCert := os.Getenv("BB_CHECK_CERT")
+	defer func() {
+		os.Setenv("BB_CLIENT_CA_FILE", origCAFile)
+		os.Setenv("BB_CHECK_CERT", origCheckCert)
+	}()
+
+	assert := assert.New(s.T())
+
+	os.Setenv("BB_CLIENT_CA_FILE", "../static/emptyFile.pem")
+	os.Unsetenv("BB_CHECK_CERT")
+	bbc, err := client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.EqualError(err, "could not append CA certificate(s)")
+
+	os.Setenv("BB_CLIENT_CA_FILE", "../static/badPublic.pem")
+	bbc, err = client.NewBlueButtonClient()
+	assert.Nil(bbc)
+	assert.NotNil(err)
+	assert.EqualError(err, "could not append CA certificate(s)")
+}
+
 func (s *BBTestSuite) TestGetBlueButtonPatientData() {
 	p, err := s.bbClient.GetPatientData("012345", "543210")
 	assert.Nil(s.T(), err)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,6 +16,7 @@ services:
       - BB_CLIENT_CERT_FILE=../shared_files/bb-dev-test-key.pem
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us
+      - BB_CHECK_CERT=false
       - FHIR_PAYLOAD_DIR=../bcdaworker/data
       - FHIR_STAGING_DIR=../bcdaworker/tmpdata
       - FHIR_ARCHIVE_DIR=../bcdaworker/archive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - BB_CLIENT_CERT_FILE=../shared_files/bb-dev-test-cert.pem
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us
+      - BB_CHECK_CERT=false
       - OKTA_CLIENT_ORGURL=https://cms-sandbox.oktapreview.com
       - OKTA_EMAIL=shawn@bcda.aco-group.us
       - OKTA_CLIENT_TOKEN=${OKTA_CLIENT_TOKEN}
@@ -70,6 +71,7 @@ services:
       - BB_CLIENT_CERT_FILE=../shared_files/bb-dev-test-cert.pem
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem 
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us
+      - BB_CHECK_CERT=false
       - BB_TIMEOUT_MS=500
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
       - BB_CLIENT_CERT_FILE=../shared_files/bb-dev-test-cert.pem
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us
-      - BB_CHECK_CERT=false
       - OKTA_CLIENT_ORGURL=https://cms-sandbox.oktapreview.com
       - OKTA_EMAIL=shawn@bcda.aco-group.us
       - OKTA_CLIENT_TOKEN=${OKTA_CLIENT_TOKEN}


### PR DESCRIPTION
### Fixes [BCDA-336](https://jira.cms.gov/browse/BCDA-336)
The Blue Button dev environment certificate can change. Currently we are checking the certificate (or not) based on URL, but using an environment variable instead would allow us to configure it by environment, regardless of BB URL.

### Proposed changes:
Add `BB_CHECK_CERT` environment variable that, when `false`, indicates that the Blue Button backend certificate should not be checked.

### Change Details
* Creates `BB_CHECK_CERT` that is used in bluebutton.go. If not explicitly set to false, the certificate will be checked.
* Adds tests for missing or invalid keypair and CA cert files

### Security Implications
By default, the Blue Button backend certificate will be checked. `BB_CHECK_CERT` needs to be set to `false` to skip adding the certificate to the Blue Button client TLS config.

### Acceptance Validation
Tests pass.

### Feedback Requested
Any.