### PR TITLE
BCDA-1032 implement delete client func for alpha

### DIFF
--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -63,8 +63,23 @@ func (p AlphaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
 	return nil, errors.New("not yet implemented")
 }
 
-func (p AlphaAuthPlugin) DeleteClient(params []byte) error {
-	return errors.New("not yet implemented")
+func (p AlphaAuthPlugin) DeleteClient(clientID string) error {
+	aco, err := GetACOByClientID(clientID)
+	if err != nil {
+		return err
+	}
+
+	aco.ClientID = ""
+	aco.AlphaSecret = ""
+
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+	err = db.Save(&aco).Error
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p AlphaAuthPlugin) GenerateClientCredentials(clientID string, ttl int) (Credentials, error) {
@@ -155,9 +170,9 @@ func (p AlphaAuthPlugin) MakeAccessToken(credentials Credentials) (string, error
 	if credentials.ClientSecret == "" || credentials.ClientID == "" {
 		return "", fmt.Errorf("missing or incomplete credentials")
 	}
-	aco, err := getACOByClientID(credentials.ClientID)
+	aco, err := GetACOByClientID(credentials.ClientID)
 	if err != nil {
-		return "", fmt.Errorf("invalid credentials; %s",err)
+		return "", fmt.Errorf("invalid credentials; %s", err)
 	}
 	// when we have ClientSecret in ACO, adjust following line
 	Hash(aco.AlphaSecret).IsHashOf(credentials.ClientSecret)

--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -87,8 +87,18 @@ func (s *AlphaAuthPluginTestSuite) TestUpdateClient() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestDeleteClient() {
-	err := s.p.DeleteClient([]byte(`{}`))
-	assert.Equal(s.T(), "not yet implemented", err.Error())
+	cmsID := testUtils.RandomHexID()[0:4]
+	acoUUID, _ := models.CreateACO("TestRegisterClient", &cmsID)
+	c, _ := s.p.RegisterClient(acoUUID.String())
+	aco, _ := auth.GetACOByClientID(c.ClientID)
+	assert.NotEmpty(s.T(), aco.ClientID)
+	assert.NotEmpty(s.T(), aco.AlphaSecret)
+
+	err := s.p.DeleteClient(c.ClientID)
+	assert.Nil(s.T(), err)
+	aco, _ = auth.GetACOByClientID(c.ClientID)
+	assert.Empty(s.T(), aco.ClientID)
+	assert.Empty(s.T(), aco.AlphaSecret)
 }
 
 func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -48,7 +48,7 @@ func ParseToken(next http.Handler) http.Handler {
 		if claims, ok := token.Claims.(*CommonClaims); ok && token.Valid {
 			// okta token
 			if claims.ClientID != "" && claims.Subject == claims.ClientID {
-				var aco, err = getACOByClientID(claims.ClientID)
+				var aco, err = GetACOByClientID(claims.ClientID)
 				if err != nil {
 					log.Errorf("no aco for clientID %s because %v", claims.ClientID, err)
 					next.ServeHTTP(w, r)

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/CMSgov/bcda-app/bcda/auth/client"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
@@ -58,7 +56,7 @@ func (o OktaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
 	return nil, errors.New("not yet implemented")
 }
 
-func (o OktaAuthPlugin) DeleteClient(params []byte) error {
+func (o OktaAuthPlugin) DeleteClient(clientID string) error {
 	return errors.New("not yet implemented")
 }
 
@@ -84,7 +82,6 @@ func (o OktaAuthPlugin) RevokeClientCredentials(clientID string) error {
 
 	return nil
 }
-
 
 // Manufactures an access token for the given credentials
 func (o OktaAuthPlugin) MakeAccessToken(credentials Credentials) (string, error) {
@@ -143,7 +140,7 @@ func (o OktaAuthPlugin) ValidateJWT(tokenString string) error {
 	// keep an in-memory cache of tokens we have revoked and check that
 	// use the introspection endpoint okta provides (expensive network call)
 
-	_, err = getACOByClientID(c.ClientID)
+	_, err = GetACOByClientID(c.ClientID)
 	if err != nil {
 		return fmt.Errorf("invalid cid claim; %s", err)
 	}
@@ -171,18 +168,4 @@ func (o OktaAuthPlugin) DecodeJWT(tokenString string) (*jwt.Token, error) {
 	}
 
 	return jwt.ParseWithClaims(tokenString, &CommonClaims{}, keyFinder)
-}
-
-func getACOByClientID(clientID string) (models.ACO, error) {
-	var (
-		db  = database.GetGORMDbConnection()
-		aco models.ACO
-		err error
-	)
-	defer database.Close(db)
-
-	if db.Find(&aco, "client_id = ?", clientID).RecordNotFound() {
-		err = errors.New("no ACO record found for " + clientID)
-	}
-	return aco, err
 }

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -64,7 +64,7 @@ func (s *OktaAuthPluginTestSuite) TestOktaUpdateClient() {
 }
 
 func (s *OktaAuthPluginTestSuite) TestOktaDeleteClient() {
-	err := s.o.DeleteClient([]byte("{}"))
+	err := s.o.DeleteClient("")
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -74,7 +74,7 @@ type Provider interface {
 	UpdateClient(params []byte) ([]byte, error)
 
 	// DeleteClient deletes the registered software client identified by clientID, revoking an active tokens
-	DeleteClient(params []byte) error
+	DeleteClient(clientID string) error
 
 	// GenerateClientCredentials new or replace existing Credentials for the given clientID
 	GenerateClientCredentials(clientID string, ttl int) (Credentials, error)


### PR DESCRIPTION
### Fixes [BCDA-1032](https://jira.cms.gov/browse/BCDA-1032)
We need a way to delete a client in the alpha auth plugin so that Eric and Jason can sleep at night.

### Proposed changes:
- implement  the DeleteClient() func for alpha

### Change Details
Since registering a client in alpha is really just generating a clientID and an alphaSecret on the ACO model, to delete the client, we will simply set these values on the db record for the ACO back to an empty string

### Feedback Requested
Anything you can think of!
