### PR TITLE
BCDA-1194 Feature: Added ETL logging

### DIFF
--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -128,14 +128,14 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 	}
 
 	if _, ok := validator["CCLF8"]; !ok {
-		fmt.Printf("Failed to parse CCLF8 from CCLF0 file: %v.\n", fileMetadata)
-		err := fmt.Errorf("failed to parse CCLF8 from CCLF0 file: %v", fileMetadata)
+		fmt.Printf("Failed to parse CCLF8 from CCLF0 file: %#v.\n", fileMetadata)
+		err := fmt.Errorf("failed to parse CCLF8 from CCLF0 file: %#v", fileMetadata)
 		log.Error(err)
 		return nil, err
 	}
 	if _, ok := validator["CCLF9"]; !ok {
-		fmt.Printf("Failed to parse CCLF9 from CCLF0 file: %v.\n", fileMetadata)
-		err := fmt.Errorf("failed to parse CCLF9 from CCLF0 file: %v", fileMetadata)
+		fmt.Printf("Failed to parse CCLF9 from CCLF0 file: %#v.\n", fileMetadata)
+		err := fmt.Errorf("failed to parse CCLF9 from CCLF0 file: %#v", fileMetadata)
 		log.Error(err)
 		return nil, err
 	}
@@ -363,8 +363,8 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		cclfvalidator, err := importCCLF0(cclf0)
 		if err != nil {
-			fmt.Printf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v.\n ", cclf0, cclf8, cclf9)
-			log.Errorf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v ", cclf0, cclf8, cclf9)
+			fmt.Printf("Failed to import CCLF0 file: %#v, Skipping CCLF8 file: %#v and CCLF9 file: %#v.\n ", cclf0, cclf8, cclf9)
+			log.Errorf("Failed to import CCLF0 file: %#v, Skipping CCLF8 file: %#v and CCLF9 file: %#v ", cclf0, cclf8, cclf9)
 			failure++
 			skipped += 2
 			continue
@@ -373,13 +373,13 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		err = validate(cclf8, cclfvalidator)
 		if err != nil {
-			fmt.Printf("Failed to validate CCLF8 file: %v.\n", cclf8)
-			log.Errorf("Failed to validate CCLF8 file: %v", cclf8)
+			fmt.Printf("Failed to validate CCLF8 file: %#v.\n", cclf8)
+			log.Errorf("Failed to validate CCLF8 file: %#v", cclf8)
 			failure++
 		} else {
 			if err = importCCLF8(cclf8); err != nil {
-				fmt.Printf("Failed to import CCLF8 file: %v.\n", cclf8)
-				log.Errorf("Failed to import CCLF8 file: %v ", cclf8)
+				fmt.Printf("Failed to import CCLF8 file: %#v.\n", cclf8)
+				log.Errorf("Failed to import CCLF8 file: %#v ", cclf8)
 				failure++
 			} else {
 				cclf8.imported = true
@@ -388,13 +388,13 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		err = validate(cclf9, cclfvalidator)
 		if err != nil {
-			fmt.Printf("Failed to validate CCLF9 file: %v.\n", cclf9)
-			log.Errorf("Failed to validate CCLF9 file: %v", cclf9)
+			fmt.Printf("Failed to validate CCLF9 file: %#v.\n", cclf9)
+			log.Errorf("Failed to validate CCLF9 file: %#v", cclf9)
 			failure++
 		} else {
 			if err = importCCLF9(cclf9); err != nil {
-				fmt.Printf("Failed to import CCLF9 file: %v.\n", cclf9)
-				log.Errorf("Failed to import CCLF9 file: %v ", cclf9)
+				fmt.Printf("Failed to import CCLF9 file: %#v.\n", cclf9)
+				log.Errorf("Failed to import CCLF9 file: %#v ", cclf9)
 				failure++
 			} else {
 				cclf9.imported = true
@@ -431,15 +431,15 @@ func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepa
 		metadata.deliveryDate = info.ModTime()
 		if err != nil {
 			// skipping files with a bad name.  An unknown file in this dir isn't a blocker
-			fmt.Printf("Unknown file found: %v.\n", metadata)
-			log.Errorf("Unknown file found: %v", metadata)
+			fmt.Printf("Unknown file found: %#v.\n", metadata)
+			log.Errorf("Unknown file found: %#v", metadata)
 			*skipped = *skipped + 1
 
 			newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), info.Name())
 			err = os.Rename(metadata.filePath, newpath)
 			if err != nil {
-				fmt.Printf("Error moving unknown file: %v to pending deletion dir.\n", metadata)
-				err  = fmt.Errorf("error moving unknown file: %v to pending deletion dir", metadata)
+				fmt.Printf("Error moving unknown file: %#v to pending deletion dir.\n", metadata)
+				err  = fmt.Errorf("error moving unknown file: %#v to pending deletion dir", metadata)
 				log.Error(err)
 				return err
 			}
@@ -474,8 +474,8 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 	} else if fileMetadata.cclfNum == 9 {
 		key = "CCLF9"
 	} else {
-		fmt.Printf("Unknown file type when validating file: %v.\n", fileMetadata)
-		err := fmt.Errorf("unknown file type when validating file: %v", fileMetadata)
+		fmt.Printf("Unknown file type when validating file: %#v.\n", fileMetadata)
+		err := fmt.Errorf("unknown file type when validating file: %#v", fileMetadata)
 		log.Error(err)
 		return err
 	}
@@ -575,8 +575,8 @@ func deleteDirectoryContents(dirToDelete string) (filesDeleted int, err error) {
 func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 	for _, cclflist := range cclfmap {
 		for _, cclf := range cclflist {
-			fmt.Printf("Cleaning up file %v.\n", cclf)
-			log.Infof("Cleaning up file %v", cclf)
+			fmt.Printf("Cleaning up file %#v.\n", cclf)
+			log.Infof("Cleaning up file %#v", cclf)
 			newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), cclf.name)
 			if !cclf.imported {
 				// check the timestamp on the failed files
@@ -584,22 +584,22 @@ func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 				if int(elapsed) > deleteThresholdHr {
 					err := os.Rename(cclf.filePath, newpath)
 					if err != nil {
-						fmt.Printf("File: %v failed to cleanup properly.\n", cclf)
-						log.Errorf("File: %v failed to cleanup properly", cclf)
+						fmt.Printf("File: %#v failed to cleanup properly.\n", cclf)
+						log.Errorf("File: %#v failed to cleanup properly", cclf)
 					} else {
-						fmt.Printf("File: %v never ingested, moved to the pending deletion dir.\n", cclf)
-						log.Infof("File: %v never ingested, moved to the pending deletion dir", cclf)
+						fmt.Printf("File: %#v never ingested, moved to the pending deletion dir.\n", cclf)
+						log.Infof("File: %#v never ingested, moved to the pending deletion dir", cclf)
 					}
 				}
 			} else {
 				// move the successful files to the deletion dir
 				err := os.Rename(cclf.filePath, newpath)
 				if err != nil {
-					fmt.Printf("File: %v failed to cleanup properly.\n", cclf)
-					log.Errorf("File: %v failed to cleanup properly", cclf)
+					fmt.Printf("File: %#v failed to cleanup properly.\n", cclf)
+					log.Errorf("File: %#v failed to cleanup properly", cclf)
 				} else {
-					fmt.Printf("File: %v successfully ingested, moved to the pending deletion dir.\n", cclf)
-					log.Infof("File: %v successfully ingested, moved to the pending deletion dir", cclf)
+					fmt.Printf("File: %#v successfully ingested, moved to the pending deletion dir.\n", cclf)
+					log.Infof("File: %#v successfully ingested, moved to the pending deletion dir", cclf)
 				}
 			}
 		}

--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -62,7 +62,7 @@ const deleteThresholdHr = 8
 
 func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, error) {
 	if fileMetadata == nil {
-		fmt.Print("file CCLF0 not found")
+		fmt.Println("File CCLF0 not found.")
 		err := errors.New("file CCLF0 not found")
 		log.Error(err)
 		return nil, err
@@ -73,7 +73,7 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 
 	r, err := zip.OpenReader(filepath.Clean(fileMetadata.filePath))
 	if err != nil {
-		fmt.Printf("could not read CCLF0 archive %s", fileMetadata.name)
+		fmt.Printf("Could not read CCLF0 archive %s.\n", fileMetadata.name)
 		err := errors.Wrapf(err, "could not read CCLF0 archive %s", fileMetadata.name)
 		log.Error(err)
 		return nil, err
@@ -88,11 +88,11 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 
 	var validator map[string]cclfFileValidator
 	for i, f := range r.File {
-		fmt.Printf("Reading file #%d from archive %s", i, fileMetadata.name)
+		fmt.Printf("Reading file #%d from archive %s.\n", i, fileMetadata.name)
 		log.Infof("Reading file #%d from archive %s", i, fileMetadata.name)
 		rc, err := f.Open()
 		if err != nil {
-			fmt.Printf("could not read file %s in CCLF0 archive %s", f.Name, fileMetadata.name)
+			fmt.Printf("Could not read file %s in CCLF0 archive %s.\n", f.Name, fileMetadata.name)
 			err = errors.Wrapf(err, "could not read file %s in CCLF0 archive %s", f.Name, fileMetadata.name)
 			log.Error(err)
 			return nil, err
@@ -109,15 +109,15 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 					}
 					count, err := strconv.Atoi(string(bytes.TrimSpace(b[totalRecordStart:totalRecordEnd])))
 					if err != nil {
-						fmt.Printf("Failed to parse %s record count from CCLF0 file", filetype)
-						err = errors.Wrapf(err,"Failed to parse %s record count from CCLF0 file", filetype)
+						fmt.Printf("Failed to parse %s record count from CCLF0 file.\n", filetype)
+						err = errors.Wrapf(err,"failed to parse %s record count from CCLF0 file", filetype)
 						log.Error(err)
 						return nil, err
 					}
 					length, err := strconv.Atoi(string(bytes.TrimSpace(b[recordLengthStart:recordLengthEnd])))
 					if err != nil {
-						fmt.Printf("Failed to parse %s record length from CCLF0 file", filetype)
-						err = errors.Wrapf(err,"Failed to parse %s record length from CCLF0 file", filetype)
+						fmt.Printf("Failed to parse %s record length from CCLF0 file.\n", filetype)
+						err = errors.Wrapf(err,"failed to parse %s record length from CCLF0 file", filetype)
 						log.Error(err)
 						return nil, err
 					}
@@ -128,13 +128,13 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 	}
 
 	if _, ok := validator["CCLF8"]; !ok {
-		fmt.Printf("failed to parse CCLF8 from CCLF0 file: %v", fileMetadata)
+		fmt.Printf("Failed to parse CCLF8 from CCLF0 file: %v.\n", fileMetadata)
 		err := fmt.Errorf("failed to parse CCLF8 from CCLF0 file: %v", fileMetadata)
 		log.Error(err)
 		return nil, err
 	}
 	if _, ok := validator["CCLF9"]; !ok {
-		fmt.Printf("failed to parse CCLF9 from CCLF0 file: %v", fileMetadata)
+		fmt.Printf("Failed to parse CCLF9 from CCLF0 file: %v.\n", fileMetadata)
 		err := fmt.Errorf("failed to parse CCLF9 from CCLF0 file: %v", fileMetadata)
 		log.Error(err)
 		return nil, err
@@ -158,7 +158,7 @@ func importCCLF8(fileMetadata *cclfFileMetadata) error {
 		}
 		err := db.Create(cclfBeneficiary).Error
 		if err != nil {
-			fmt.Print("could not create CCLF8 beneficiary record")
+			fmt.Println("Could not create CCLF8 beneficiary record.")
 			err = errors.Wrap(err, "could not create CCLF8 beneficiary record")
 			log.Error(err)
 			return err
@@ -192,7 +192,7 @@ func importCCLF9(fileMetadata *cclfFileMetadata) error {
 		}
 		err := db.Create(&cclf9).Error
 		if err != nil {
-			fmt.Print("could not create CCLF9 cross reference record")
+			fmt.Println("Could not create CCLF9 cross reference record.")
 			err = errors.Wrap(err, "could not create CCLF9 cross reference record")
 			log.Error(err)
 			return err
@@ -209,7 +209,7 @@ func importCCLF9(fileMetadata *cclfFileMetadata) error {
 
 func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *gorm.DB) error) error {
 	if fileMetadata == nil {
-		fmt.Print("CCLF file not found")
+		fmt.Println("CCLF file not found.")
 		err := errors.New("CCLF file not found")
 		log.Error(err)
 		return err
@@ -220,7 +220,7 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 
 	r, err := zip.OpenReader(filepath.Clean(fileMetadata.filePath))
 	if err != nil {
-		fmt.Printf("could not read CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
+		fmt.Printf("Could not read CCLF%d archive %s.\n", fileMetadata.cclfNum, fileMetadata.name)
 		err := errors.Wrapf(err, "could not read CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
 		log.Error(err)
 		return err
@@ -228,7 +228,7 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 	defer r.Close()
 
 	if len(r.File) < 1 {
-		fmt.Printf("no files found in CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
+		fmt.Printf("No files found in CCLF%d archive %s.\n", fileMetadata.cclfNum, fileMetadata.name)
 		err := fmt.Errorf("no files found in CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
 		log.Error(err)
 		return err
@@ -247,18 +247,18 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 
 	err = db.Create(&cclfFile).Error
 	if err != nil {
-		fmt.Printf("could not create CCLF%d file record", fileMetadata.cclfNum)
+		fmt.Printf("Could not create CCLF%d file record.\n", fileMetadata.cclfNum)
 		err = errors.Wrapf(err, "could not create CCLF%d file record", fileMetadata.cclfNum)
 		log.Error(err)
 		return err
 	}
 
 	for i, f := range r.File {
-		fmt.Printf("Reading file #%d from archive %s", i, fileMetadata.name)
+		fmt.Printf("Reading file #%d from archive %s.\n", i, fileMetadata.name)
 		log.Infof("Reading file #%d from archive %s", i, fileMetadata.name)
 		rc, err := f.Open()
 		if err != nil {
-			fmt.Printf("could not read file %s in CCLF%d archive %s", f.Name, fileMetadata.cclfNum, fileMetadata.name)
+			fmt.Printf("Could not read file %s in CCLF%d archive %s.\n", f.Name, fileMetadata.cclfNum, fileMetadata.name)
 			err = errors.Wrapf(err, "could not read file %s in CCLF%d archive %s", f.Name, fileMetadata.cclfNum, fileMetadata.name)
 			log.Error(err)
 			return err
@@ -290,7 +290,7 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 	filenameRegexp := regexp.MustCompile(`(T|P)\.(A\d{4})\.ACO\.ZC(0|8|9)Y(\d{2})\.(D\d{6}\.T\d{6})\d`)
 	filenameMatches := filenameRegexp.FindStringSubmatch(filePath)
 	if len(filenameMatches) < 5 {
-		fmt.Printf("invalid filename for file: %s", filePath)
+		fmt.Printf("Invalid filename for file: %s.\n", filePath)
 		err := fmt.Errorf("invalid filename for file: %s", filePath)
 		log.Error(err)
 		return metadata, err
@@ -298,7 +298,7 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 
 	cclfNum, err := strconv.Atoi(filenameMatches[3])
 	if err != nil {
-		fmt.Printf("failed to parse cclf num from file: %s", filePath)
+		fmt.Printf("Failed to parse cclf num from file: %s.\n", filePath)
 		err = errors.Wrapf(err,"failed to parse cclf num from file: %s", filePath)
 		log.Error(err)
 		return metadata, err
@@ -306,7 +306,7 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 
 	perfYear, err := strconv.Atoi(filenameMatches[4])
 	if err != nil {
-		fmt.Printf("failed to parse performance year from file: %s", filePath)
+		fmt.Printf("Failed to parse performance year from file: %s.\n", filePath)
 		err = errors.Wrapf(err,"failed to parse performance year from file: %s", filePath)
 		log.Error(err)
 		return metadata, err
@@ -315,7 +315,7 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 	filenameDate := filenameMatches[5]
 	t, err := time.Parse("D060102.T150405", filenameDate)
 	if err != nil || t.IsZero() {
-		fmt.Printf("failed to parse date '%s' from file: %s", filenameDate, filePath)
+		fmt.Printf("Failed to parse date '%s' from file: %s.\n", filenameDate, filePath)
 		err = errors.Wrapf(err,"failed to parse date '%s' from file: %s", filenameDate, filePath)
 		log.Error(err)
 		return metadata, err
@@ -363,7 +363,7 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		cclfvalidator, err := importCCLF0(cclf0)
 		if err != nil {
-			fmt.Printf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v ", cclf0, cclf8, cclf9)
+			fmt.Printf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v.\n ", cclf0, cclf8, cclf9)
 			log.Errorf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v ", cclf0, cclf8, cclf9)
 			failure++
 			skipped += 2
@@ -373,12 +373,12 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		err = validate(cclf8, cclfvalidator)
 		if err != nil {
-			fmt.Printf("Failed to validate CCLF8 file: %v", cclf8)
+			fmt.Printf("Failed to validate CCLF8 file: %v.\n", cclf8)
 			log.Errorf("Failed to validate CCLF8 file: %v", cclf8)
 			failure++
 		} else {
 			if err = importCCLF8(cclf8); err != nil {
-				fmt.Printf("Failed to import CCLF8 file: %v ", cclf8)
+				fmt.Printf("Failed to import CCLF8 file: %v.\n", cclf8)
 				log.Errorf("Failed to import CCLF8 file: %v ", cclf8)
 				failure++
 			} else {
@@ -388,12 +388,12 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		err = validate(cclf9, cclfvalidator)
 		if err != nil {
-			fmt.Printf("Failed to validate CCLF9 file: %v", cclf9)
+			fmt.Printf("Failed to validate CCLF9 file: %v.\n", cclf9)
 			log.Errorf("Failed to validate CCLF9 file: %v", cclf9)
 			failure++
 		} else {
 			if err = importCCLF9(cclf9); err != nil {
-				fmt.Printf("Failed to import CCLF9 file: %v ", cclf9)
+				fmt.Printf("Failed to import CCLF9 file: %v.\n", cclf9)
 				log.Errorf("Failed to import CCLF9 file: %v ", cclf9)
 				failure++
 			} else {
@@ -417,8 +417,8 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			fmt.Printf("Error in sorting cclf file: %v,", info.Name())
-			err = errors.Wrapf(err,"Error in sorting cclf file: %v,", info.Name())
+			fmt.Printf("Error in sorting cclf file: %v.\n", info.Name())
+			err = errors.Wrapf(err,"error in sorting cclf file: %v,", info.Name())
 			log.Error(err)
 			return err
 		}
@@ -431,14 +431,14 @@ func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepa
 		metadata.deliveryDate = info.ModTime()
 		if err != nil {
 			// skipping files with a bad name.  An unknown file in this dir isn't a blocker
-			fmt.Printf("unknown file found: %v", metadata)
-			log.Errorf("unknown file found: %v", metadata)
+			fmt.Printf("Unknown file found: %v.\n", metadata)
+			log.Errorf("Unknown file found: %v", metadata)
 			*skipped = *skipped + 1
 
 			newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), info.Name())
 			err = os.Rename(metadata.filePath, newpath)
 			if err != nil {
-				fmt.Printf("error moving unknown file: %v to pending deletion dir", metadata)
+				fmt.Printf("Error moving unknown file: %v to pending deletion dir.\n", metadata)
 				err  = fmt.Errorf("error moving unknown file: %v to pending deletion dir", metadata)
 				log.Error(err)
 				return err
@@ -459,7 +459,7 @@ func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepa
 
 func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfFileValidator) error {
 	if fileMetadata == nil {
-		fmt.Printf("file not found")
+		fmt.Printf("File not found.\n")
 		err := errors.New("file not found")
 		log.Error(err)
 		return err
@@ -474,15 +474,15 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 	} else if fileMetadata.cclfNum == 9 {
 		key = "CCLF9"
 	} else {
-		fmt.Printf("unknown file type when validating file: %v,", fileMetadata)
-		err := fmt.Errorf("unknown file type when validating file: %v,", fileMetadata)
+		fmt.Printf("Unknown file type when validating file: %v.\n", fileMetadata)
+		err := fmt.Errorf("unknown file type when validating file: %v", fileMetadata)
 		log.Error(err)
 		return err
 	}
 
 	r, err := zip.OpenReader(filepath.Clean(fileMetadata.filePath))
 	if err != nil {
-		fmt.Printf("could not read archive %s", fileMetadata.name)
+		fmt.Printf("Could not read archive %s.\n", fileMetadata.name)
 		err := errors.Wrapf(err, "could not read archive %s", fileMetadata.name)
 		log.Error(err)
 		return err
@@ -493,11 +493,11 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 	validator := cclfFileValidator[key]
 
 	for i, f := range r.File {
-		fmt.Printf("Reading file #%d from archive %s", i, fileMetadata.name)
+		fmt.Printf("Reading file #%d from archive %s.\n", i, fileMetadata.name)
 		log.Infof("Reading file #%d from archive %s", i, fileMetadata.name)
 		rc, err := f.Open()
 		if err != nil {
-			fmt.Printf("could not read file %s in archive %s", f.Name, fileMetadata.name)
+			fmt.Printf("Could not read file %s in archive %s.\n", f.Name, fileMetadata.name)
 			err = errors.Wrapf(err, "could not read file %s in archive %s", f.Name, fileMetadata.name)
 			log.Error(err)
 			return err
@@ -512,13 +512,13 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 
 				// currently only errors if there are more records than we expect.
 				if count > validator.totalRecordCount {
-					fmt.Printf("maximum record count reached for file %s, Expected record count: %d, Actual record count: %d ", key, validator.totalRecordCount, count)
+					fmt.Printf("Maximum record count reached for file %s, Expected record count: %d, Actual record count: %d.\n", key, validator.totalRecordCount, count)
 					err := fmt.Errorf("maximum record count reached for file %s, Expected record count: %d, Actual record count: %d ", key, validator.totalRecordCount, count)
 					log.Error(err)
 					return err
 				}
 			} else {
-				fmt.Printf("incorrect record length for file %s, Expected record length: %d, Actual record length: %d", key, validator.maxRecordLength, bytelength)
+				fmt.Printf("Incorrect record length for file %s, Expected record length: %d, Actual record length: %d.\n", key, validator.maxRecordLength, bytelength)
 				err := fmt.Errorf("incorrect record length for file %s, Expected record length: %d, Actual record length: %d", key, validator.maxRecordLength, bytelength)
 				log.Error(err)
 				return err
@@ -531,43 +531,43 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 }
 
 func deleteDirectoryContents(dirToDelete string) (filesDeleted int, err error) {
-	fmt.Printf("preparing to delete directory '%v'", dirToDelete)
-	log.Infof("preparing to delete directory '%v'", dirToDelete)
+	fmt.Printf("Preparing to delete directory %v.\n", dirToDelete)
+	log.Infof("Preparing to delete directory %v", dirToDelete)
 	f, err := os.Open(filepath.Clean(dirToDelete))
 	if err != nil {
-		fmt.Printf("could not open dir: %s", dirToDelete)
+		fmt.Printf("Could not open dir: %s.\n", dirToDelete)
 		err = errors.Wrapf(err, "could not open dir: %s", dirToDelete)
 		log.Error(err)
 		return 0, err
 	}
 	files, err := f.Readdir(-1)
 	if err != nil {
-		fmt.Printf("error reading files from dir: %s", f.Name())
+		fmt.Printf("Error reading files from dir: %s.\n", f.Name())
 		err = errors.Wrapf(err, "error reading files from dir: %s", f.Name())
 		log.Error(err)
 		return 0, err
 	}
 	err = f.Close()
 	if err != nil {
-		fmt.Printf("error closing dir: %s", f.Name())
+		fmt.Printf("Error closing dir: %s.\n", f.Name())
 		err = errors.Wrapf(err,"error closing dir: %s", f.Name())
 		log.Error(err)
 		return 0, err
 	}
 
 	for _, file := range files {
-		fmt.Printf("deleting %s", file.Name())
+		fmt.Printf("Deleting %s.\n", file.Name())
 		log.Infof("deleting %s ", file.Name())
 		err = os.Remove(filepath.Join(dirToDelete, file.Name()))
 		if err != nil {
-			fmt.Printf("error deleting file: %s from dir: %s", file.Name(), dirToDelete)
+			fmt.Printf("Error deleting file: %s from dir: %s.\n", file.Name(), dirToDelete)
 			err = errors.Wrapf(err,"error deleting file: %s from dir: %s", file.Name(), dirToDelete)
 			log.Error(err)
 			return 0, err
 		}
 	}
 
-	fmt.Printf("Successfully deleted all files from dir: %s", dirToDelete)
+	fmt.Printf("Successfully deleted all files from dir: %s.\n", dirToDelete)
 	log.Infof("Successfully deleted all files from dir: %s", dirToDelete)
 	return len(files), nil
 }
@@ -575,7 +575,7 @@ func deleteDirectoryContents(dirToDelete string) (filesDeleted int, err error) {
 func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 	for _, cclflist := range cclfmap {
 		for _, cclf := range cclflist {
-			fmt.Printf("Cleaning up file %v", cclf)
+			fmt.Printf("Cleaning up file %v.\n", cclf)
 			log.Infof("Cleaning up file %v", cclf)
 			newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), cclf.name)
 			if !cclf.imported {
@@ -584,22 +584,22 @@ func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 				if int(elapsed) > deleteThresholdHr {
 					err := os.Rename(cclf.filePath, newpath)
 					if err != nil {
-						fmt.Printf("file: %v failed to cleanup properly", cclf)
-						log.Errorf("file: %v failed to cleanup properly", cclf)
+						fmt.Printf("File: %v failed to cleanup properly.\n", cclf)
+						log.Errorf("File: %v failed to cleanup properly", cclf)
 					} else {
-						fmt.Printf("file: %v never ingested, moved to the pending deletion dir", cclf)
-						log.Infof("file: %v never ingested, moved to the pending deletion dir", cclf)
+						fmt.Printf("File: %v never ingested, moved to the pending deletion dir.\n", cclf)
+						log.Infof("File: %v never ingested, moved to the pending deletion dir", cclf)
 					}
 				}
 			} else {
 				// move the successful files to the deletion dir
 				err := os.Rename(cclf.filePath, newpath)
 				if err != nil {
-					fmt.Printf("file: %v failed to cleanup properly", cclf)
-					log.Errorf("file: %v failed to cleanup properly", cclf)
+					fmt.Printf("File: %v failed to cleanup properly.\n", cclf)
+					log.Errorf("File: %v failed to cleanup properly", cclf)
 				} else {
-					fmt.Printf("file: %v successfully ingested, moved to the pending deletion dir", cclf)
-					log.Infof("file: %v successfully ingested, moved to the pending deletion dir", cclf)
+					fmt.Printf("File: %v successfully ingested, moved to the pending deletion dir.\n", cclf)
+					log.Infof("File: %v successfully ingested, moved to the pending deletion dir", cclf)
 				}
 			}
 		}

--- a/bcda/cli.go
+++ b/bcda/cli.go
@@ -62,6 +62,7 @@ const deleteThresholdHr = 8
 
 func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, error) {
 	if fileMetadata == nil {
+		fmt.Print("file CCLF0 not found")
 		err := errors.New("file CCLF0 not found")
 		log.Error(err)
 		return nil, err
@@ -72,6 +73,7 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 
 	r, err := zip.OpenReader(filepath.Clean(fileMetadata.filePath))
 	if err != nil {
+		fmt.Printf("could not read CCLF0 archive %s", fileMetadata.name)
 		err := errors.Wrapf(err, "could not read CCLF0 archive %s", fileMetadata.name)
 		log.Error(err)
 		return nil, err
@@ -86,9 +88,11 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 
 	var validator map[string]cclfFileValidator
 	for i, f := range r.File {
+		fmt.Printf("Reading file #%d from archive %s", i, fileMetadata.name)
 		log.Infof("Reading file #%d from archive %s", i, fileMetadata.name)
 		rc, err := f.Open()
 		if err != nil {
+			fmt.Printf("could not read file %s in CCLF0 archive %s", f.Name, fileMetadata.name)
 			err = errors.Wrapf(err, "could not read file %s in CCLF0 archive %s", f.Name, fileMetadata.name)
 			log.Error(err)
 			return nil, err
@@ -105,11 +109,15 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 					}
 					count, err := strconv.Atoi(string(bytes.TrimSpace(b[totalRecordStart:totalRecordEnd])))
 					if err != nil {
+						fmt.Printf("Failed to parse %s record count from CCLF0 file", filetype)
+						err = errors.Wrapf(err,"Failed to parse %s record count from CCLF0 file", filetype)
 						log.Error(err)
 						return nil, err
 					}
 					length, err := strconv.Atoi(string(bytes.TrimSpace(b[recordLengthStart:recordLengthEnd])))
 					if err != nil {
+						fmt.Printf("Failed to parse %s record length from CCLF0 file", filetype)
+						err = errors.Wrapf(err,"Failed to parse %s record length from CCLF0 file", filetype)
 						log.Error(err)
 						return nil, err
 					}
@@ -120,17 +128,19 @@ func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, 
 	}
 
 	if _, ok := validator["CCLF8"]; !ok {
+		fmt.Printf("failed to parse CCLF8 from CCLF0 file: %v", fileMetadata)
 		err := fmt.Errorf("failed to parse CCLF8 from CCLF0 file: %v", fileMetadata)
 		log.Error(err)
 		return nil, err
 	}
 	if _, ok := validator["CCLF9"]; !ok {
+		fmt.Printf("failed to parse CCLF9 from CCLF0 file: %v", fileMetadata)
 		err := fmt.Errorf("failed to parse CCLF9 from CCLF0 file: %v", fileMetadata)
 		log.Error(err)
 		return nil, err
 	}
-	fmt.Printf("Imported CCLF0 file %s.\n", fileMetadata.name)
-	log.Infof("Imported CCLF0 file %s.", fileMetadata.name)
+	fmt.Printf("Successfully imported CCLF0 file %s.\n", fileMetadata.name)
+	log.Infof("Successfully imported CCLF0 file %s.", fileMetadata.name)
 
 	return validator, nil
 }
@@ -148,7 +158,10 @@ func importCCLF8(fileMetadata *cclfFileMetadata) error {
 		}
 		err := db.Create(cclfBeneficiary).Error
 		if err != nil {
-			return errors.Wrap(err, "could not create CCLF8 beneficiary record")
+			fmt.Print("could not create CCLF8 beneficiary record")
+			err = errors.Wrap(err, "could not create CCLF8 beneficiary record")
+			log.Error(err)
+			return err
 		}
 		return nil
 	})
@@ -179,7 +192,10 @@ func importCCLF9(fileMetadata *cclfFileMetadata) error {
 		}
 		err := db.Create(&cclf9).Error
 		if err != nil {
-			return errors.Wrap(err, "could not create CCLF9 cross reference record")
+			fmt.Print("could not create CCLF9 cross reference record")
+			err = errors.Wrap(err, "could not create CCLF9 cross reference record")
+			log.Error(err)
+			return err
 		}
 		return nil
 	})
@@ -193,6 +209,7 @@ func importCCLF9(fileMetadata *cclfFileMetadata) error {
 
 func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *gorm.DB) error) error {
 	if fileMetadata == nil {
+		fmt.Print("CCLF file not found")
 		err := errors.New("CCLF file not found")
 		log.Error(err)
 		return err
@@ -203,6 +220,7 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 
 	r, err := zip.OpenReader(filepath.Clean(fileMetadata.filePath))
 	if err != nil {
+		fmt.Printf("could not read CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
 		err := errors.Wrapf(err, "could not read CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
 		log.Error(err)
 		return err
@@ -210,6 +228,7 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 	defer r.Close()
 
 	if len(r.File) < 1 {
+		fmt.Printf("no files found in CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
 		err := fmt.Errorf("no files found in CCLF%d archive %s", fileMetadata.cclfNum, fileMetadata.name)
 		log.Error(err)
 		return err
@@ -228,13 +247,18 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 
 	err = db.Create(&cclfFile).Error
 	if err != nil {
-		return errors.Wrapf(err, "could not create CCLF%d file record", fileMetadata.cclfNum)
+		fmt.Printf("could not create CCLF%d file record", fileMetadata.cclfNum)
+		err = errors.Wrapf(err, "could not create CCLF%d file record", fileMetadata.cclfNum)
+		log.Error(err)
+		return err
 	}
 
 	for i, f := range r.File {
+		fmt.Printf("Reading file #%d from archive %s", i, fileMetadata.name)
 		log.Infof("Reading file #%d from archive %s", i, fileMetadata.name)
 		rc, err := f.Open()
 		if err != nil {
+			fmt.Printf("could not read file %s in CCLF%d archive %s", f.Name, fileMetadata.cclfNum, fileMetadata.name)
 			err = errors.Wrapf(err, "could not read file %s in CCLF%d archive %s", f.Name, fileMetadata.cclfNum, fileMetadata.name)
 			log.Error(err)
 			return err
@@ -253,8 +277,8 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 		}
 	}
 
-	fmt.Printf("Imported CCLF%d file %s.\n", fileMetadata.cclfNum, fileMetadata.name)
-	log.Infof("Imported CCLF%d file %s.", fileMetadata.cclfNum, fileMetadata.name)
+	fmt.Printf("Successfully imported CCLF%d file %s.\n", fileMetadata.cclfNum, fileMetadata.name)
+	log.Infof("Successfully imported CCLF%d file %s.", fileMetadata.cclfNum, fileMetadata.name)
 
 	return nil
 }
@@ -266,23 +290,35 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 	filenameRegexp := regexp.MustCompile(`(T|P)\.(A\d{4})\.ACO\.ZC(0|8|9)Y(\d{2})\.(D\d{6}\.T\d{6})\d`)
 	filenameMatches := filenameRegexp.FindStringSubmatch(filePath)
 	if len(filenameMatches) < 5 {
-		return metadata, fmt.Errorf("invalid filename for file: %s", filePath)
+		fmt.Printf("invalid filename for file: %s", filePath)
+		err := fmt.Errorf("invalid filename for file: %s", filePath)
+		log.Error(err)
+		return metadata, err
 	}
 
 	cclfNum, err := strconv.Atoi(filenameMatches[3])
 	if err != nil {
+		fmt.Printf("failed to parse cclf num from file: %s", filePath)
+		err = errors.Wrapf(err,"failed to parse cclf num from file: %s", filePath)
+		log.Error(err)
 		return metadata, err
 	}
 
 	perfYear, err := strconv.Atoi(filenameMatches[4])
 	if err != nil {
+		fmt.Printf("failed to parse performance year from file: %s", filePath)
+		err = errors.Wrapf(err,"failed to parse performance year from file: %s", filePath)
+		log.Error(err)
 		return metadata, err
 	}
 
 	filenameDate := filenameMatches[5]
 	t, err := time.Parse("D060102.T150405", filenameDate)
 	if err != nil || t.IsZero() {
-		return metadata, fmt.Errorf("failed to parse date '%s' from file: %s", filenameDate, filePath)
+		fmt.Printf("failed to parse date '%s' from file: %s", filenameDate, filePath)
+		err = errors.Wrapf(err,"failed to parse date '%s' from file: %s", filenameDate, filePath)
+		log.Error(err)
+		return metadata, err
 	}
 
 	if filenameMatches[1] == "T" {
@@ -309,7 +345,9 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 	}
 
 	if len(cclfmap) == 0 {
-		return 0, 0, 0, errors.New("failed to find any CCLF files in directory")
+		err := errors.New("failed to find any CCLF files in directory")
+		log.Error(err)
+		return 0, 0, 0, err
 	}
 
 	for _, cclflist := range cclfmap {
@@ -325,38 +363,40 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 		}
 		cclfvalidator, err := importCCLF0(cclf0)
 		if err != nil {
+			fmt.Printf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v ", cclf0, cclf8, cclf9)
 			log.Errorf("Failed to import CCLF0 file: %v, Skipping CCLF8 file: %v and CCLF9 file: %v ", cclf0, cclf8, cclf9)
 			failure++
 			skipped += 2
 			continue
 		} else {
-			log.Infof("Successfully imported CCLF0 file: %v", cclf0)
 			success++
 		}
 		err = validate(cclf8, cclfvalidator)
 		if err != nil {
+			fmt.Printf("Failed to validate CCLF8 file: %v", cclf8)
 			log.Errorf("Failed to validate CCLF8 file: %v", cclf8)
 			failure++
 		} else {
 			if err = importCCLF8(cclf8); err != nil {
+				fmt.Printf("Failed to import CCLF8 file: %v ", cclf8)
 				log.Errorf("Failed to import CCLF8 file: %v ", cclf8)
 				failure++
 			} else {
-				log.Infof("Successfully imported CCLF8 file: %v", cclf8)
 				cclf8.imported = true
 				success++
 			}
 		}
 		err = validate(cclf9, cclfvalidator)
 		if err != nil {
+			fmt.Printf("Failed to validate CCLF9 file: %v", cclf9)
 			log.Errorf("Failed to validate CCLF9 file: %v", cclf9)
 			failure++
 		} else {
 			if err = importCCLF9(cclf9); err != nil {
+				fmt.Printf("Failed to import CCLF9 file: %v ", cclf9)
 				log.Errorf("Failed to import CCLF9 file: %v ", cclf9)
 				failure++
 			} else {
-				log.Infof(fmt.Sprintf("Successfully imported CCLF9 file: %v", cclf9))
 				cclf9.imported = true
 				success++
 			}
@@ -367,6 +407,7 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 
 	if failure > 0 {
 		err = errors.New("one or more files failed to import correctly")
+		log.Error(err)
 	} else {
 		err = nil
 	}
@@ -376,6 +417,8 @@ func importCCLFDirectory(filePath string) (success, failure, skipped int, err er
 func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			fmt.Printf("Error in sorting cclf file: %v,", info.Name())
+			err = errors.Wrapf(err,"Error in sorting cclf file: %v,", info.Name())
 			log.Error(err)
 			return err
 		}
@@ -388,12 +431,15 @@ func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepa
 		metadata.deliveryDate = info.ModTime()
 		if err != nil {
 			// skipping files with a bad name.  An unknown file in this dir isn't a blocker
-			log.Error(err)
+			fmt.Printf("unknown file found: %v", metadata)
+			log.Errorf("unknown file found: %v", metadata)
 			*skipped = *skipped + 1
 
 			newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), info.Name())
 			err = os.Rename(metadata.filePath, newpath)
 			if err != nil {
+				fmt.Printf("error moving unknown file: %v to pending deletion dir", metadata)
+				err  = fmt.Errorf("error moving unknown file: %v to pending deletion dir", metadata)
 				log.Error(err)
 				return err
 			}
@@ -413,10 +459,14 @@ func sortCCLFFiles(cclfmap *map[string][]*cclfFileMetadata, skipped *int) filepa
 
 func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfFileValidator) error {
 	if fileMetadata == nil {
+		fmt.Printf("file not found")
 		err := errors.New("file not found")
 		log.Error(err)
 		return err
 	}
+
+	fmt.Printf("Validating CCLF%d file %s...\n", fileMetadata.cclfNum, fileMetadata.name)
+	log.Infof("Validating CCLF%d file %s...", fileMetadata.cclfNum, fileMetadata.name)
 
 	var key string
 	if fileMetadata.cclfNum == 8 {
@@ -424,6 +474,7 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 	} else if fileMetadata.cclfNum == 9 {
 		key = "CCLF9"
 	} else {
+		fmt.Printf("unknown file type when validating file: %v,", fileMetadata)
 		err := fmt.Errorf("unknown file type when validating file: %v,", fileMetadata)
 		log.Error(err)
 		return err
@@ -431,6 +482,7 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 
 	r, err := zip.OpenReader(filepath.Clean(fileMetadata.filePath))
 	if err != nil {
+		fmt.Printf("could not read archive %s", fileMetadata.name)
 		err := errors.Wrapf(err, "could not read archive %s", fileMetadata.name)
 		log.Error(err)
 		return err
@@ -441,10 +493,12 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 	validator := cclfFileValidator[key]
 
 	for i, f := range r.File {
+		fmt.Printf("Reading file #%d from archive %s", i, fileMetadata.name)
 		log.Infof("Reading file #%d from archive %s", i, fileMetadata.name)
 		rc, err := f.Open()
 		if err != nil {
-			err = errors.Wrapf(err, "could not read file %s in CCLF8 archive %s", f.Name, fileMetadata.name)
+			fmt.Printf("could not read file %s in archive %s", f.Name, fileMetadata.name)
+			err = errors.Wrapf(err, "could not read file %s in archive %s", f.Name, fileMetadata.name)
 			log.Error(err)
 			return err
 		}
@@ -458,49 +512,71 @@ func validate(fileMetadata *cclfFileMetadata, cclfFileValidator map[string]cclfF
 
 				// currently only errors if there are more records than we expect.
 				if count > validator.totalRecordCount {
+					fmt.Printf("maximum record count reached for file %s, Expected record count: %d, Actual record count: %d ", key, validator.totalRecordCount, count)
 					err := fmt.Errorf("maximum record count reached for file %s, Expected record count: %d, Actual record count: %d ", key, validator.totalRecordCount, count)
 					log.Error(err)
 					return err
 				}
 			} else {
+				fmt.Printf("incorrect record length for file %s, Expected record length: %d, Actual record length: %d", key, validator.maxRecordLength, bytelength)
 				err := fmt.Errorf("incorrect record length for file %s, Expected record length: %d, Actual record length: %d", key, validator.maxRecordLength, bytelength)
 				log.Error(err)
 				return err
 			}
 		}
 	}
+	fmt.Printf("Successfully validated CCLF%d file %s.\n", fileMetadata.cclfNum, fileMetadata.name)
+	log.Infof("Successfully validated CCLF%d file %s.", fileMetadata.cclfNum, fileMetadata.name)
 	return nil
 }
 
 func deleteDirectoryContents(dirToDelete string) (filesDeleted int, err error) {
-	log.Info(fmt.Sprintf("preparing to delete directory '%v'", dirToDelete))
+	fmt.Printf("preparing to delete directory '%v'", dirToDelete)
+	log.Infof("preparing to delete directory '%v'", dirToDelete)
 	f, err := os.Open(filepath.Clean(dirToDelete))
 	if err != nil {
+		fmt.Printf("could not open dir: %s", dirToDelete)
+		err = errors.Wrapf(err, "could not open dir: %s", dirToDelete)
+		log.Error(err)
 		return 0, err
 	}
 	files, err := f.Readdir(-1)
 	if err != nil {
+		fmt.Printf("error reading files from dir: %s", f.Name())
+		err = errors.Wrapf(err, "error reading files from dir: %s", f.Name())
+		log.Error(err)
 		return 0, err
 	}
 	err = f.Close()
 	if err != nil {
+		fmt.Printf("error closing dir: %s", f.Name())
+		err = errors.Wrapf(err,"error closing dir: %s", f.Name())
+		log.Error(err)
 		return 0, err
 	}
 
 	for _, file := range files {
-		log.Info(fmt.Sprintf("deleting %v", file.Name()))
+		fmt.Printf("deleting %s", file.Name())
+		log.Infof("deleting %s ", file.Name())
 		err = os.Remove(filepath.Join(dirToDelete, file.Name()))
 		if err != nil {
+			fmt.Printf("error deleting file: %s from dir: %s", file.Name(), dirToDelete)
+			err = errors.Wrapf(err,"error deleting file: %s from dir: %s", file.Name(), dirToDelete)
+			log.Error(err)
 			return 0, err
 		}
 	}
 
+	fmt.Printf("Successfully deleted all files from dir: %s", dirToDelete)
+	log.Infof("Successfully deleted all files from dir: %s", dirToDelete)
 	return len(files), nil
 }
 
 func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 	for _, cclflist := range cclfmap {
 		for _, cclf := range cclflist {
+			fmt.Printf("Cleaning up file %v", cclf)
+			log.Infof("Cleaning up file %v", cclf)
 			newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), cclf.name)
 			if !cclf.imported {
 				// check the timestamp on the failed files
@@ -508,9 +584,10 @@ func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 				if int(elapsed) > deleteThresholdHr {
 					err := os.Rename(cclf.filePath, newpath)
 					if err != nil {
-						err := fmt.Errorf("file: %v failed to cleanup properly", cclf)
-						log.Error(err)
+						fmt.Printf("file: %v failed to cleanup properly", cclf)
+						log.Errorf("file: %v failed to cleanup properly", cclf)
 					} else {
+						fmt.Printf("file: %v never ingested, moved to the pending deletion dir", cclf)
 						log.Infof("file: %v never ingested, moved to the pending deletion dir", cclf)
 					}
 				}
@@ -518,9 +595,10 @@ func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) {
 				// move the successful files to the deletion dir
 				err := os.Rename(cclf.filePath, newpath)
 				if err != nil {
-					err := fmt.Errorf("file: %v failed to cleanup properly", cclf)
-					log.Error(err)
+					fmt.Printf("file: %v failed to cleanup properly", cclf)
+					log.Errorf("file: %v failed to cleanup properly", cclf)
 				} else {
+					fmt.Printf("file: %v successfully ingested, moved to the pending deletion dir", cclf)
 					log.Infof("file: %v successfully ingested, moved to the pending deletion dir", cclf)
 				}
 			}

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -423,7 +423,7 @@ func (s *CLITestSuite) TestGetCCLFFileMetadata() {
 	assert.EqualError(err, "invalid filename for file: /path/to/file")
 
 	metadata, err := getCCLFFileMetadata("/path/T.A0000.ACO.ZC8Y18.D190117.T9909420")
-	assert.EqualError(err, "failed to parse date 'D190117.T990942' from file: /path/T.A0000.ACO.ZC8Y18.D190117.T9909420")
+	assert.EqualError(err, "failed to parse date 'D190117.T990942' from file: /path/T.A0000.ACO.ZC8Y18.D190117.T9909420: parsing time \"D190117.T990942\": hour out of range")
 
 	expTime, _ := time.Parse(time.RFC3339, "2019-01-17T21:09:42Z")
 	metadata, err = getCCLFFileMetadata("/path/T.A0000.ACO.ZC8Y18.D190117.T2109420")

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -430,7 +430,7 @@ func (s *CLITestSuite) TestGetCCLFFileMetadata() {
 	assert.Equal("test", metadata.env)
 	assert.Equal("A0000", metadata.acoID)
 	assert.Equal(8, metadata.cclfNum)
-	assert.Equal(expTime, metadata.timestamp)
+	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
 	assert.Equal(18, metadata.perfYear)
 	assert.Nil(err)
 
@@ -439,7 +439,7 @@ func (s *CLITestSuite) TestGetCCLFFileMetadata() {
 	assert.Equal("production", metadata.env)
 	assert.Equal("A0001", metadata.acoID)
 	assert.Equal(9, metadata.cclfNum)
-	assert.Equal(expTime, metadata.timestamp)
+	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
 	assert.Equal(18, metadata.perfYear)
 	assert.Nil(err)
 
@@ -448,7 +448,7 @@ func (s *CLITestSuite) TestGetCCLFFileMetadata() {
 	assert.Equal("test", metadata.env)
 	assert.Equal("A0002", metadata.acoID)
 	assert.Equal(0, metadata.cclfNum)
-	assert.Equal(expTime, metadata.timestamp)
+	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
 	assert.Equal(18, metadata.perfYear)
 	assert.Nil(err)
 
@@ -519,7 +519,7 @@ func (s *CLITestSuite) TestSortCCLFFiles() {
 	modtimeAfter := time.Now().Truncate(time.Second)
 	for _, cclf := range cclflist {
 		assert.Equal(9, cclf.cclfNum)
-		assert.Equal(modtimeBefore, cclf.deliveryDate)
+		assert.Equal(modtimeBefore.Format("010203040506"), cclf.deliveryDate.Format("010203040506"))
 
 		// change the modification time for all the files
 		err := os.Chtimes(cclf.filePath, modtimeAfter, modtimeAfter)
@@ -535,7 +535,7 @@ func (s *CLITestSuite) TestSortCCLFFiles() {
 	cclflist = cclfmap["A0001_18"]
 	for _, cclf := range cclflist {
 		// check for the new modification time
-		assert.Equal(modtimeAfter, cclf.deliveryDate)
+		assert.Equal(modtimeAfter.Format("010203040506"), cclf.deliveryDate.Format("010203040506"))
 	}
 
 	cclfmap = make(map[string][]*cclfFileMetadata)

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -234,7 +234,7 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"),file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	beneficiaries := []models.CCLFBeneficiary{}
@@ -287,7 +287,7 @@ func (s *CLITestSuite) TestImportCCLF8_SplitFiles() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"),file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	beneficiaries := []models.CCLFBeneficiary{}
@@ -347,7 +347,7 @@ func (s *CLITestSuite) TestImportCCLF9() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC9Y18.D181120.T1000010", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"),file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	var savedCCLF9 models.CCLFBeneficiaryXref
@@ -391,7 +391,7 @@ func (s *CLITestSuite) TestImportCCLF9_SplitFiles() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC9Y18.D181120.T1000010", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"),file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	var savedCCLF9 models.CCLFBeneficiaryXref

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -234,7 +234,7 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	beneficiaries := []models.CCLFBeneficiary{}
@@ -287,7 +287,7 @@ func (s *CLITestSuite) TestImportCCLF8_SplitFiles() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	beneficiaries := []models.CCLFBeneficiary{}
@@ -347,7 +347,7 @@ func (s *CLITestSuite) TestImportCCLF9() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC9Y18.D181120.T1000010", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	var savedCCLF9 models.CCLFBeneficiaryXref
@@ -391,7 +391,7 @@ func (s *CLITestSuite) TestImportCCLF9_SplitFiles() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC9Y18.D181120.T1000010", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	var savedCCLF9 models.CCLFBeneficiaryXref


### PR DESCRIPTION
Fixes [BCDA-1194](https://jira.cms.gov/browse/BCDA-1194)

Problem:
We need to have logging for every part of our cli ingesting process. We had some in place but needed to make sure we covered everything. This ticket should take care of that.

Proposed changes:
bcda/cli.go - added logging and print statements for our entire cclf ingestion workflow
bcda/cli_test.go - modified test case to successfully run

Security Implications:
No, there is no PII/PHI dealing with this change. However this ticket does log tasks that handle PII/PHI around our cclf ingestion process. There is **NO** logging of PHI/PII itself.

Acceptance Validation:
Yes

Screenshot:
<img width="1431" alt="Screen Shot 2019-05-13 at 11 43 07 AM" src="https://user-images.githubusercontent.com/42976557/57635282-d31c1580-7574-11e9-8e6d-c82c578d1cf0.png">


Feedback Requested:
Any and all