### PR TITLE
BCDA-1182: Log worker health check errors

### DIFF
--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -17,18 +17,30 @@ func IsDatabaseOK() bool {
 		}
 	}()
 	if err != nil {
+		log.Error("Database connection check encountered an error:", err.Error())
 		return false
 	}
 
-	return db.Ping() == nil
+	if db.Ping() != nil {
+		log.Error("Database connection check could not reach database")
+		return false
+	}
+
+	return true
 }
 
 func IsBlueButtonOK() bool {
 	bbc, err := client.NewBlueButtonClient()
 	if err != nil {
+		log.Error("Blue Button connection check could not create client due to error:", err.Error())
 		return false
 	}
 
 	_, err = bbc.GetMetadata()
-	return err == nil
+	if err != nil {
+		log.Error("Blue Button connection check encountered an error:", err.Error())
+		return false
+	}
+
+	return true
 }

--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -11,18 +11,18 @@ import (
 
 func IsDatabaseOK() bool {
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Error("Health check: database connection error: ", err.Error())
+		return false
+	}
 	defer func() {
 		if err := db.Close(); err != nil {
 			log.Infof("failed to close db connection at bcda/health/health.go#IsDatabaseOK() because %s", err)
 		}
 	}()
-	if err != nil {
-		log.Error("Database connection check encountered an error:", err.Error())
-		return false
-	}
 
-	if db.Ping() != nil {
-		log.Error("Database connection check could not reach database")
+	if err := db.Ping(); err != nil {
+		log.Error("Health check: database ping error: ", err.Error())
 		return false
 	}
 
@@ -32,13 +32,13 @@ func IsDatabaseOK() bool {
 func IsBlueButtonOK() bool {
 	bbc, err := client.NewBlueButtonClient()
 	if err != nil {
-		log.Error("Blue Button connection check could not create client due to error:", err.Error())
+		log.Error("Health check: Blue Button client error: ", err.Error())
 		return false
 	}
 
 	_, err = bbc.GetMetadata()
 	if err != nil {
-		log.Error("Blue Button connection check encountered an error:", err.Error())
+		log.Error("Health check: Blue Button connection error: ", err.Error())
 		return false
 	}
 


### PR DESCRIPTION
### Fixes [BCDA-1182](https://jira.cms.gov/browse/BCDA-1182)
Although we have a health check log for bcdaworker, it does not indicate the cause of errors reported.

### Proposed changes:
Log database and Blue Button connection errors from worker health checks.

### Change Details
* Adds `log.Error()` calls in `health.IsDatabaseOK()` and `health.IsBlueButtonOK` for error scenarios. These write to the standard worker log.

### Security Implications
No PII involved. This logs errors encountered when checking connectivity to the BCDA database and to the Blue Button metadata endpoint.

### Acceptance Validation
Error examples:
* Invalid database driver:
![Screen Shot 2019-04-05 at 4 07 32 PM](https://user-images.githubusercontent.com/1923441/55653574-ff49b700-57bc-11e9-9099-6f3779bb9aa6.png)
* Database shut down:
![Screen Shot 2019-04-05 at 3 57 27 PM](https://user-images.githubusercontent.com/1923441/55653130-87c75800-57bb-11e9-97e2-b0f3b7c70c1c.png)
* Blue Button key file does not exist:
![Screen Shot 2019-04-05 at 4 10 21 PM](https://user-images.githubusercontent.com/1923441/55653707-59e31300-57bd-11e9-8efb-8fd17334a178.png)
* Invalid Blue Button URL:
![Screen Shot 2019-04-05 at 3 53 46 PM](https://user-images.githubusercontent.com/1923441/55652941-04a60200-57bb-11e9-8f06-679b1db624e2.png)

### Feedback Requested
Any.
