### PR TITLE
BCDA-964/BCDA-958: Save CCLF8 data into database

### DIFF
--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,8 +10,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 )
 
@@ -39,12 +40,13 @@ func createACO(name, cmsID string) (string, error) {
 }
 
 type cclfFileMetadata struct {
+	name      string
 	env       string
 	acoID     string
 	cclfNum   int
+	perfYear  int
 	timestamp time.Time
 	filePath  string
-	perfYear  int
 }
 
 type cclfFileValidator struct {
@@ -110,8 +112,15 @@ func importCCLF0(fileMetadata cclfFileMetadata) (map[string]cclfFileValidator, e
 }
 
 func importCCLF8(fileMetadata cclfFileMetadata) error {
+	fmt.Printf("Importing CCLF8 file %s...\n", fileMetadata.name)
+	log.Infof("Importing CCLF8 file %s...", fileMetadata.name)
+
+	if fileMetadata.filePath == "" {
+		return errors.New("file path must be provided")
+	}
+
 	if fileMetadata.cclfNum != 8 {
-		err := errors.New("invalid CCLF8 file number")
+		err := fmt.Errorf("expected CCLF file number 8, but was %d", fileMetadata.cclfNum)
 		log.Error(err)
 		return err
 	}
@@ -122,7 +131,21 @@ func importCCLF8(fileMetadata cclfFileMetadata) error {
 		return err
 	}
 
-	log.Infof("File contains %s data for ACO %s at %s.\n", fileMetadata.env, fileMetadata.acoID, fileMetadata.timestamp)
+	cclf8File := models.CCLFFile{
+		CCLFNum:         8,
+		Name:            fileMetadata.name,
+		ACOCMSID:        fileMetadata.acoID,
+		Timestamp:       fileMetadata.timestamp,
+		PerformanceYear: fileMetadata.perfYear,
+	}
+
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+
+	err = db.Create(&cclf8File).Error
+	if err != nil {
+		return errors.Wrap(err, "could not create CCLF8 file record")
+	}
 
 	const (
 		mbiStart, mbiEnd   = 0, 11
@@ -133,10 +156,21 @@ func importCCLF8(fileMetadata cclfFileMetadata) error {
 	for sc.Scan() {
 		b := sc.Bytes()
 		if len(bytes.TrimSpace(b)) > 0 {
-			fmt.Printf("\nMBI: %s\n", b[mbiStart:mbiEnd])
-			fmt.Printf("HICN: %s\n", b[hicnStart:hicnEnd])
+			err = db.Create(&models.CCLFBeneficiary{
+				FileID: cclf8File.ID,
+				MBI:    string(bytes.TrimSpace(b[mbiStart:mbiEnd])),
+				HICN:   string(bytes.TrimSpace(b[hicnStart:hicnEnd])),
+				//TODO: BeneficiaryID
+			}).Error
+			if err != nil {
+				return errors.Wrap(err, "could not create CCLF8 beneficiary record")
+			}
 		}
 	}
+
+	fmt.Printf("Imported CCLF8 file %s.\n", fileMetadata.name)
+	log.Infof("Imported CCLF8 file %s.", fileMetadata.name)
+
 	return nil
 }
 
@@ -178,7 +212,7 @@ func importCCLF9(fileMetadata cclfFileMetadata) error {
 
 func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 	var metadata cclfFileMetadata
-	// CCLF8/9 filename convention for SSP: P.A****.ACO.ZC*Y**.Dyymmdd.Thhmmsst
+	// CCLF filename convention for SSP: P.A****.ACO.ZC*Y**.Dyymmdd.Thhmmsst
 	// Prefix: T = test, P = prod; A**** = ACO ID; ZC* = CCLF file number; Y** = performance year
 	filenameRegexp := regexp.MustCompile(`(T|P)\.(A\d{4})\.ACO\.ZC(0|8|9)Y(\d{2})\.(D\d{6}\.T\d{6})\d`)
 	filenameMatches := filenameRegexp.FindStringSubmatch(filePath)
@@ -208,6 +242,7 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 		metadata.env = "production"
 	}
 
+	metadata.name = filenameMatches[0]
 	metadata.cclfNum = cclfNum
 	metadata.acoID = filenameMatches[2]
 	metadata.timestamp = t

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -170,6 +170,9 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
+	db.Unscoped().Delete(&models.CCLFBeneficiary{})
+	db.Unscoped().Delete(&models.CCLFFile{})
+
 	acoID := "A0001"
 	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
 	metadata := cclfFileMetadata{
@@ -372,14 +375,15 @@ func (s *CLITestSuite) TestSortCCLFFiles() {
 func (s *CLITestSuite) TestImportCCLFDirectory() {
 	assert := assert.New(s.T())
 
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+
+	db.Unscoped().Delete(&models.CCLFBeneficiary{})
+	db.Unscoped().Delete(&models.CCLFFile{})
+
 	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
 	buf := new(bytes.Buffer)
 	s.testApp.Writer = buf
-
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
-	db.Unscoped().Delete(&models.CCLFBeneficiary{})
-	db.Unscoped().Delete(&models.CCLFFile{})
 
 	args := []string{"bcda", "import-cclf-directory", "--directory", "../shared_files/cclf/"}
 	err := s.testApp.Run(args)

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -186,7 +186,7 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	assert.Nil(err)
 
 	file := models.CCLFFile{}
-	db.First(&file, "aco_id = ?", acoID)
+	db.First(&file, "aco_cms_id = ?", acoID)
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -167,17 +167,67 @@ func (s *CLITestSuite) TestValidate() {
 
 func (s *CLITestSuite) TestImportCCLF8() {
 	assert := assert.New(s.T())
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
 
-	filePath := "../shared_files/cclf/T.A0001.ACO.ZC8Y18.D181120.T1000009"
-	metadata, err := getCCLFFileMetadata(filePath)
-	metadata.filePath = filePath
+	db.Unscoped().Delete(&models.CCLFBeneficiary{})
+	db.Unscoped().Delete(&models.CCLFFile{})
+
+	acoID := "A0001"
+	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
+	metadata := cclfFileMetadata{
+		name:      "T.A0001.ACO.ZC8Y18.D181120.T1000009",
+		env:       "test",
+		acoID:     acoID,
+		cclfNum:   8,
+		perfYear:  18,
+		timestamp: fileTime,
+		filePath:  "../shared_files/cclf/T.A0001.ACO.ZC8Y18.D181120.T1000009",
+	}
+
+	err := importCCLF8(metadata)
 	assert.Nil(err)
-	err = importCCLF8(metadata)
-	assert.Nil(err)
+
+	file := models.CCLFFile{}
+	db.First(&file, "aco_cms_id = ?", acoID)
+	assert.NotNil(file)
+	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
+	assert.Equal(acoID, file.ACOCMSID)
+	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(18, file.PerformanceYear)
+
+	beneficiaries := []models.CCLFBeneficiary{}
+	db.Find(&beneficiaries, "file_id = ?", file.ID)
+	assert.Equal(6, len(beneficiaries))
+	assert.Equal("203031401M", beneficiaries[0].HICN)
+	assert.Equal("1A69B98CD30", beneficiaries[0].MBI)
+	assert.Equal("203031402A", beneficiaries[1].HICN)
+	assert.Equal("1A69B98CD31", beneficiaries[1].MBI)
+	assert.Equal("203031403A", beneficiaries[2].HICN)
+	assert.Equal("1A69B98CD32", beneficiaries[2].MBI)
+	assert.Equal("203031404A", beneficiaries[3].HICN)
+	assert.Equal("1A69B98CD33", beneficiaries[3].MBI)
+	assert.Equal("203031405C7", beneficiaries[4].HICN)
+	assert.Equal("1A69B98CD34", beneficiaries[4].MBI)
+	assert.Equal("203031406M", beneficiaries[5].HICN)
+	assert.Equal("1A69B98CD35", beneficiaries[5].MBI)
+}
+
+func (s *CLITestSuite) TestImportCCLF8_InvalidMetadata() {
+	metadata := cclfFileMetadata{}
+	assert := assert.New(s.T())
 
 	metadata.cclfNum = 9
+	metadata.filePath = "../shared_files/cclf/T.A0001.ACO.ZC8Y18.D181120.T1000009"
+	err := importCCLF8(metadata)
+	assert.NotNil(err)
+	assert.EqualError(err, "expected CCLF file number 8, but was 9")
+
+	metadata.cclfNum = 8
+	metadata.filePath = ""
 	err = importCCLF8(metadata)
 	assert.NotNil(err)
+	assert.EqualError(err, "file path must be provided")
 }
 
 func (s *CLITestSuite) TestImportCCLF9() {
@@ -329,6 +379,11 @@ func (s *CLITestSuite) TestImportCCLFDirectory() {
 	buf := new(bytes.Buffer)
 	s.testApp.Writer = buf
 
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+	db.Unscoped().Delete(&models.CCLFBeneficiary{})
+	db.Unscoped().Delete(&models.CCLFFile{})
+
 	args := []string{"bcda", "import-cclf-directory", "--directory", "../shared_files/cclf/"}
 	err := s.testApp.Run(args)
 	assert.Nil(err)
@@ -338,6 +393,8 @@ func (s *CLITestSuite) TestImportCCLFDirectory() {
 	assert.Contains(buf.String(), "Skipped 0 files.")
 
 	buf.Reset()
+	db.Unscoped().Delete(&models.CCLFBeneficiary{})
+	db.Unscoped().Delete(&models.CCLFFile{})
 
 	// dir has 4 files, but 2 will be ignored because of bad file names.
 	args = []string{"bcda", "import-cclf-directory", "--directory", "../shared_files/cclf_BadFileNames/"}

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -170,9 +170,6 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
-	db.Unscoped().Delete(&models.CCLFBeneficiary{})
-	db.Unscoped().Delete(&models.CCLFFile{})
-
 	acoID := "A0001"
 	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
 	metadata := cclfFileMetadata{
@@ -189,7 +186,7 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	assert.Nil(err)
 
 	file := models.CCLFFile{}
-	db.First(&file, "aco_cms_id = ?", acoID)
+	db.First(&file, "aco_id = ?", acoID)
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -270,18 +270,6 @@ func AssignAlphaBeneficiaries(db *gorm.DB, aco ACO, acoSize string) error {
 	return db.Exec(s).Error
 }
 
-// CLI command only support; note that we are choosing to fail quickly and let the user (one of us) figure it out
-func CreateAlphaUser(db *gorm.DB, aco ACO) (User, error) {
-	var count int
-	db.Table("users").Count(&count)
-	user := User{UUID: uuid.NewRandom(),
-		Name:  fmt.Sprintf("Alpha User%d", count),
-		Email: fmt.Sprintf("alpha.user.%d@nosuchdomain.com", count), ACOID: aco.UUID}
-	db.Create(&user)
-
-	return user, db.Error
-}
-
 type CCLFFile struct {
 	gorm.Model
 	CCLFNum         int       `gorm:"not null"`

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/utils"
@@ -34,10 +35,14 @@ func InitializeGormModels() *gorm.DB {
 		&JobKey{},
 		&Beneficiary{},
 		&ACOBeneficiary{},
+		&CCLFFile{},
+		&CCLFBeneficiary{},
 	)
 
 	db.Model(&ACOBeneficiary{}).AddForeignKey("aco_id", "acos(uuid)", "RESTRICT", "RESTRICT")
 	db.Model(&ACOBeneficiary{}).AddForeignKey("beneficiary_id", "beneficiaries(id)", "RESTRICT", "RESTRICT")
+
+	db.Model(&CCLFBeneficiary{}).AddForeignKey("file_id", "cclf_files(id)", "RESTRICT", "RESTRICT")
 
 	return db
 }
@@ -144,7 +149,7 @@ type JobKey struct {
 type ACO struct {
 	gorm.Model
 	UUID             uuid.UUID `gorm:"primary_key;type:char(36)" json:"uuid"`
-	CMSID            *string   `gorm:"type:char(5)" json:"cms_id"`
+	CMSID            *string   `gorm:"type:char(5);unique" json:"cms_id"`
 	Name             string    `json:"name"`
 	ClientID         string    `json:"client_id"`
 	AlphaSecret      string    `json:"alpha_secret"`
@@ -263,6 +268,37 @@ func AssignAlphaBeneficiaries(db *gorm.DB, aco ACO, acoSize string) error {
 		"', b.id from beneficiaries b join acos_beneficiaries ab on b.id = ab.beneficiary_id " +
 		"where ab.aco_id = (select uuid from acos where name ilike 'ACO " + acoSize + "')"
 	return db.Exec(s).Error
+}
+
+// CLI command only support; note that we are choosing to fail quickly and let the user (one of us) figure it out
+func CreateAlphaUser(db *gorm.DB, aco ACO) (User, error) {
+	var count int
+	db.Table("users").Count(&count)
+	user := User{UUID: uuid.NewRandom(),
+		Name:  fmt.Sprintf("Alpha User%d", count),
+		Email: fmt.Sprintf("alpha.user.%d@nosuchdomain.com", count), ACOID: aco.UUID}
+	db.Create(&user)
+
+	return user, db.Error
+}
+
+type CCLFFile struct {
+	gorm.Model
+	CCLFNum         int       `gorm:"not null"`
+	Name            string    `gorm:"not null;unique"`
+	ACOCMSID        string    `gorm:"column:aco_cms_id"`
+	Timestamp       time.Time `gorm:"not null"`
+	PerformanceYear int       `gorm:"not null"`
+}
+
+// "The MBI has 11 characters, like the Health Insurance Claim Number (HICN), which can have up to 11."
+// https://www.cms.gov/Medicare/New-Medicare-Card/Understanding-the-MBI-with-Format.pdf
+type CCLFBeneficiary struct {
+	gorm.Model
+	FileID        uint   `gorm:"not null"`
+	HICN          string `gorm:"type:varchar(11);not null"`
+	MBI           string `gorm:"type:char(11);not null"`
+	BeneficiaryID uint
 }
 
 // This is not a persistent model so it is not necessary to include in GORM auto migrate.


### PR DESCRIPTION
### Fixes [BCDA-964](https://jira.cms.gov/browse/BCDA-964), [BCDA-958](https://jira.cms.gov/browse/BCDA-958)
The CLI has a proof of concept for reading CCLF8 files, but does not yet store the file metadata or contents.

### Proposed changes:
Create data model for CCLF8 file metadata and beneficiaries, and save to database as files are read.

### Change Details
* Creates two new data models and tables:
  * `CCLF8File` model - `cclf8_files` table
  * `CCLF8Beneficiary` - `cclf8_beneficiaries` table
* Saves file metadata, one row per file, into `cclf8_files`
* Saves beneficiary HICN and MBI, per row in file, into `cclf8_beneficiaries`

Note that the new tables currently stand alone, and our next steps for attribution will determine how they are used. We will likely need foreign key associations:
* `cclf8_files.aco_cms_id`-`acos.cms_id`
* `cclf8_beneficiaries.beneficiary_id`-`beneficiaries.id`

### Security Implications
This change allows the storage of beneficiary identifiers, HICN and MBI, found in CCLF8 files. ACO IDs and other metadata about the files are also stored.

### Acceptance Validation
`TestImportCCLF8()` in cli_test.go confirms that data can be read and imported from a sample CCLF8 file. The sample file used contains synthetic data.

### Feedback Requested
Any
