### PR TITLE
BCDA-1143 Maintenance: Separate Auth API Methods from BCDA API

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -376,53 +376,6 @@ func serveData(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, fmt.Sprintf("%s/%s/%s", dataDir, jobID, fileName))
 }
 
-/*
-	swagger:route POST /auth/token auth getAuthToken
-
-	Get access token
-
-	Verifies Basic authentication credentials, and returns a JWT bearer token that can be presented to the other API endpoints.
-
-	Produces:
-	- application/json
-
-	Schemes: https
-
-	Security:
-		basic_auth:
-
-	Responses:
-		200: tokenResponse
-		400: missingCredentials
-		401: invalidCredentials
-		500: serverError
-*/
-func getAuthToken(w http.ResponseWriter, r *http.Request) {
-	clientId, secret, ok := r.BasicAuth()
-	if !ok {
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-		return
-	}
-
-	token, err := auth.GetProvider().MakeAccessToken(auth.Credentials{ClientID: clientId, ClientSecret: secret})
-	if err != nil {
-		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-		return
-	}
-
-	// https://tools.ietf.org/html/rfc6749#section-5.1
-	// not included: recommended field expires_in
-	body := []byte(fmt.Sprintf(`{"access_token": "%s","token_type":"bearer"}`, token))
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	_, err = w.Write(body)
-	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-	}
-	log.WithField("client_id", clientId).Println("issued access token")
-}
-
 func getToken(w http.ResponseWriter, r *http.Request) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -667,7 +667,7 @@ func (s *APITestSuite) TestAuthToken() {
 	s.SetupAuthBackend()
 	req := httptest.NewRequest("POST", "/auth/token", nil)
 
-	handler := http.HandlerFunc(getAuthToken)
+	handler := http.HandlerFunc(auth.GetAuthToken)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)

--- a/bcda/api_test.go
+++ b/bcda/api_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"regexp"
 	"testing"
 	"time"
 
