### PR TITLE
Fix race condition in RPM packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 package:
 	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1
-	docker-compose up -d documentation
-	docker-compose up -d static_site
+	docker-compose up documentation
+	docker-compose up static_site
 	docker build -t packaging -f Dockerfiles/Dockerfile.package .
 	docker run --rm \
 	-e BCDA_GPG_RPM_PASSPHRASE='${BCDA_GPG_RPM_PASSPHRASE}' \


### PR DESCRIPTION
### Fixes race condition in BCDA RPM packaging scripts

When building/packaging the RPMs, we were previously generating swagger and static site data in docker-compose detached mode (which runs the containers and generates the data in the background).  To reduce the risk of race condition, we should ensure that the data is generated in the proper sequence, since it is a prerequisite for the RPM packaging.

### Proposed changes:

Ensure that the data generation for swagger and static site is completed before packaging the RPMs.


### Change Details

No longer running the data generation containers for swagger and static site in detached mode.


### Security Implications

This modification is strictly related to build/packaging scripts and does not affect security.


### Acceptance Validation

Build and deployed feature branch in Jenkins: https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/599/

<img width="425" alt="Screen Shot 2019-04-29 at 12 06 33 PM" src="https://user-images.githubusercontent.com/37818548/56909922-499a1d00-6a77-11e9-973d-03de489b88de.png">



### Feedback Requested
Please review.
