### PR TITLE
BCDA-1283 Feature: Update to router file to exclude user guide

### DIFF
--- a/bcda/router.go
+++ b/bcda/router.go
@@ -15,9 +15,12 @@ func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
 	r.Use(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
+
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui"))
-	FileServer(r, "/", http.Dir("./_site"))
+	if os.Getenv("DEPLOYMENT_TARGET") != "prod"{
+		FileServer(r, "/", http.Dir("./_site"))
+	}
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/ExplanationOfBenefit/$export", bulkEOBRequest))
 		if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {

--- a/bcda/router_test.go
+++ b/bcda/router_test.go
@@ -47,6 +47,22 @@ func (s *RouterTestSuite) TestDefaultRoute() {
 	assert.Contains(s.T(), string(body), "Beneficiary Claims Data API")
 }
 
+func (s *RouterTestSuite) TestDefaultProdRoute() {
+	err := os.Setenv("DEPLOYMENT_TARGET","prod")
+	if err != nil {
+		s.FailNow("err in setting env var",err)
+	}
+
+	s.apiRouter = NewAPIRouter()
+	res := s.getAPIRoute("/")
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+
+	err = os.Unsetenv("DEPLOYMENT_TARGET")
+	if err != nil {
+		s.FailNow("err in setting env var",err)
+	}
+}
+
 func (s *RouterTestSuite) TestDataRoute() {
 	res := s.getDataRoute("/data/test/test.ndjson")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)


### PR DESCRIPTION
Fixes [BCDA-1283](https://jira.cms.gov/browse/BCDA-1283)

Problem:
We had no way of limiting the user guide in production. Our desired state is to **not** have this shown at all when we launch to prod, this change does that.

Proposed changes:
bcda/router.go - disables access to the user guide in production
bcda/router_test.go - testing code that verifies a 404 response

Security Implications:
No, this change does not deal with PII/PHI at all.

Acceptance Validation:
I was able to fully test this and confirmed the 404 error.

Feedback Requested
Any and all