@@ -27,11 +26,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 )
-
-type TokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-}
 
 type APITestSuite struct {
 	testUtils.AuthTestSuite
@@ -667,59 +661,6 @@ func (s *APITestSuite) TestGetToken() {
 
 	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
 	assert.NotEmpty(s.T(), s.rr.Body)
-}
-
-func (s *APITestSuite) TestAuthToken() {
-	s.SetupAuthBackend()
-
-	// Missing authorization header
-	req := httptest.NewRequest("POST", "/auth/token", nil)
-	handler := http.HandlerFunc(auth.GetAuthToken)
-	fmt.Println("No authorization header")
-	handler.ServeHTTP(s.rr, req)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
-
-	// Malformed authorization header
-	s.rr = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/auth/token", nil)
-	req.Header.Add("Authorization", "Basic not_an_encoded_client_and_secret")
-	req.Header.Add("Accept", "application/json")
-	handler = http.HandlerFunc(auth.GetAuthToken)
-	fmt.Println("Malformed authorization header")
-	handler.ServeHTTP(s.rr, req)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
-
-	// Invalid credentials
-	s.rr = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/auth/token", nil)
-	req.SetBasicAuth("not_a_client", "not_a_secret")
-	req.Header.Add("Accept", "application/json")
-	fmt.Println("Invalid credentials")
-	handler = http.HandlerFunc(auth.GetAuthToken)
-	handler.ServeHTTP(s.rr, req)
-	assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
-
-	// Success!?
-	s.rr = httptest.NewRecorder()
-	t := TokenResponse{}
-	outputPattern := regexp.MustCompile(`.+\n(.+)\n(.+)`)
-	tokenResp, _ := createAlphaToken(60, "Dev")
-	assert.Regexp(s.T(), outputPattern, tokenResp)
-	matches := outputPattern.FindSubmatch([]byte(tokenResp))
-	clientID := string(matches[1])
-	clientSecret := string(matches[2])
-	assert.NotEmpty(s.T(), clientID)
-	assert.NotEmpty(s.T(), clientSecret)
-
-	req = httptest.NewRequest("POST", "/auth/token", nil)
-	req.SetBasicAuth(clientID, clientSecret)
-	req.Header.Add("Accept", "application/json")
-	handler = http.HandlerFunc(auth.GetAuthToken)
-	handler.ServeHTTP(s.rr, req)
-	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
-	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
-	assert.NotEmpty(s.T(), t)
-	assert.NotEmpty(s.T(), t.AccessToken)
 }
 
 func (s *APITestSuite) TestMetadata() {

--- a/bcda/auth/api.go
+++ b/bcda/auth/api.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+/*
+	swagger:route POST /auth/token auth getAuthToken
+
+	Get access token
+
+	Verifies Basic authentication credentials, and returns a JWT bearer token that can be presented to the other API endpoints.
+
+	Produces:
+	- application/json
+
+	Schemes: https
+
+	Security:
+		basic_auth:
+
+	Responses:
+		200: tokenResponse
+		400: missingCredentials
+		401: invalidCredentials
+		500: serverError
+*/
+func GetAuthToken(w http.ResponseWriter, r *http.Request) {
+	clientId, secret, ok := r.BasicAuth()
+	if !ok {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	token, err := GetProvider().MakeAccessToken(Credentials{ClientID: clientId, ClientSecret: secret})
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	// https://tools.ietf.org/html/rfc6749#section-5.1
+	// not included: recommended field expires_in
+	body := []byte(fmt.Sprintf(`{"access_token": "%s","token_type":"bearer"}`, token))
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	_, err = w.Write(body)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+	log.WithField("client_id", clientId).Println("issued access token")
+}

--- a/bcda/auth/api.go
+++ b/bcda/auth/api.go
@@ -8,7 +8,7 @@ import (
 )
 
 /*
-	swagger:route POST /auth/token auth getAuthToken
+	swagger:route POST /auth/token auth GetAuthToken
 
 	Get access token
 
@@ -52,4 +52,20 @@ func GetAuthToken(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 	log.WithField("client_id", clientId).Println("issued access token")
+}
+
+func GetAuthGroups(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}
+
+func CreateAuthGroup(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusNotImplemented), http.StatusNotImplemented)
+}
+
+func EditAuthGroup(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusNotImplemented), http.StatusNotImplemented)
+}
+
+func DeactivateAuthGroup(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusNotImplemented), http.StatusNotImplemented)
 }

--- a/bcda/auth/api_test.go
+++ b/bcda/auth/api_test.go
@@ -1,0 +1,93 @@
+package auth_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
+type AuthAPITestSuite struct {
+	testUtils.AuthTestSuite
+	rr *httptest.ResponseRecorder
+	db *gorm.DB
+}
+
+func (s *AuthAPITestSuite) SetupTest() {
+	models.InitializeGormModels()
+	auth.InitializeGormModels()
+	s.db = database.GetGORMDbConnection()
+	s.rr = httptest.NewRecorder()
+}
+
+func (s *AuthAPITestSuite) TearDownTest() {
+	database.Close(s.db)
+}
+
+func (s *AuthAPITestSuite) TestAuthToken() {
+	s.SetupAuthBackend()
+	devACOID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
+
+	// Missing authorization header
+	req := httptest.NewRequest("POST", "/auth/token", nil)
+	handler := http.HandlerFunc(auth.GetAuthToken)
+	fmt.Println("No authorization header")
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
+
+	// Malformed authorization header
+	s.rr = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/auth/token", nil)
+	req.Header.Add("Authorization", "Basic not_an_encoded_client_and_secret")
+	req.Header.Add("Accept", "application/json")
+	handler = http.HandlerFunc(auth.GetAuthToken)
+	fmt.Println("Malformed authorization header")
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
+
+	// Invalid credentials
+	s.rr = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/auth/token", nil)
+	req.SetBasicAuth("not_a_client", "not_a_secret")
+	req.Header.Add("Accept", "application/json")
+	fmt.Println("Invalid credentials")
+	handler = http.HandlerFunc(auth.GetAuthToken)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
+
+	// Success!?
+	s.rr = httptest.NewRecorder()
+	t := TokenResponse{}
+	creds, err := auth.GetProvider().RegisterClient(devACOID)
+	assert.Nil(s.T(), err)
+	assert.NotEmpty(s.T(), creds.ClientID)
+	assert.NotEmpty(s.T(), creds.ClientSecret)
+
+	req = httptest.NewRequest("POST", "/auth/token", nil)
+	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
+	req.Header.Add("Accept", "application/json")
+	handler = http.HandlerFunc(auth.GetAuthToken)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
+	assert.NotEmpty(s.T(), t)
+	assert.NotEmpty(s.T(), t.AccessToken)
+}
+
+func TestAuthAuthAPITestSuite(t *testing.T) {
+	suite.Run(t, new(AuthAPITestSuite))
+}

--- a/bcda/auth/router.go
+++ b/bcda/auth/router.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/CMSgov/bcda-app/bcda/monitoring"
+	"github.com/go-chi/chi"
+)
+
+func NewAuthRouter(middlewares ...func(http.Handler) http.Handler) http.Handler {
+	r := chi.NewRouter()
+	m := monitoring.GetMonitor()
+	r.Use(middlewares...)
+	r.Post(m.WrapHandler("/auth/token", GetAuthToken))
+	// TODO: remove conditional when new authentication implemented for administrative endpoints
+	if os.Getenv("DEBUG") == "true" {
+		r.Get(m.WrapHandler("/auth/group", GetAuthGroups))
+		r.Post(m.WrapHandler("/auth/group", CreateAuthGroup))
+		r.Put(m.WrapHandler("/auth/group", EditAuthGroup))
+		r.Delete(m.WrapHandler("/auth/group", DeactivateAuthGroup))
+	}
+	return r
+}

--- a/bcda/auth/router_test.go
+++ b/bcda/auth/router_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type AuthRouterTestSuite struct {
+	suite.Suite
+	authRouter http.Handler
+}
+
+func (s *AuthRouterTestSuite) SetupTest() {
+	os.Setenv("DEBUG", "true")
+	s.authRouter = NewAuthRouter()
+}
+
+func (s *AuthRouterTestSuite) reqAuthRoute(verb string, route string, body io.Reader) *http.Response {
+	req := httptest.NewRequest(strings.ToUpper(verb), route, body)
+	rr := httptest.NewRecorder()
+	s.authRouter.ServeHTTP(rr, req)
+	return rr.Result()
+}
+
+func (s *AuthRouterTestSuite) TestAuthTokenRoute() {
+	res := s.reqAuthRoute("POST", "/auth/token", nil)
+	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
+}
+
+func (s *AuthRouterTestSuite) TestGetAuthGroupRoute() {
+	res := s.reqAuthRoute("GET", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+}
+
+func (s *AuthRouterTestSuite) TestPostAuthGroupRoute() {
+	res := s.reqAuthRoute("POST", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
+}
+
+func (s *AuthRouterTestSuite) TestPutAuthGroupRoute() {
+	res := s.reqAuthRoute("PUT", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
+}
+
+func (s *AuthRouterTestSuite) TestDeleteAuthGroupRoute() {
+	res := s.reqAuthRoute("DELETE", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
+}

--- a/bcda/main.go
+++ b/bcda/main.go
@@ -110,14 +110,14 @@ func setUpApp() *cli.App {
 				go func() { log.Fatal(srv.ListenAndServe()) }()
 
 				auth := &http.Server{
-					Handler:      NewAPIRouter(),
+					Handler:      NewAuthRouter(),
 					ReadTimeout:  time.Duration(utils.GetEnvInt("API_READ_TIMEOUT", 10)) * time.Second,
 					WriteTimeout: time.Duration(utils.GetEnvInt("API_WRITE_TIMEOUT", 20)) * time.Second,
 					IdleTimeout:  time.Duration(utils.GetEnvInt("API_IDLE_TIMEOUT", 120)) * time.Second,
 				}
 
 				api := &http.Server{
-					Handler:      NewAuthRouter(),
+					Handler:      NewAPIRouter(),
 					ReadTimeout:  time.Duration(utils.GetEnvInt("API_READ_TIMEOUT", 10)) * time.Second,
 					WriteTimeout: time.Duration(utils.GetEnvInt("API_WRITE_TIMEOUT", 20)) * time.Second,
 					IdleTimeout:  time.Duration(utils.GetEnvInt("API_IDLE_TIMEOUT", 120)) * time.Second,

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -29,10 +29,17 @@ func NewAPIRouter() http.Handler {
 		r.With(auth.RequireTokenAuth, auth.RequireTokenJobMatch).Get(m.WrapHandler("/jobs/{jobID}", jobStatus))
 		r.Get(m.WrapHandler("/metadata", metadata))
 	})
-	r.Post(m.WrapHandler("/auth/token", auth.GetAuthToken))
 	r.Get(m.WrapHandler("/_version", getVersion))
 	r.Get(m.WrapHandler("/_health", healthCheck))
 	r.Get(m.WrapHandler("/_auth", getAuthInfo))
+	return r
+}
+
+func NewAuthRouter() http.Handler {
+	r := chi.NewRouter()
+	m := monitoring.GetMonitor()
+	r.Use(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
+	r.Post(m.WrapHandler("/auth/token", auth.GetAuthToken))
 	return r
 }
 

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -40,6 +40,13 @@ func NewAuthRouter() http.Handler {
 	m := monitoring.GetMonitor()
 	r.Use(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
 	r.Post(m.WrapHandler("/auth/token", auth.GetAuthToken))
+	// TODO: remove conditional when new authentication implemented for administrative endpoints
+	if os.Getenv("DEBUG") == "true" {
+		r.Get(m.WrapHandler("/auth/group", auth.GetAuthGroups))
+		r.Post(m.WrapHandler("/auth/group", auth.CreateAuthGroup))
+		r.Put(m.WrapHandler("/auth/group", auth.EditAuthGroup))
+		r.Delete(m.WrapHandler("/auth/group", auth.DeactivateAuthGroup))
+	}
 	return r
 }
 

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -32,7 +32,7 @@ func NewAPIRouter() http.Handler {
 			r.Get(m.WrapHandler("/token", getToken))
 		}
 	})
-	r.Post(m.WrapHandler("/auth/token", getAuthToken))
+	r.Post(m.WrapHandler("/auth/token", auth.GetAuthToken))
 	r.Get(m.WrapHandler("/_version", getVersion))
 	r.Get(m.WrapHandler("/_health", healthCheck))
 	r.Get(m.WrapHandler("/_auth", getAuthInfo))

--- a/bcda/router.go
+++ b/bcda/router.go
@@ -36,18 +36,7 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	r := chi.NewRouter()
-	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
-	r.Post(m.WrapHandler("/auth/token", auth.GetAuthToken))
-	// TODO: remove conditional when new authentication implemented for administrative endpoints
-	if os.Getenv("DEBUG") == "true" {
-		r.Get(m.WrapHandler("/auth/group", auth.GetAuthGroups))
-		r.Post(m.WrapHandler("/auth/group", auth.CreateAuthGroup))
-		r.Put(m.WrapHandler("/auth/group", auth.EditAuthGroup))
-		r.Delete(m.WrapHandler("/auth/group", auth.DeactivateAuthGroup))
-	}
-	return r
+	return auth.NewAuthRouter(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
 }
 
 func NewDataRouter() http.Handler {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/go-chi/chi"
@@ -18,14 +16,12 @@ import (
 type RouterTestSuite struct {
 	suite.Suite
 	apiRouter  http.Handler
-	authRouter http.Handler
 	dataRouter http.Handler
 }
 
 func (s *RouterTestSuite) SetupTest() {
 	os.Setenv("DEBUG", "true")
 	s.apiRouter = NewAPIRouter()
-	s.authRouter = NewAuthRouter()
 	s.dataRouter = NewDataRouter()
 }
 
@@ -33,13 +29,6 @@ func (s *RouterTestSuite) getAPIRoute(route string) *http.Response {
 	req := httptest.NewRequest("GET", route, nil)
 	rr := httptest.NewRecorder()
 	s.apiRouter.ServeHTTP(rr, req)
-	return rr.Result()
-}
-
-func (s *RouterTestSuite) getAuthRoute(verb string, route string, body io.Reader) *http.Response {
-	req := httptest.NewRequest(strings.ToUpper(verb), route, body)
-	rr := httptest.NewRecorder()
-	s.authRouter.ServeHTTP(rr, req)
 	return rr.Result()
 }
 
@@ -61,31 +50,6 @@ func (s *RouterTestSuite) TestDefaultRoute() {
 func (s *RouterTestSuite) TestDataRoute() {
 	res := s.getDataRoute("/data/test/test.ndjson")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
-}
-
-func (s *RouterTestSuite) TestGetAuthGroupRoute() {
-	res := s.getAuthRoute("GET", "/auth/group", nil)
-	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
-}
-
-func (s *RouterTestSuite) TestPostAuthGroupRoute() {
-	res := s.getAuthRoute("POST", "/auth/group", nil)
-	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
-}
-
-func (s *RouterTestSuite) TestPutAuthGroupRoute() {
-	res := s.getAuthRoute("PUT", "/auth/group", nil)
-	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
-}
-
-func (s *RouterTestSuite) TestDeleteAuthGroupRoute() {
-	res := s.getAuthRoute("DELETE", "/auth/group", nil)
-	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
-}
-
-func (s *RouterTestSuite) TestAuthTokenRoute() {
-	res := s.getAuthRoute("POST", "/auth/token", nil)
-	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestFileServerRoute() {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -17,12 +17,14 @@ import (
 type RouterTestSuite struct {
 	suite.Suite
 	apiRouter  http.Handler
+	authRouter http.Handler
 	dataRouter http.Handler
 }
 
 func (s *RouterTestSuite) SetupTest() {
 	os.Setenv("DEBUG", "true")
 	s.apiRouter = NewAPIRouter()
+	s.authRouter = NewAuthRouter()
 	s.dataRouter = NewDataRouter()
 }
 
@@ -37,6 +39,13 @@ func (s *RouterTestSuite) postAPIRoute(route string, body io.Reader) *http.Respo
 	req := httptest.NewRequest("POST", route, body)
 	rr := httptest.NewRecorder()
 	s.apiRouter.ServeHTTP(rr, req)
+	return rr.Result()
+}
+
+func (s *RouterTestSuite) postAuthRoute(route string, body io.Reader) *http.Response {
+	req := httptest.NewRequest("POST", route, body)
+	rr := httptest.NewRecorder()
+	s.authRouter.ServeHTTP(rr, req)
 	return rr.Result()
 }
 
@@ -61,7 +70,7 @@ func (s *RouterTestSuite) TestDataRoute() {
 }
 
 func (s *RouterTestSuite) TestAuthTokenRoute() {
-	res := s.postAPIRoute("/auth/token", nil)
+	res := s.postAuthRoute("/auth/token", nil)
 	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi"
@@ -35,15 +36,8 @@ func (s *RouterTestSuite) getAPIRoute(route string) *http.Response {
 	return rr.Result()
 }
 
-func (s *RouterTestSuite) postAPIRoute(route string, body io.Reader) *http.Response {
-	req := httptest.NewRequest("POST", route, body)
-	rr := httptest.NewRecorder()
-	s.apiRouter.ServeHTTP(rr, req)
-	return rr.Result()
-}
-
-func (s *RouterTestSuite) postAuthRoute(route string, body io.Reader) *http.Response {
-	req := httptest.NewRequest("POST", route, body)
+func (s *RouterTestSuite) getAuthRoute(verb string, route string, body io.Reader) *http.Response {
+	req := httptest.NewRequest(strings.ToUpper(verb), route, body)
 	rr := httptest.NewRecorder()
 	s.authRouter.ServeHTTP(rr, req)
 	return rr.Result()
@@ -69,8 +63,28 @@ func (s *RouterTestSuite) TestDataRoute() {
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 }
 
+func (s *RouterTestSuite) TestGetAuthGroupRoute() {
+	res := s.getAuthRoute("GET", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestPostAuthGroupRoute() {
+	res := s.getAuthRoute("POST", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestPutAuthGroupRoute() {
+	res := s.getAuthRoute("PUT", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestDeleteAuthGroupRoute() {
+	res := s.getAuthRoute("DELETE", "/auth/group", nil)
+	assert.Equal(s.T(), http.StatusNotImplemented, res.StatusCode)
+}
+
 func (s *RouterTestSuite) TestAuthTokenRoute() {
-	res := s.postAuthRoute("/auth/token", nil)
+	res := s.getAuthRoute("POST", "/auth/token", nil)
 	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 


### PR DESCRIPTION
### Fixes [BCDA-1143](https://jira.cms.gov/browse/BCDA-1143)
The goal is to separate the auth routing code (as much as possible), and create stubs for the next few auth endpoints.

### Proposed changes:
Reduce knowledge of auth internals by moving auth-related routing and route testing to the `/bdca/auth/` folder.


### Change Details
Added (by taking away code from `/bcda/*.go`:
- `/bcda/auth/api.go`
- `/bcda/auth/api_test.go`
- `/bcda/auth/router.go`
- `/bcda/auth/router_test.go`

Created stubs for four `/auth/group` verbs.  
Note that:
- No Swagger documentation was added, since these will be private and unavailable to the audience using our Swagger docs.
- An `auth_test` package had to be created for `/bcda/auth/api_test.go` to prevent an import loop with testUtils.


### Security Implications
The new `/auth/group` endpoints are only available when the environment contains `DEBUG=true`.  We'll likely have a more sophisticated way of making them available to ACO-MS later.


### Feedback Requested
- Are these the correct new locations for this code?
- Has too much/too little been moved?
