### PR TITLE
BCDA-1280: Remove option to turn off encryption

### DIFF
--- a/bcda/api.go
+++ b/bcda/api.go
@@ -178,7 +178,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enqueueJobs, err := newJob.GetEnqueJobs(true, t)
+	enqueueJobs, err := newJob.GetEnqueJobs(t)
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)

--- a/bcda/api.go
+++ b/bcda/api.go
@@ -171,16 +171,6 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: this checks for ?encrypt=false appended to the bulk data request URL
-	// By default, our encryption process is enabled but for now we are giving users the ability to turn
-	// it off
-	// Eventually, we will remove the ability for users to turn it off and it will remain on always
-	var encrypt = true
-	param, ok := r.URL.Query()["encrypt"]
-	if ok && strings.ToLower(param[0]) == "false" {
-		encrypt = false
-	}
-
 	if qc == nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)
@@ -188,7 +178,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enqueueJobs, err := newJob.GetEnqueJobs(encrypt, t)
+	enqueueJobs, err := newJob.GetEnqueJobs(true, t)
 	if err != nil {
 		log.Error(err)
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)

--- a/bcda/cli_test.go
+++ b/bcda/cli_test.go
@@ -234,7 +234,7 @@ func (s *CLITestSuite) TestImportCCLF8() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	beneficiaries := []models.CCLFBeneficiary{}
@@ -287,7 +287,7 @@ func (s *CLITestSuite) TestImportCCLF8_SplitFiles() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC8Y18.D181120.T1000009", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	beneficiaries := []models.CCLFBeneficiary{}
@@ -347,7 +347,7 @@ func (s *CLITestSuite) TestImportCCLF9() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC9Y18.D181120.T1000010", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	var savedCCLF9 models.CCLFBeneficiaryXref
@@ -391,7 +391,7 @@ func (s *CLITestSuite) TestImportCCLF9_SplitFiles() {
 	assert.NotNil(file)
 	assert.Equal("T.A0001.ACO.ZC9Y18.D181120.T1000010", file.Name)
 	assert.Equal(acoID, file.ACOCMSID)
-	assert.Equal(fileTime, file.Timestamp)
+	assert.Equal(fileTime.Format("010203040506"), file.Timestamp.Format("010203040506"))
 	assert.Equal(18, file.PerformanceYear)
 
 	var savedCCLF9 models.CCLFBeneficiaryXref

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -98,7 +98,7 @@ func (job *Job) CheckCompletedAndCleanup() (bool, error) {
 	return false, nil
 }
 
-func (job *Job) GetEnqueJobs(encrypt bool, t string) (enqueJobs []*que.Job, err error) {
+func (job *Job) GetEnqueJobs(t string) (enqueJobs []*que.Job, err error) {
 	var jobIDs []string
 
 	var rowCount = 0
@@ -128,8 +128,6 @@ func (job *Job) GetEnqueJobs(encrypt bool, t string) (enqueJobs []*que.Job, err 
 				UserID:         job.UserID.String(),
 				BeneficiaryIDs: jobIDs,
 				ResourceType:   t,
-				// TODO: remove `Encrypt` when file encryption disable functionality is ready to be deprecated
-				Encrypt: encrypt,
 			})
 			if err != nil {
 				return nil, err
@@ -390,8 +388,6 @@ type jobEnqueueArgs struct {
 	UserID         string
 	BeneficiaryIDs []string
 	ResourceType   string
-	// TODO: remove `Encrypt` when file encryption disable functionality is ready to be deprecated
-	Encrypt bool
 }
 
 type EncryptionKey struct {

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -191,7 +191,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs() {
 	s.db.Save(&j)
 	defer s.db.Delete(&j)
 
-	enqueueJobs, err := j.GetEnqueJobs(true, "Patient")
+	enqueueJobs, err := j.GetEnqueJobs("Patient")
 
 	assert.Nil(err)
 	assert.NotNil(enqueueJobs)
@@ -207,7 +207,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs() {
 		assert.Equal(testConstants.DEVACOUUID, jobArgs.ACOID)
 		assert.Equal("6baf8254-2e8a-4808-b11d-0fa00c527d2e", jobArgs.UserID)
 		assert.Equal("Patient", jobArgs.ResourceType)
-		assert.Equal(true, jobArgs.Encrypt)
 		assert.Equal(50, len(jobArgs.BeneficiaryIDs))
 	}
 
@@ -222,7 +221,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs() {
 	defer s.db.Delete(&j)
 	os.Setenv("BCDA_FHIR_MAX_RECORDS", "15")
 
-	enqueueJobs, err = j.GetEnqueJobs(true, "ExplanationOfBenefit")
+	enqueueJobs, err = j.GetEnqueJobs("ExplanationOfBenefit")
 	assert.Nil(err)
 	assert.NotNil(enqueueJobs)
 	assert.Equal(4, len(enqueueJobs))

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -38,6 +38,8 @@ func (s *MainTestSuite) SetupTest() {
 	os.Setenv("BB_CLIENT_CERT_FILE", "../shared_files/bb-dev-test-cert.pem")
 	os.Setenv("BB_CLIENT_KEY_FILE", "../shared_files/bb-dev-test-key.pem")
 	os.Setenv("BB_CLIENT_CA_FILE", "../shared_files/localhost.crt")
+	os.Setenv("ATO_PUBLIC_KEY_FILE", "../shared_files/ATO_public.pem")
+	os.Setenv("ATO_PRIVATE_KEY_FILE", "../shared_files/ATO_private.pem")
 	models.InitializeGormModels()
 }
 

--- a/test/performance_test/performance_test.sh
+++ b/test/performance_test/performance_test.sh
@@ -7,6 +7,3 @@ set -e
 go run performance.go -host=api:3000 -endpoint=ExplanationOfBenefit
 go run performance.go -host=api:3000 -endpoint=Patient
 go run performance.go -host=api:3000 -endpoint=Coverage
-go run performance.go -host=api:3000 -endpoint=ExplanationOfBenefit -encrypt=false
-go run performance.go -host=api:3000 -endpoint=Patient -encrypt=false
-go run performance.go -host=api:3000 -endpoint=Coverage -encrypt=false

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -3,15 +3,9 @@
 # This script is intended to be run from within the Docker "smoke_test" container
 #
 set -e
-echo "Running EOB Encrypted"
+echo "Running EOB"
 go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=ExplanationOfBenefit
-echo "Running Patient Encrypted"
+echo "Running Patient"
 go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient
-echo "Running Coverage Encrypted"
+echo "Running Coverage"
 go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Coverage
-echo "Running EOB Unencrypted"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=ExplanationOfBenefit -encrypt=false
-echo "Running Patient Unencrypted"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -encrypt=false
-echo "Running Coverage Unencrypted"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Coverage -encrypt=false


### PR DESCRIPTION
### Fixes [BCDA-1280](https://jira.cms.gov/browse/BCDA-1280)
BCDA provided an option to use a query parameter to disable encryption (`encrypt=false`) of exported data for testing purposes. The option was intended to be temporary, and is now ready to be removed as we move toward production.

### Proposed changes:
Remove `encrypt` parameter and tests of unencrypted requests.

### Change Details
* `bulkRequest()` no longer looks for `encrypt` query parameter
* `encrypt` parameter removed from `GetEnqueJobs()`
* `processJob()` always encrypts data; encryption cannot be disabled
* Tests using `encrypt=false` have been removed

### Security Implications
These changes improve our security as they completely remove the option to retrieve unencrypted NDJSON files. All data returned from export jobs will be encrypted.

### Acceptance Validation
Tests are passing. Smoke and performance tests are no longer split into encrypted and unencrypted versions. Smoke test output shown below.
<img width="667" alt="Screen Shot 2019-05-10 at 4 40 02 PM" src="https://user-images.githubusercontent.com/1923441/57555467-5144a600-7342-11e9-84c0-26cb14b92850.png">

### Feedback Requested
Any
