### PR TITLE
BCDA-1245 add func to revoke encryption keys

### DIFF
--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -64,21 +64,20 @@ func GetACOByClientID(clientID string) (models.ACO, error) {
 }
 
 // RevokeSystemKeyPair soft deletes the specified encryption key so that it can no longer be used
-func RevokeSystemKeyPair(encryptionKeyID uint) (models.EncryptionKey, error) {
+func RevokeSystemKeyPair(encryptionKeyID uint) error {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 	encryptionKey := models.EncryptionKey{}
 
 	err := db.Find(&encryptionKey, encryptionKeyID).Error
 	if err != nil {
-		return encryptionKey, err
+		return err
 	}
 
 	err = db.Delete(&encryptionKey).Error
 	if err != nil {
-		return encryptionKey, err
+		return err
 	}
 
-	db.Unscoped().Find(&encryptionKey, encryptionKeyID)
-	return encryptionKey, nil
+	return nil
 }

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -79,5 +79,6 @@ func RevokeSystemKeyPair(encryptionKeyID uint) (models.EncryptionKey, error) {
 		return encryptionKey, err
 	}
 
+	db.Unscoped().Find(&encryptionKey, encryptionKeyID)
 	return encryptionKey, nil
 }

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -3,12 +3,11 @@ package auth
 import (
 	"errors"
 
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/pborman/uuid"
-
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/models"
 )
 
 func InitializeGormModels() *gorm.DB {
@@ -62,4 +61,23 @@ func GetACOByClientID(clientID string) (models.ACO, error) {
 		err = errors.New("no ACO record found for " + clientID)
 	}
 	return aco, err
+}
+
+// RevokeSystemKeyPair soft deletes the specified encryption key so that it can no longer be used
+func RevokeSystemKeyPair(encryptionKeyID uint) (models.EncryptionKey, error) {
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+	encryptionKey := models.EncryptionKey{}
+
+	err := db.Find(&encryptionKey, encryptionKeyID).Error
+	if err != nil {
+		return encryptionKey, err
+	}
+
+	err = db.Delete(&encryptionKey).Error
+	if err != nil {
+		return encryptionKey, err
+	}
+
+	return encryptionKey, nil
 }

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -63,13 +63,20 @@ func GetACOByClientID(clientID string) (models.ACO, error) {
 	return aco, err
 }
 
-// RevokeSystemKeyPair soft deletes the specified encryption key so that it can no longer be used
-func RevokeSystemKeyPair(encryptionKeyID uint) error {
+// RevokeSystemKeyPair soft deletes the active encryption key
+// for the specified system so that it can no longer be used
+func RevokeSystemKeyPair(systemID uint) error {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
-	encryptionKey := models.EncryptionKey{}
+	var system models.System
 
-	err := db.Find(&encryptionKey, encryptionKeyID).Error
+	err := db.Preload("EncryptionKeys").Find(&system, systemID).Error
+	if err != nil {
+		return err
+	}
+
+	var encryptionKey models.EncryptionKey
+	err = db.Find(&encryptionKey, system.EncryptionKeys[0].ID).Error
 	if err != nil {
 		return err
 	}

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -64,12 +64,14 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 }
 
 func (s *ModelsTestSuite) TestRevokeSystemKeyPair() {
-	encryptionKey := models.EncryptionKey{SystemID: 1}
+	system := models.System{GroupID: "A00001"}
 	s.db.Save(&models.Group{GroupID: "A00001"})
-	s.db.Save(&models.System{GroupID: "A00001"})
+	s.db.Save(&system)
+	encryptionKey := models.EncryptionKey{SystemID: system.ID}
 	s.db.Save(&encryptionKey)
-	err := auth.RevokeSystemKeyPair(encryptionKey.ID)
+	err := auth.RevokeSystemKeyPair(system.ID)
 	assert.Nil(s.T(), err)
+	assert.Empty(s.T(), system.EncryptionKeys)
 	s.db.Unscoped().Find(&encryptionKey)
 	assert.NotNil(s.T(), encryptionKey.DeletedAt)
 }

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -68,8 +68,9 @@ func (s *ModelsTestSuite) TestRevokeSystemKeyPair() {
 	s.db.Save(&models.Group{GroupID: "A00001"})
 	s.db.Save(&models.System{GroupID: "A00001"})
 	s.db.Save(&encryptionKey)
-	encryptionKey, err := auth.RevokeSystemKeyPair(encryptionKey.ID)
+	err := auth.RevokeSystemKeyPair(encryptionKey.ID)
 	assert.Nil(s.T(), err)
+	s.db.Unscoped().Find(&encryptionKey)
 	assert.NotNil(s.T(), encryptionKey.DeletedAt)
 }
 

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -67,11 +67,16 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 }
 
 func (s *ModelsTestSuite) TestRevokeSystemKeyPair() {
-	system := models.System{GroupID: "A00001"}
-	s.db.Save(&models.Group{GroupID: "A00001"})
+	group := models.Group{GroupID: "A00001"}
+	s.db.Save(&group)
+	defer s.db.Unscoped().Delete(&group)
+	system := models.System{GroupID: group.GroupID}
 	s.db.Save(&system)
+	defer s.db.Unscoped().Delete(&system)
 	encryptionKey := models.EncryptionKey{SystemID: system.ID}
 	s.db.Save(&encryptionKey)
+	defer s.db.Unscoped().Delete(&encryptionKey)
+
 	err := auth.RevokeSystemKeyPair(system.ID)
 	assert.Nil(s.T(), err)
 	assert.Empty(s.T(), system.EncryptionKeys)

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
 )
 
 type ModelsTestSuite struct {
@@ -61,6 +61,16 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 	s.db.Find(&savedToken, "UUID = ?", tokenUUID)
 	assert.NotNil(s.T(), savedToken)
 	assert.Equal(s.T(), tokenString, savedToken.TokenString)
+}
+
+func (s *ModelsTestSuite) TestRevokeSystemKeyPair() {
+	encryptionKey := models.EncryptionKey{SystemID: 1}
+	s.db.Save(&models.Group{GroupID: "A00001"})
+	s.db.Save(&models.System{GroupID: "A00001"})
+	s.db.Save(&encryptionKey)
+	encryptionKey, err := auth.RevokeSystemKeyPair(encryptionKey.ID)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), encryptionKey.DeletedAt)
 }
 
 func TestModelsTestSuite(t *testing.T) {


### PR DESCRIPTION
### Fixes [BCDA-1245](https://jira.cms.gov/browse/BCDA-1245)
We need a way to properly remove access of encryption keys for a system

### Proposed changes:
- add func to auth/models.go that soft deletes an encryption key belonging to a system
- add test to validate functionality

### Security Implications
No security implications with this PR yet.  It's just adding some functionality to inactivate a system's encryption keys.  These encryption keys are not being distributed or used yet.

### Acceptance Validation
I added a test to make sure that an encryption key is deleted without errors and that the deleted_at field is set (soft deletion)

### Feedback Requested
Why am I failing the assertion I wrote to make sure that the deleted_at column is not null?
