### PR TITLE
BCDA-846: Add testing of api routes in router_test.go

### DIFF
--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -90,8 +90,28 @@ func (s *RouterTestSuite) TestMetadataRoute() {
 }
 
 func (s *RouterTestSuite) TestTokenRoute() {
-	res := s.getAPIRoute("/api/v1/token")
+	origCovExp := os.Getenv("ENABLE_COVERAGE_EXPORT")
+	defer os.Setenv("ENABLE_COVERAGE_EXPORT", origCovExp)
+
+	os.Setenv("DEBUG", "true")
+	req := httptest.NewRequest("GET", "/api/v1/token", nil)
+	rr := httptest.NewRecorder()
+	NewAPIRouter().ServeHTTP(rr, req)
+	res := rr.Result()
 	assert.Equal(s.T(), 200, res.StatusCode)
+
+	os.Setenv("DEBUG", "false")
+	rr = httptest.NewRecorder()
+	NewAPIRouter().ServeHTTP(rr, req)
+	res = rr.Result()
+	assert.Equal(s.T(), 404, res.StatusCode)
+
+	os.Unsetenv("DEBUG")
+	rr = httptest.NewRecorder()
+	NewAPIRouter().ServeHTTP(rr, req)
+	res = rr.Result()
+	assert.Equal(s.T(), 404, res.StatusCode)
+
 }
 
 func (s *RouterTestSuite) TestHealthRoute() {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -21,62 +21,146 @@ type RouterTestSuite struct {
 	rr         *httptest.ResponseRecorder
 }
 
-func (suite *RouterTestSuite) SetupTest() {
+func (s *RouterTestSuite) SetupTest() {
 	os.Setenv("DEBUG", "true")
-	suite.apiServer = httptest.NewServer(NewAPIRouter())
-	suite.dataServer = httptest.NewServer(NewDataRouter())
-	suite.rr = httptest.NewRecorder()
+	s.apiServer = httptest.NewServer(NewAPIRouter())
+	s.dataServer = httptest.NewServer(NewDataRouter())
 }
 
-func (suite *RouterTestSuite) TearDownTest() {
-	suite.apiServer.Close()
-	suite.dataServer.Close()
+func (s *RouterTestSuite) TearDownTest() {
+	s.apiServer.Close()
+	s.dataServer.Close()
 }
 
-func (suite *RouterTestSuite) GetStringBody(url string) (string, error) {
-	client := suite.apiServer.Client()
-	res, err := client.Get(url)
-	if err != nil {
-		return "", err
-	}
+func (s *RouterTestSuite) TestDefaultRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 200, res.StatusCode)
 
 	bytes, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s", bytes), nil
+	assert.Nil(s.T(), err)
+	r := string(bytes)
+	assert.NotContains(s.T(), r, "404 page not found", "Default route returned wrong body")
+	assert.Contains(s.T(), r, "Beneficiary Claims Data API")
 }
 
-func (suite *RouterTestSuite) TestDefaultRoute() {
-	r, err := suite.GetStringBody(suite.apiServer.URL)
-	assert.Nil(suite.T(), err, fmt.Sprintf("error when getting default route: %s", err))
-	assert.NotContains(suite.T(), r, "404 page not found", "Default route returned wrong body")
-	assert.Contains(suite.T(), r, "Beneficiary Claims Data API")
+func (s *RouterTestSuite) TestDataRoute() {
+	res, err := s.apiServer.Client().Get(s.dataServer.URL + "/data/test/test.ndjson")
+	assert.Nil(s.T(), err, fmt.Sprintf("error when getting data route: %s", err))
+	assert.Equal(s.T(), 401, res.StatusCode)
 }
 
-func (suite *RouterTestSuite) TestDataRoute() {
-	_, err := suite.GetStringBody(suite.dataServer.URL + "/data")
-	assert.Nil(suite.T(), err, fmt.Sprintf("error when getting data route: %s", err))
-	//assert.Equal(suite.T(), "Hello world!", r, "Default route returned wrong body")
+func (s *RouterTestSuite) TestAuthTokenRoute() {
+	res, err := s.apiServer.Client().Post(s.apiServer.URL+"/auth/token", "", nil)
+	assert.Nil(s.T(), err, fmt.Sprintf("error getting auth token route: %s", err))
+	assert.Equal(s.T(), 400, res.StatusCode)
 }
 
-func (suite *RouterTestSuite) TestAuthTokenRoute() {
-	_, err := suite.GetStringBody(suite.apiServer.URL + "/auth/token")
-	assert.Nil(suite.T(), err, fmt.Sprintf("error getting auth token route: %s", err))
-}
+func (s *RouterTestSuite) TestFileServerRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/api/v1/swagger")
+	assert.Nil(s.T(), err, fmt.Sprintf("error when getting swagger route: %s", err))
+	assert.Equal(s.T(), 200, res.StatusCode)
 
-func (suite *RouterTestSuite) TestFileServerRoute() {
-	_, err := suite.GetStringBody(suite.apiServer.URL + "/api/v1/swagger")
-	assert.Nil(suite.T(), err, fmt.Sprintf("error when getting swagger route: %s", err))
 	r := chi.NewRouter()
 	// Set up a bad route.  DON'T do this in real life
-	assert.Panics(suite.T(), func() {
+	assert.Panics(s.T(), func() {
 		FileServer(r, "/api/v1/swagger{}", http.Dir("./swaggerui"))
 	})
 }
 
-func (suite *RouterTestSuite) TestHTTPServerRedirect() {
+func (s *RouterTestSuite) TestMetadataRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/api/v1/metadata")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 200, res.StatusCode)
+
+	bytes, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	assert.Nil(s.T(), err)
+	assert.Contains(s.T(), string(bytes), "resourceType")
+}
+
+func (s *RouterTestSuite) TestTokenRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/api/v1/token")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 200, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestHealthRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/_health")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 200, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestVersionRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/_version")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 200, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestEOBExportRoute() {
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/api/v1/ExplanationOfBenefit/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 401, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestPatientExportRoute() {
+	origPtExp := os.Getenv("ENABLE_PATIENT_EXPORT")
+	defer os.Setenv("ENABLE_PATIENT_EXPORT", origPtExp)
+
+	os.Setenv("ENABLE_PATIENT_EXPORT", "true")
+	apiServer := httptest.NewServer(NewAPIRouter())
+	client := apiServer.Client()
+	res, err := client.Get(apiServer.URL + "/api/v1/Patient/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 401, res.StatusCode)
+
+	os.Setenv("ENABLE_PATIENT_EXPORT", "false")
+	apiServer.Config.Handler = NewAPIRouter()
+	res, err = client.Get(apiServer.URL + "/api/v1/Patient/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 404, res.StatusCode)
+
+	os.Unsetenv("ENABLE_PATIENT_EXPORT")
+	apiServer.Config.Handler = NewAPIRouter()
+	res, err = client.Get(apiServer.URL + "/api/v1/Patient/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 404, res.StatusCode)
+
+	apiServer.Close()
+}
+
+func (s *RouterTestSuite) TestCoverageExportRoute() {
+	origCovExp := os.Getenv("ENABLE_COVERAGE_EXPORT")
+	defer os.Setenv("ENABLE_COVERAGE_EXPORT", origCovExp)
+
+	os.Setenv("ENABLE_COVERAGE_EXPORT", "true")
+	apiServer := httptest.NewServer(NewAPIRouter())
+	client := apiServer.Client()
+	res, err := client.Get(apiServer.URL + "/api/v1/Coverage/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 401, res.StatusCode)
+
+	os.Setenv("ENABLE_COVERAGE_EXPORT", "false")
+	apiServer.Config.Handler = NewAPIRouter()
+	res, err = client.Get(apiServer.URL + "/api/v1/Coverage/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 404, res.StatusCode)
+
+	os.Unsetenv("ENABLE_COVERAGE_EXPORT")
+	apiServer.Config.Handler = NewAPIRouter()
+	res, err = client.Get(apiServer.URL + "/api/v1/Coverage/$export")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 404, res.StatusCode)
+
+	apiServer.Close()
+}
+
+func (s *RouterTestSuite) TestJobStatusRoute() {
+
+}
+
+func (s *RouterTestSuite) TestHTTPServerRedirect() {
 	router := NewHTTPRouter()
 
 	// Redirect GET http requests to https
@@ -89,10 +173,10 @@ func (suite *RouterTestSuite) TestHTTPServerRedirect() {
 	router.ServeHTTP(w, req)
 	res := w.Result()
 
-	assert.Nil(suite.T(), err, "redirect GET http to https")
-	assert.Equal(suite.T(), 301, res.StatusCode, "http to https redirect return correct status code")
-	assert.Equal(suite.T(), "close", res.Header.Get("Connection"), "http to https redirect sets 'connection: close' header")
-	assert.Contains(suite.T(), res.Header.Get("Location"), "https://", "location response header contains 'https://'")
+	assert.Nil(s.T(), err, "redirect GET http to https")
+	assert.Equal(s.T(), 301, res.StatusCode, "http to https redirect return correct status code")
+	assert.Equal(s.T(), "close", res.Header.Get("Connection"), "http to https redirect sets 'connection: close' header")
+	assert.Contains(s.T(), res.Header.Get("Location"), "https://", "location response header contains 'https://'")
 
 	// Only respond to GET requests
 	req, err = http.NewRequest("POST", "/", nil)
@@ -104,8 +188,8 @@ func (suite *RouterTestSuite) TestHTTPServerRedirect() {
 	router.ServeHTTP(w, req)
 	res = w.Result()
 
-	assert.Nil(suite.T(), err, "redirect POST http to https")
-	assert.Equal(suite.T(), 405, res.StatusCode, "http to https redirect rejects POST requests")
+	assert.Nil(s.T(), err, "redirect POST http to https")
+	assert.Equal(s.T(), 405, res.StatusCode, "http to https redirect rejects POST requests")
 }
 
 func TestRouterTestSuite(t *testing.T) {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -90,8 +90,8 @@ func (s *RouterTestSuite) TestMetadataRoute() {
 }
 
 func (s *RouterTestSuite) TestTokenRoute() {
-	origCovExp := os.Getenv("ENABLE_COVERAGE_EXPORT")
-	defer os.Setenv("ENABLE_COVERAGE_EXPORT", origCovExp)
+	origDebug := os.Getenv("DEBUG")
+	defer os.Setenv("DEBUG", origDebug)
 
 	os.Setenv("DEBUG", "true")
 	req := httptest.NewRequest("GET", "/api/v1/token", nil)

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -157,7 +157,9 @@ func (s *RouterTestSuite) TestCoverageExportRoute() {
 }
 
 func (s *RouterTestSuite) TestJobStatusRoute() {
-
+	res, err := s.apiServer.Client().Get(s.apiServer.URL + "/api/v1/jobs/1")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 401, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestHTTPServerRedirect() {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -49,7 +49,7 @@ func (s *RouterTestSuite) getDataRoute(route string) *http.Response {
 
 func (s *RouterTestSuite) TestDefaultRoute() {
 	res := s.getAPIRoute("/")
-	assert.Equal(s.T(), 200, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 	body, _ := ioutil.ReadAll(res.Body)
 	assert.NotContains(s.T(), string(body), "404 page not found", "Default route returned wrong body")
 	assert.Contains(s.T(), string(body), "Beneficiary Claims Data API")
@@ -57,20 +57,20 @@ func (s *RouterTestSuite) TestDefaultRoute() {
 
 func (s *RouterTestSuite) TestDataRoute() {
 	res := s.getDataRoute("/data/test/test.ndjson")
-	assert.Equal(s.T(), 401, res.StatusCode)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestAuthTokenRoute() {
 	res := s.postAPIRoute("/auth/token", nil)
-	assert.Equal(s.T(), 400, res.StatusCode)
+	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestFileServerRoute() {
 	res := s.getAPIRoute("/api/v1/swagger")
-	assert.Equal(s.T(), 301, res.StatusCode)
+	assert.Equal(s.T(), http.StatusMovedPermanently, res.StatusCode)
 
 	res = s.getAPIRoute("/api/v1/swagger/")
-	assert.Equal(s.T(), 200, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 
 	r := chi.NewRouter()
 	// Set up a bad route.  DON'T do this in real life
@@ -81,7 +81,7 @@ func (s *RouterTestSuite) TestFileServerRoute() {
 
 func (s *RouterTestSuite) TestMetadataRoute() {
 	res := s.getAPIRoute("/api/v1/metadata")
-	assert.Equal(s.T(), 200, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 
 	bytes, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
@@ -98,35 +98,35 @@ func (s *RouterTestSuite) TestTokenRoute() {
 	rr := httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res := rr.Result()
-	assert.Equal(s.T(), 200, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 
 	os.Setenv("DEBUG", "false")
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
-	assert.Equal(s.T(), 404, res.StatusCode)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 
 	os.Unsetenv("DEBUG")
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
-	assert.Equal(s.T(), 404, res.StatusCode)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 
 }
 
 func (s *RouterTestSuite) TestHealthRoute() {
 	res := s.getAPIRoute("/_health")
-	assert.Equal(s.T(), 200, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestVersionRoute() {
 	res := s.getAPIRoute("/_version")
-	assert.Equal(s.T(), 200, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestEOBExportRoute() {
 	res := s.getAPIRoute("/api/v1/ExplanationOfBenefit/$export")
-	assert.Equal(s.T(), 401, res.StatusCode)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestPatientExportRoute() {
@@ -138,19 +138,19 @@ func (s *RouterTestSuite) TestPatientExportRoute() {
 	rr := httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res := rr.Result()
-	assert.Equal(s.T(), 401, res.StatusCode)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 
 	os.Setenv("ENABLE_PATIENT_EXPORT", "false")
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
-	assert.Equal(s.T(), 404, res.StatusCode)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 
 	os.Unsetenv("ENABLE_PATIENT_EXPORT")
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
-	assert.Equal(s.T(), 404, res.StatusCode)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestCoverageExportRoute() {
@@ -162,24 +162,24 @@ func (s *RouterTestSuite) TestCoverageExportRoute() {
 	rr := httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res := rr.Result()
-	assert.Equal(s.T(), 401, res.StatusCode)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 
 	os.Setenv("ENABLE_COVERAGE_EXPORT", "false")
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
-	assert.Equal(s.T(), 404, res.StatusCode)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 
 	os.Unsetenv("ENABLE_COVERAGE_EXPORT")
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
-	assert.Equal(s.T(), 404, res.StatusCode)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestJobStatusRoute() {
 	res := s.getAPIRoute("/api/v1/jobs/1")
-	assert.Equal(s.T(), 401, res.StatusCode)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestHTTPServerRedirect() {
@@ -196,7 +196,7 @@ func (s *RouterTestSuite) TestHTTPServerRedirect() {
 	res := w.Result()
 
 	assert.Nil(s.T(), err, "redirect GET http to https")
-	assert.Equal(s.T(), 301, res.StatusCode, "http to https redirect return correct status code")
+	assert.Equal(s.T(), http.StatusMovedPermanently, res.StatusCode, "http to https redirect return correct status code")
 	assert.Equal(s.T(), "close", res.Header.Get("Connection"), "http to https redirect sets 'connection: close' header")
 	assert.Contains(s.T(), res.Header.Get("Location"), "https://", "location response header contains 'https://'")
 
@@ -211,7 +211,7 @@ func (s *RouterTestSuite) TestHTTPServerRedirect() {
 	res = w.Result()
 
 	assert.Nil(s.T(), err, "redirect POST http to https")
-	assert.Equal(s.T(), 405, res.StatusCode, "http to https redirect rejects POST requests")
+	assert.Equal(s.T(), http.StatusMethodNotAllowed, res.StatusCode, "http to https redirect rejects POST requests")
 }
 
 func TestRouterTestSuite(t *testing.T) {


### PR DESCRIPTION
### Fixes [BCDA-846](https://jira.cms.gov/browse/BCDA-846)
router_test.go does not contain tests for all API routes.

### Proposed changes:
Add tests for all API routes.

### Change Details
* New tests for:
  * /api/v1/ExplanationOfBenefit/$export
  * /api/v1/Patient/$export, with multiple values for env var `ENABLE_PATIENT_EXPORT`
  * /api/v1/Coverage/$export, with multiple values for env var `ENABLE_COVERAGE_EXPORT`
  * /api/v1/jobs/{jobId}
  * /api/v1/metdata
  * /api/v1/token, with multiple values for env var `DEBUG`
  * /_health
  * /_version
* New helper functions in router_test.go
* Change `RouterTestSuite` struct to include API and data router `http.Handler`s rather than `httptest` servers

### Security Implications
None; tests only

### Acceptance Validation
Tests pass

### Feedback Requested
Any