### PR TITLE
BCDA-1259: Remove beneficiaries and acobeneficiaries table and associated structures/code

### DIFF
--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -159,8 +159,8 @@ func GenerateSystemKeyPair(systemID uint) (string, error) {
 
 	return string(privateKeyBytes), nil
 }
-func CreateAlphaToken(ttl int, acoSize string) (string, error) {
-	aco, err := createAlphaEntities(acoSize)
+func CreateAlphaToken(ttl int, acoCMSID string) (string, error) {
+	aco, err := createAlphaEntities(acoCMSID)
 	if err != nil {
 		return "", err
 	}
@@ -184,7 +184,7 @@ func CreateAlphaToken(ttl int, acoSize string) (string, error) {
 	return msg, nil
 }
 
-func createAlphaEntities(acoSize string) (aco models.ACO, err error) {
+func createAlphaEntities(acoCMSID string) (aco models.ACO, err error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 	tx := db.Begin()
@@ -201,13 +201,8 @@ func createAlphaEntities(acoSize string) (aco models.ACO, err error) {
 		return aco, tx.Error
 	}
 
-	aco, err = models.CreateAlphaACO(tx)
+	aco, err = models.CreateAlphaACO(acoCMSID, tx)
 	if err != nil {
-		tx.Rollback()
-		return aco, err
-	}
-
-	if err = models.AssignAlphaBeneficiaries(tx, aco, acoSize); err != nil {
 		tx.Rollback()
 		return aco, err
 	}

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -155,7 +155,7 @@ func (s *ModelsTestSuite) TestGenerateSystemKeyPair_AlreadyExists() {
 }
 
 func (s *ModelsTestSuite) TestCreateAlphaToken() {
-	msg, err := auth.CreateAlphaToken(1000, "dev")
+	msg, err := auth.CreateAlphaToken(1000, "T0004")
 	assert.NotEmpty(s.T(), msg)
 	assert.Nil(s.T(), err)
 }

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -276,9 +277,9 @@ func setUpApp() *cli.App {
 					Destination: &ttl,
 				},
 				cli.StringFlag{
-					Name:        "size",
-					Usage:       "Set the size of the ACO.  Must be one of 'Dev', 'Small', 'Medium', 'Large', or 'Extra_Large'",
-					Destination: &acoSize,
+					Name:        "cms-id",
+					Usage:       "CMS ID of ACO",
+					Destination: &acoCMSID,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -288,11 +289,11 @@ func setUpApp() *cli.App {
 						ttl = "72"
 					}
 				}
-				ttlInt, err := validateAlphaTokenInputs(ttl, acoSize)
+				ttlInt, err := validateAlphaTokenInputs(ttl, acoCMSID)
 				if err != nil {
 					return err
 				}
-				accessToken, err := auth.CreateAlphaToken(ttlInt, acoSize)
+				accessToken, err := auth.CreateAlphaToken(ttlInt, acoCMSID)
 				if err != nil {
 					return err
 				}
@@ -496,22 +497,18 @@ func revokeAccessToken(accessToken string) error {
 	return auth.GetProvider().RevokeAccessToken(accessToken)
 }
 
-func validateAlphaTokenInputs(ttl, acoSize string) (int, error) {
+func validateAlphaTokenInputs(ttl, acoID string) (int, error) {
 	i, err := strconv.Atoi(ttl)
 	if err != nil || i <= 0 {
 		return i, fmt.Errorf("invalid argument '%v' for --ttl; should be an integer > 0", ttl)
 	}
-	switch strings.ToLower(acoSize) {
-	case
-		"dev",
-		"small",
-		"medium",
-		"large",
-		"extra_large":
-		return i, nil
-	default:
-		return i, errors.New("invalid argument for --size.  Please use 'Dev', 'Small', 'Medium', 'Large', or 'Extra_Large'")
+
+	acoIDFmt := regexp.MustCompile(`T\d{4}`)
+	if !acoIDFmt.MatchString(acoID) {
+		return i, errors.New("expected CMS ACO ID format for alpha ACOs is 'T' followed by four digits (e.g., 'T1234')")
 	}
+
+	return i, nil
 }
 
 func archiveExpiring(hrThreshold int) error {

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -419,12 +419,12 @@ func setUpApp() *cli.App {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        "acoSize",
-					Usage:       "Set the size of the ACO.  Must be one of 'Dev', 'Small', 'Medium', 'Large', or 'Extra_Large'",
+					Usage:       "Set the size of the ACO.  Must be one of 'dev', 'small', 'medium', 'large', or 'extra-large'",
 					Destination: &acoSize,
 				},
 				cli.StringFlag{
 					Name:        "environment",
-					Usage:       "Which set of files to use.  ",
+					Usage:       "Which set of files to use.",
 					Destination: &environment,
 				},
 			},

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -342,7 +342,7 @@ func (s *CLITestSuite) TestCreateAlphaTokenCLI() {
 	outputPattern := regexp.MustCompile(`.+\n(.+)\n.+`)
 
 	// execute positive scenarios via CLI
-	args := []string{"bcda", "create-alpha-token", "--ttl", "720", "--size", "Dev"}
+	args := []string{"bcda", "create-alpha-token", "--ttl", "720", "--cms-id", "T0001"}
 	err := s.testApp.Run(args)
 	assert.Nil(err)
 	assert.Regexp(outputPattern, buf.String())
@@ -350,7 +350,7 @@ func (s *CLITestSuite) TestCreateAlphaTokenCLI() {
 	buf.Reset()
 
 	// ttl is optional when using the CLI
-	args = []string{"bcda", "create-alpha-token", "--size", "Dev"}
+	args = []string{"bcda", "create-alpha-token", "--cms-id", "T0002"}
 	err = s.testApp.Run(args)
 	assert.Nil(err)
 	assert.Regexp(outputPattern, buf.String())
@@ -362,7 +362,7 @@ func (s *CLITestSuite) TestCreateAlphaTokenCLI() {
 	assert.NotEmpty(aco.AlphaSecret)
 	buf.Reset()
 
-	args = []string{"bcda", "create-alpha-token", "--size", "DEV"}
+	args = []string{"bcda", "create-alpha-token", "--cms-id", "T0003"}
 	err = s.testApp.Run(args)
 	assert.Nil(err)
 	assert.Regexp(outputPattern, buf.String())
@@ -371,19 +371,19 @@ func (s *CLITestSuite) TestCreateAlphaTokenCLI() {
 	// Execute CLI with invalid inputs
 	args = []string{"bcda", "create-alpha-token"}
 	err = s.testApp.Run(args)
-	assert.Equal("invalid argument for --size.  Please use 'Dev', 'Small', 'Medium', 'Large', or 'Extra_Large'", err.Error())
+	assert.Equal("expected CMS ACO ID format for alpha ACOs is 'T' followed by four digits (e.g., 'T1234')", err.Error())
 	assert.Equal(0, buf.Len())
 	buf.Reset()
 
-	args = []string{"bcda", "create-alpha-token", "--ttl", "ABCD", "--size", "Dev"}
+	args = []string{"bcda", "create-alpha-token", "--ttl", "ABCD", "--cms-id", "T0001"}
 	err = s.testApp.Run(args)
 	assert.Equal("invalid argument 'ABCD' for --ttl; should be an integer > 0", err.Error())
 	assert.Equal(0, buf.Len())
 	buf.Reset()
 
-	args = []string{"bcda", "create-alpha-token", "--ttl", "720", "--size", "ABCD"}
+	args = []string{"bcda", "create-alpha-token", "--ttl", "720", "--cms-id", "ABCD"}
 	err = s.testApp.Run(args)
-	assert.Equal("invalid argument for --size.  Please use 'Dev', 'Small', 'Medium', 'Large', or 'Extra_Large'", err.Error())
+	assert.Equal("expected CMS ACO ID format for alpha ACOs is 'T' followed by four digits (e.g., 'T1234')", err.Error())
 	assert.Equal(0, buf.Len())
 	buf.Reset()
 

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -287,8 +287,8 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 	var metadata cclfFileMetadata
 	// CCLF filename convention for SSP: P.A****.ACO.ZC*Y**.Dyymmdd.Thhmmsst
-	// Prefix: T = test, P = prod; A**** = ACO ID; ZC* = CCLF file number; Y** = performance year
-	filenameRegexp := regexp.MustCompile(`(T|P).*\.(A\d{4})\.ACO.*\.ZC(0|8|9)Y(\d{2})\.(D\d{6}\.T\d{6})\d`)
+	// Prefix: T = test, P = prod; A**** or T**** (test) = ACO ID; ZC* = CCLF file number; Y** = performance year
+	filenameRegexp := regexp.MustCompile(`(T|P).*\.((?:A|T)\d{4})\.ACO.*\.ZC(0|8|9)Y(\d{2})\.(D\d{6}\.T\d{6})\d`)
 	filenameMatches := filenameRegexp.FindStringSubmatch(filePath)
 	if len(filenameMatches) < 5 {
 		fmt.Printf("Invalid filename for file: %s.\n", filePath)
@@ -299,8 +299,8 @@ func getCCLFFileMetadata(filePath string) (cclfFileMetadata, error) {
 
 	cclfNum, err := strconv.Atoi(filenameMatches[3])
 	if err != nil {
-		fmt.Printf("Failed to parse cclf num from file: %s.\n", filePath)
-		err = errors.Wrapf(err, "failed to parse cclf num from file: %s", filePath)
+		fmt.Printf("Failed to parse CCLF number from file: %s.\n", filePath)
+		err = errors.Wrapf(err, "failed to parse CCLF number from file: %s", filePath)
 		log.Error(err)
 		return metadata, err
 	}

--- a/bcda/cclf/cclf_test.go
+++ b/bcda/cclf/cclf_test.go
@@ -341,16 +341,19 @@ func (s *CCLFTestSuite) TestImportCCLF9_InvalidMetadata() {
 func (s *CCLFTestSuite) TestGetCCLFFileMetadata() {
 	assert := assert.New(s.T())
 
-	_, err := getCCLFFileMetadata("/path/to/file")
-	assert.EqualError(err, "invalid filename for file: /path/to/file")
-
-	metadata, err := getCCLFFileMetadata("/path/T.A0000.ACO.ZC8Y18.D190117.T9909420")
-	assert.EqualError(err, "failed to parse date 'D190117.T990942' from file: /path/T.A0000.ACO.ZC8Y18.D190117.T9909420: parsing time \"D190117.T990942\": hour out of range")
-
-	expTime, _ := time.Parse(time.RFC3339, "2019-01-17T21:09:42Z")
-	metadata, err = getCCLFFileMetadata("/path/T.A0000.ACO.ZC8Y18.D190117.T2109420")
+	expTime, _ := time.Parse(time.RFC3339, "2019-01-19T20:13:01Z")
+	metadata, err := getCCLFFileMetadata("/path/T.A0002.ACO.ZC0Y18.D190119.T2013010")
 	assert.Equal("test", metadata.env)
-	assert.Equal("A0000", metadata.acoID)
+	assert.Equal("A0002", metadata.acoID)
+	assert.Equal(0, metadata.cclfNum)
+	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
+	assert.Equal(18, metadata.perfYear)
+	assert.Nil(err)
+
+	expTime, _ = time.Parse(time.RFC3339, "2019-01-17T21:09:42Z")
+	metadata, err = getCCLFFileMetadata("/path/T.T0000.ACO.ZC8Y18.D190117.T2109420")
+	assert.Equal("test", metadata.env)
+	assert.Equal("T0000", metadata.acoID)
 	assert.Equal(8, metadata.cclfNum)
 	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
 	assert.Equal(18, metadata.perfYear)
@@ -365,15 +368,6 @@ func (s *CCLFTestSuite) TestGetCCLFFileMetadata() {
 	assert.Equal(18, metadata.perfYear)
 	assert.Nil(err)
 
-	expTime, _ = time.Parse(time.RFC3339, "2019-01-19T20:13:01Z")
-	metadata, err = getCCLFFileMetadata("/path/T.A0002.ACO.ZC0Y18.D190119.T2013010")
-	assert.Equal("test", metadata.env)
-	assert.Equal("A0002", metadata.acoID)
-	assert.Equal(0, metadata.cclfNum)
-	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
-	assert.Equal(18, metadata.perfYear)
-	assert.Nil(err)
-	
 	// CMS EFT file format structure
 	expTime, _ = time.Parse(time.RFC3339, "2019-01-19T20:13:01Z")
 	metadata, err = getCCLFFileMetadata("/cclf/T#EFT.ON.A0001.ACOB.ZC0Y19.D190119.T2013010")
@@ -383,11 +377,21 @@ func (s *CCLFTestSuite) TestGetCCLFFileMetadata() {
 	assert.Equal(expTime.Format("010203040506"), metadata.timestamp.Format("010203040506"))
 	assert.Equal(19, metadata.perfYear)
 	assert.Nil(err)
+}
 
-	metadata, err = getCCLFFileMetadata("/cclf/T.A0001.ACO.ZC8Y18.D18NOV20.T1000010")
+func (s *CCLFTestSuite) TestGetCCLFFileMetadata_InvalidFilename() {
+	assert := assert.New(s.T())
+
+	_, err := getCCLFFileMetadata("/path/to/file")
+	assert.EqualError(err, "invalid filename for file: /path/to/file")
+
+	_, err = getCCLFFileMetadata("/path/T.A0000.ACO.ZC8Y18.D190117.T9909420")
+	assert.EqualError(err, "failed to parse date 'D190117.T990942' from file: /path/T.A0000.ACO.ZC8Y18.D190117.T9909420: parsing time \"D190117.T990942\": hour out of range")
+
+	_, err = getCCLFFileMetadata("/cclf/T.A0001.ACO.ZC8Y18.D18NOV20.T1000010")
 	assert.NotNil(err)
 
-	metadata, err = getCCLFFileMetadata("/cclf/T.ABCDE.ACO.ZC8Y18.D181120.T1000010")
+	_, err = getCCLFFileMetadata("/cclf/T.ABCDE.ACO.ZC8Y18.D181120.T1000010")
 	assert.NotNil(err)
 }
 

--- a/bcda/cclf/testutils/cclfUtils.go
+++ b/bcda/cclf/testutils/cclfUtils.go
@@ -27,10 +27,11 @@ func ImportCCLFPackage(acoSize, environment string) (err error) {
 		"dev",
 		"small",
 		"medium",
-		"large":
+		"large",
+		"extra-large":
 
 	default:
-		return errors.New("invalid argument for aco size")
+		return errors.New("invalid argument for ACO size")
 	}
 
 	switch environment {

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -286,20 +286,13 @@ func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
 }
 
 // CLI command only support; note that we are choosing to fail quickly and let the user (one of us) figure it out
-func CreateAlphaACO(db *gorm.DB) (ACO, error) {
+func CreateAlphaACO(acoCMSID string, db *gorm.DB) (ACO, error) {
 	var count int
 	db.Table("acos").Count(&count)
-	aco := ACO{Name: fmt.Sprintf("Alpha ACO %d", count), UUID: uuid.NewRandom()}
+	aco := ACO{Name: fmt.Sprintf("Alpha ACO %d", count), UUID: uuid.NewRandom(), CMSID: &acoCMSID}
 	db.Create(&aco)
 
 	return aco, db.Error
-}
-
-func AssignAlphaBeneficiaries(db *gorm.DB, aco ACO, acoSize string) error {
-	s := "insert into acos_beneficiaries (aco_id, beneficiary_id) select '" + aco.UUID.String() +
-		"', b.id from beneficiaries b join acos_beneficiaries ab on b.id = ab.beneficiary_id " +
-		"where ab.aco_id = (select uuid from acos where name ilike 'ACO " + acoSize + "')"
-	return db.Exec(s).Error
 }
 
 type Group struct {

--- a/db/api.sql
+++ b/db/api.sql
@@ -34,16 +34,6 @@ create table tokens (
   active boolean not null default false
 );
 
-create table beneficiaries (
-  id serial not null primary key,
-  blue_button_id text not null
-);
-
-create table acos_beneficiaries (
-  aco_id uuid not null,
-  beneficiary_id int not null
-);
-
 create table cclf_files (
     id serial primary key,
     cclf_num integer not null,

--- a/db/migrations/20190524-attribution.sql
+++ b/db/migrations/20190524-attribution.sql
@@ -1,0 +1,2 @@
+DROP TABLE acos_beneficiaries;
+DROP TABLE beneficiaries;


### PR DESCRIPTION
### Fixes [BCDA-1259](https://jira.cms.gov/browse/BCDA-1259)
Changes to the attribution process mean that the `beneficiaries` and `acos_beneficiaries` tables are no longer needed. Related models were removed with BCDA-1234.

### Proposed changes
Drop `beneficiaries` and `acos_beneficiaries` tables, and update functions that rely on them.

### Change details
* SQL script to drop `beneficiaries` and `acos_beneficiaries`
* `beneficiaries` and `acos_beneficiaries` removed from api.sql
* CLI `create-alpha-token` changed to require a CMS ID for the ACO in the format `T****` (`T` + four digits)
  * `AssignAlphaBeneficiaries()` removed due to reliance on dropped tables. To associate beneficiaries with an alpha ACO, synthetic CCLF files may be ingested.

### Security implications
No security impact. This script removes two tables that are not used and modifies the attribution process for an alpha ACO.

### Acceptance validation
Tests updated. Will deploy to dev environment if these changes are approved.

### Feedback requested
For the auth team: do we still need `create-alpha-token` and if so, does this approach work?
