### PR TITLE
Rename Postman test to reflect opensbx instead of sbx

### DIFF
--- a/test/postman_test/opensbx.postman_environment.json
+++ b/test/postman_test/opensbx.postman_environment.json
@@ -1,6 +1,6 @@
 {
 	"id": "6c024be7-f7f0-42ed-ae9d-82e8384490ab",
-	"name": "bcda-sbx",
+	"name": "bcda-opensbx",
 	"values": [
 		{
 			"key": "scheme",
@@ -16,7 +16,7 @@
 		},
 		{
 			"key": "env",
-			"value": "sbx",
+			"value": "opensbx",
 			"description": "",
 			"enabled": true
 		}


### PR DESCRIPTION
### Fixes Test Configuration Inconsistency

Our Postman test is still named `sbx` instead of `opensbx`.  That results in this failure: 
```
error: ENOENT: no such file or directory, open 'test/postman_test/opensbx.postman_environment.json'
```

### Proposed changes:

Rename the test to reflect the correct environment.


### Change Details

- Renamed the Postman test for our Open Sandbox to be `opensbx` instead of `sbx`.


### Security Implications

None.


### Acceptance Validation

Executed locally against `r20` in `opensbx`, and all tests passed.


### Feedback Requested

Please review.
