### PR TITLE
BCDA-1242: Update Auth Function for Key Pairs

### DIFF
--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -1,6 +1,8 @@
 package auth_test
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 )
 
@@ -61,6 +64,81 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 	s.db.Find(&savedToken, "UUID = ?", tokenUUID)
 	assert.NotNil(s.T(), savedToken)
 	assert.Equal(s.T(), tokenString, savedToken.TokenString)
+}
+
+func (s *ModelsTestSuite) TestGenerateSystemKeyPair() {
+	group := models.Group{GroupID: "abcdef123456"}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	system := models.System{
+		GroupID:  group.GroupID,
+		ClientID: "1234",
+	}
+	err = s.db.Create(&system).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	privateKeyStr, err := auth.GenerateSystemKeyPair("1234")
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), privateKeyStr)
+
+	privKeyBlock, _ := pem.Decode([]byte(privateKeyStr))
+	privateKey, err := x509.ParsePKCS1PrivateKey(privKeyBlock.Bytes)
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	var pubEncrKey models.EncryptionKey
+	err = s.db.First(&pubEncrKey, "system_id = ?", system.ID).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+	pubKeyBlock, _ := pem.Decode([]byte(pubEncrKey.Body))
+	publicKey, err := x509.ParsePKIXPublicKey(pubKeyBlock.Bytes)
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+	assert.Equal(s.T(), &privateKey.PublicKey, publicKey)
+
+	s.db.Unscoped().Delete(&pubEncrKey)
+	s.db.Unscoped().Delete(&system)
+	s.db.Unscoped().Delete(&group)
+}
+
+func (s *ModelsTestSuite) TestGenerateSystemKeyPair_AlreadyExists() {
+	group := models.Group{GroupID: "bcdefa234561"}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	system := models.System{
+		GroupID:  group.GroupID,
+		ClientID: "2345",
+	}
+	err = s.db.Create(&system).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	encrKey := models.EncryptionKey{
+		SystemID: system.ID,
+	}
+	err = s.db.Create(&encrKey).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	privateKey, err := auth.GenerateSystemKeyPair("2345")
+	assert.EqualError(s.T(), err, "encryption keypair already exists for system with client ID 2345")
+	assert.Empty(s.T(), privateKey)
+
+	s.db.Unscoped().Delete(&system)
+	s.db.Unscoped().Delete(&group)
 }
 
 func TestModelsTestSuite(t *testing.T) {

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"strconv"
 	"testing"
 	"time"
 
@@ -73,16 +74,13 @@ func (s *ModelsTestSuite) TestGenerateSystemKeyPair() {
 		s.FailNow(err.Error())
 	}
 
-	system := models.System{
-		GroupID:  group.GroupID,
-		ClientID: "1234",
-	}
+	system := models.System{GroupID:  group.GroupID}
 	err = s.db.Create(&system).Error
 	if err != nil {
 		s.FailNow(err.Error())
 	}
 
-	privateKeyStr, err := auth.GenerateSystemKeyPair("1234")
+	privateKeyStr, err := auth.GenerateSystemKeyPair(system.ID)
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), privateKeyStr)
 
@@ -116,10 +114,7 @@ func (s *ModelsTestSuite) TestGenerateSystemKeyPair_AlreadyExists() {
 		s.FailNow(err.Error())
 	}
 
-	system := models.System{
-		GroupID:  group.GroupID,
-		ClientID: "2345",
-	}
+	system := models.System{GroupID:  group.GroupID}
 	err = s.db.Create(&system).Error
 	if err != nil {
 		s.FailNow(err.Error())
@@ -133,8 +128,9 @@ func (s *ModelsTestSuite) TestGenerateSystemKeyPair_AlreadyExists() {
 		s.FailNow(err.Error())
 	}
 
-	privateKey, err := auth.GenerateSystemKeyPair("2345")
-	assert.EqualError(s.T(), err, "encryption keypair already exists for system with client ID 2345")
+	privateKey, err := auth.GenerateSystemKeyPair(system.ID)
+	systemIDStr := strconv.FormatUint(uint64(system.ID), 10)
+	assert.EqualError(s.T(), err, "encryption keypair already exists for system ID " + systemIDStr)
 	assert.Empty(s.T(), privateKey)
 
 	s.db.Unscoped().Delete(&system)


### PR DESCRIPTION
### Fixes [BCDA-1242](https://jira.cms.gov/browse/BCDA-1242)
BCDA needs a function in the auth package for generating a key pair for encryption, and assigning that key pair to an ACO.

### Proposed changes:
Add function to generate a key pair and assign it to a system, which can be linked to an ACO by client ID.

### Change Details
* Adds function `GenerateSystemKeyPair` that creates a 2048 bit RSA key pair, saves the public key in the database, and returns the private key.

### Security Implications
The newly added `GenerateSystemKeyPair` function uses Go's `rsa` library to create the key pair, as used elsewhere in the BCDA application. The new function is not currently called anywhere except for its tests.

### Acceptance Validation
Added two tests:
* `TestGenerateSystemKeyPair` - confirms that key pair is created successfully
* `TestGenerateSystemKeyPair_AlreadyExists` - confirms that function will return an error if encryption keys already exist for the system

### Feedback Requested
I know we wanted to put this in the `auth` package, but it was not clear where. Open to suggestions on where the function should live. And any other feedback.
