### PR TITLE
BCDA-1216 adding a name to the Swagger license

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -13,7 +13,7 @@ Until you click logout your token will be presented with every request made.  To
 
 
      Version: 1.0.0
-     License: https://github.com/CMSgov/bcda-app/blob/master/LICENSE.md
+     License: Public Domain https://github.com/CMSgov/bcda-app/blob/master/LICENSE.md
      Contact: bcapi@cms.hhs.gov
 
      Produces:


### PR DESCRIPTION
<!-- Replace xxx with the JIRA ticket number: -->
### Fixes [BCDA-1216](https://jira.cms.gov/browse/BCDA-1216)

<!-- describe the problem being solved here -->
Per the swagger documentation (see Ticket) there is a required attribute on license called "Name". We currently do not have this value set and it is causing an error at the bottom of the swagger page.
### Proposed changes:
<!-- List of changes with bullet points here: -->
Added the name "Public Domain" to the license comment

### Change Details
<!-- add detailed discussion of changes here: -->
Added the name "Public Domain" to the license comment


### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
None.  All this does is change the name displayed on the link to the license.

### Acceptance Validation
<!-- were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
No error at the bottom of the page
<!-- insert screenshots if applicable (drag images here) -->
Good:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/42681520/56514488-68426600-6503-11e9-8379-eb5545774570.png">
Bad:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/42681520/56514511-78f2dc00-6503-11e9-8c28-72140b4e852c.png">




### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
Any