### PR TITLE
BCDA-1159 add CLI to delete files in a dir

### DIFF
--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/models"
+	log "github.com/sirupsen/logrus"
 )
 
 func createACO(name, cmsID string) (string, error) {
@@ -156,4 +157,30 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 	metadata.timestamp = t
 
 	return metadata, nil
+}
+
+func deleteDirectory(dirToDelete string) (filesDeleted int, err error) {
+	log.Info(fmt.Sprintf("preparing to delete directory '%v'", dirToDelete))
+	f, err := os.Open(dirToDelete)
+	if err != nil {
+		return 0, err
+	}
+	files, err := f.Readdir(-1)
+	if err != nil {
+		return 0, err
+	}
+	err = f.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	for _, file := range files {
+		log.Info(fmt.Sprintf("deleting %v", file.Name()))
+		err = os.Remove(filepath.Join(dirToDelete, file.Name()))
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return len(files), nil
 }


### PR DESCRIPTION
### Fixes [BCDA-1159](https://jira.cms.gov/browse/BCDA-1159)

<!-- describe the problem being solved here -->
In order to ensure that CCLF files are removed after import we need a CLI to delete all of the files in a specific Directory.  To prevent accidental deletion of any random dir the CLI has an ENV var as the argument which should prevent removal of an arbitrary directory by mistake.
### Proposed changes:
<!-- List of changes with bullet points here: -->
Added a CLI

### Change Details
<!-- add detailed discussion of changes here: -->
Added a CLI and associated tests

### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
This code deletes file in order to increase our security posture by ensuring that files do not exist longer than necessary

### Acceptance Validation
<!-- were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
Run the CLI (Set an ENV Var first)
<!-- insert screenshots if applicable (drag images here) -->


### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
Any