### PR TITLE
BCDA-1255: Create Function to make the required directories for NFS

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -34,12 +34,10 @@ package main
 
 import (
 	"fmt"
-
 	"os"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/bcdacli"
-
 	"github.com/CMSgov/bcda-app/bcda/monitoring"
 
 	log "github.com/sirupsen/logrus"
@@ -49,6 +47,8 @@ func init() {
 	isEtlMode := os.Getenv("BCDA_ETL_MODE")
 	if isEtlMode != "true" {
 		createAPIDirs()
+	} else {
+		createETLDirs()
 	}
 
 	log.SetFormatter(&log.JSONFormatter{})
@@ -78,6 +78,14 @@ func createAPIDirs() {
 	err := os.MkdirAll(archive, 0744)
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+func createETLDirs() {
+	pendingDeletionPath := os.Getenv("PENDING_DELETION_DIR")
+	err := os.MkdirAll(pendingDeletionPath, 0744)
+	if err != nil {
+		log.Fatal("Could not create CCLF file pending deletion directory", err.Error())
 	}
 }
 


### PR DESCRIPTION
### Fixes [BCDA-1255](https://jira.cms.gov/browse/BCDA-1255)
For the ETL process, we need a pending deletion directory to exist to move files to after they are ingested.

### Proposed changes:
When `BCDA_ETL_MODE` is `true`, directory defined by `PENDING_DELETION_DIR` will be created when the BCDA application starts.

### Security Implications
The directory created by this ticket will be used as a place for CCLF files to be moved into to indicate that they are ready to be deleted by the cleanup process.

### Acceptance Validation
We will need to confirm that the directory is created in the NFS.

### Feedback Requested
Any. Is `744` the right permissions setting for this directory?
