### PR TITLE
Knollfear/bcda 1233 - Fix Bene Assignment

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -172,8 +172,8 @@ func (aco *ACO) GetBeneficiaryIDs() (cclfBeneficiaryIDs []string, err error) {
 	defer database.Close(db)
 	var cclfFile CCLFFile
 	// should I put a filter here to make sure it isn't too old?
-	if db.Where("aco_cms_id = ? and cclf_num = 8", aco.CMSID).Order("Timestamp, desc").First(&cclfFile).RecordNotFound() {
-		log.Error("Unable to find CCLF8 File for ACO %s", aco.CMSID)
+	if db.Where("aco_cms_id = ? and cclf_num = 8", aco.CMSID).Order("timestamp desc").First(&cclfFile).RecordNotFound() {
+		log.Errorf("Unable to find CCLF8 File for ACO %v", aco.CMSID)
 		return cclfBeneficiaryIDs, fmt.Errorf("unable to find cclfFile")
 	}
 
@@ -376,6 +376,11 @@ func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (bl
 		return "", err
 	}
 
+	if len(patient.Entry) == 0 {
+		err = fmt.Errorf("patient identifier not found at BlueButton for cclfBenficiary ID: %v", cclfBeneficiary.ID)
+		log.Error(err)
+		return "", err
+	}
 	blueButtonID = patient.Entry[0].Resource.ID
 	fullURL := patient.Entry[0].FullUrl
 	if !strings.Contains(fullURL, blueButtonID) {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -185,7 +185,7 @@ func processJob(j *que.Job) error {
 	return nil
 }
 
-func writeBBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []string, jobID, t string) (fileName string, error error) {
+func writeBBDataToFile(bb client.APIClient, acoID string, cclfbeneficiaryIDs []string, jobID, t string) (fileName string, error error) {
 	segment := newrelic.StartSegment(txn, "writeBBDataToFile")
 
 	if bb == nil {
@@ -228,10 +228,14 @@ func writeBBDataToFile(bb client.APIClient, acoID string, beneficiaryIDs []strin
 
 	w := bufio.NewWriter(f)
 	errorCount := 0
-	totalBeneIDs := float64(len(beneficiaryIDs))
+	totalBeneIDs := float64(len(cclfbeneficiaryIDs))
 	failThreshold := getFailureThreshold()
-
-	for _, beneficiaryID := range beneficiaryIDs {
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+	for _, cclfBeneficiaryID := range cclfBeneficiaryIDs {
+		var cclfBeneficiary models.CCLFBeneficiary
+		db.First(&cclfBeneficiary, cclfBeneficiaryID)
+		blueButtonID = cclfBeneficiary.
 		pData, err := bbFunc(beneficiaryID, jobID)
 		if err != nil {
 			log.Error(err)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -8,7 +8,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/bgentry/que-go"
 	"github.com/pborman/uuid"
@@ -50,23 +52,33 @@ func TestMainTestSuite(t *testing.T) {
 }
 
 func TestWriteEOBDataToFile(t *testing.T) {
+	db := database.GetGORMDbConnection()
+	defer db.Close()
 	os.Setenv("FHIR_STAGING_DIR", "data/test")
 
 	bbc := testUtils.BlueButtonClient{}
 	acoID := "9c05c1f8-349d-400f-9b69-7963f2262b07"
-	beneficiaryIDs := []string{"10000", "11000"}
 	jobID := "1"
 	staging := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012309"}
+	db.Create(&cclfFile)
+	defer db.Delete(&cclfFile)
 
 	// clean out the data dir before beginning this test
 	os.RemoveAll(staging)
 	testUtils.CreateStaging(jobID)
-
+	beneficiaryIDs := []string{"1000003701", "1000050699"}
+	var cclfBeneficiaryIDs []string
 	for i := 0; i < len(beneficiaryIDs); i++ {
-		bbc.On("GetExplanationOfBenefitData", beneficiaryIDs[i]).Return(bbc.GetData("ExplanationOfBenefit", beneficiaryIDs[i]))
+		beneficiaryID := beneficiaryIDs[i]
+		cclfBeneficiary := models.CCLFBeneficiary{FileID: cclfFile.ID, HICN: beneficiaryID, MBI: "whatever", BlueButtonID: beneficiaryID}
+		db.Create(&cclfBeneficiary)
+		defer db.Delete(&cclfBeneficiary)
+		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
+		bbc.On("GetExplanationOfBenefitData", beneficiaryIDs[i]).Return(bbc.GetData("ExplanationOfBenefit", beneficiaryID))
 	}
 
-	_, err := writeBBDataToFile(&bbc, acoID, beneficiaryIDs, jobID, "ExplanationOfBenefit")
+	_, err := writeBBDataToFile(&bbc, acoID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit")
 	if err != nil {
 		t.Fail()
 	}
@@ -130,10 +142,25 @@ func TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(t *testing.T) {
 	bbc.On("GetExplanationOfBenefitData", "12000").Return(bbc.GetData("ExplanationOfBenefit", "12000"))
 	acoID := "387c3a62-96fa-4d93-a5d0-fd8725509dd9"
 	beneficiaryIDs := []string{"10000", "11000", "12000"}
+	var cclfBeneficiaryIDs []string
+
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012309"}
+	db.Create(&cclfFile)
+	defer db.Delete(&cclfFile)
+
+	for i := 0; i < len(beneficiaryIDs); i++ {
+		beneficiaryID := beneficiaryIDs[i]
+		cclfBeneficiary := models.CCLFBeneficiary{FileID: cclfFile.ID, HICN: beneficiaryID, MBI: "whatever", BlueButtonID: beneficiaryID}
+		db.Create(&cclfBeneficiary)
+		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
+		defer db.Delete(&cclfBeneficiary)
+	}
 	jobID := "1"
 	testUtils.CreateStaging(jobID)
 
-	fileName, err := writeBBDataToFile(&bbc, acoID, beneficiaryIDs, jobID, "ExplanationOfBenefit")
+	fileName, err := writeBBDataToFile(&bbc, acoID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit")
 	if err != nil {
 		t.Fail()
 	}
@@ -161,14 +188,29 @@ func TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(t *testing.T) {
 
 	bbc := testUtils.BlueButtonClient{}
 	// Set up the mock function to return the expected values
-	bbc.On("GetExplanationOfBenefitData", "10000").Return("", errors.New("error"))
-	bbc.On("GetExplanationOfBenefitData", "11000").Return("", errors.New("error"))
+	bbc.On("GetExplanationOfBenefitData", "1000089833").Return("", errors.New("error"))
+	bbc.On("GetExplanationOfBenefitData", "1000065301").Return("", errors.New("error"))
 	acoID := "387c3a62-96fa-4d93-a5d0-fd8725509dd9"
-	beneficiaryIDs := []string{"10000", "11000", "12000"}
+	beneficiaryIDs := []string{"1000089833", "1000065301", "1000012463"}
+	var cclfBeneficiaryIDs []string
+	db := database.GetGORMDbConnection()
+	defer db.Close()
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012309"}
+	db.Create(&cclfFile)
+	defer db.Delete(&cclfFile)
+
+	for i := 0; i < len(beneficiaryIDs); i++ {
+		beneficiaryID := beneficiaryIDs[i]
+		cclfBeneficiary := models.CCLFBeneficiary{FileID: cclfFile.ID, HICN: beneficiaryID, MBI: "whatever", BlueButtonID: beneficiaryID}
+		db.Create(&cclfBeneficiary)
+		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
+		defer db.Delete(&cclfBeneficiary)
+	}
+
 	jobID := "1"
 	testUtils.CreateStaging(jobID)
 
-	_, err := writeBBDataToFile(&bbc, acoID, beneficiaryIDs, jobID, "ExplanationOfBenefit")
+	_, err := writeBBDataToFile(&bbc, acoID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit")
 	assert.Equal(t, "number of failed requests has exceeded threshold", err.Error())
 
 	filePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_STAGING_DIR"), jobID, acoID)
@@ -177,12 +219,12 @@ func TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(t *testing.T) {
 		t.Fail()
 	}
 
-	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 10000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}
-{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 11000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 11000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}`
+	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 1000089833 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 1000089833 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}
+{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary 1000065301 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary 1000065301 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}`
 	assert.Equal(t, ooResp+"\n", string(fData))
 	bbc.AssertExpectations(t)
 	// should not have requested third beneficiary EOB because failure threshold was reached after second
-	bbc.AssertNotCalled(t, "GetExplanationOfBenefitData", "12000")
+	bbc.AssertNotCalled(t, "GetExplanationOfBenefitData", "1000012463")
 
 	os.Remove(fmt.Sprintf("%s/%s/%s.ndjson", os.Getenv("FHIR_STAGING_DIR"), jobID, acoID))
 	os.Remove(filePath)


### PR DESCRIPTION

<!-- Replace xxx with the JIRA ticket number: -->
### Fixes [BCDA-1233](https://jira.cms.gov/browse/BCDA-1233)

<!-- describe the problem being solved here -->

Due to changes in the underlying architecture the source of truth about which beneficiaries are attributed to an ACO at any given time has changed.  This PR represents a switch from using ACOBeneficiaries to using CCLFBeneficiaries.  

### Proposed changes:
<!-- List of changes with bullet points here: -->

- Change aco.GetBeneficiaryIDs to return a list of CCLFBeneficiary ID's instead of blue button Identifiers.
- Change job processing to expect a cclfBeneficiaryID instead of a BlueButtonIdentifier

### Change Details
<!-- add detailed discussion of changes here: -->
- Also had to change out several unit tests because they were no longer getting the right arguments to ProcessJob.

### Security Implications
<!-- Does the change deal with PII at all? What should reviewers look for in terms of security concerns? -->
This PR changes how we align beneficiaries with ACO's.  If this gets it wrong we would end up sending the wrong beneficiary data to the end user.

### Acceptance Validation
<!-- were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
Unit tests ran, data retrieved from BlueButton was for the correct beneficiary ID's 
<!-- insert screenshots if applicable (drag images here) -->


### Feedback Requested
<!-- what type of feedback you want from your reviewers? -->
any.  
Do I need to limit how old a valid CCLF8 file can be to still be valid.