### PR TITLE
BCDA-777 part 2 Feature: added Coverage as a swagger parameter to the BulkRequestHeader

### DIFF
--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -128,7 +128,7 @@ type FileParam struct {
 	Filename string `json:"filename"`
 }
 
-// swagger:parameters bulkPatientRequest bulkEOBRequest
+// swagger:parameters bulkPatientRequest bulkEOBRequest bulkCoverageRequest
 type BulkRequestHeaders struct {
 	// required: true
 	// in: header


### PR DESCRIPTION
Fixes [BCDA-777](https://jira.cms.gov/browse/BCDA-777)

Problem:
When running a coverage request via swagger a missing header was found.

Proposed changes:
bcda/models/SwaggerStructs.go - added bulkCoverageRequest to the BulkRequestHeaders struct.
This should fix the structural issue with the prefer header

Security Implications:
None

Acceptance Validation:
Ran locally and didn't see the structural issue for the prefer header.

<img width="1377" alt="result" src="https://user-images.githubusercontent.com/42976557/55572538-cbe02d00-56d5-11e9-8ec7-199800d4df24.png">

Feedback Requested:
Any and all