### PR TITLE
BCDA-1365 Bug: When creating an ACO, set the client_id

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -251,7 +251,11 @@ func CreateACO(name string, cmsID *string) (uuid.UUID, error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
-	aco := ACO{Name: name, CMSID: cmsID, UUID: uuid.NewRandom()}
+	id := uuid.NewRandom()
+
+	// TODO: remove ClientID below when a future refactor removes the need
+	//    for every ACO to have a client_id at creation
+	aco := ACO{Name: name, CMSID: cmsID, UUID: id, ClientID: id.String()}
 	db.Create(&aco)
 
 	return aco.UUID, db.Error

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -52,7 +52,7 @@ func (s *ModelsTestSuite) TestCreateACO() {
 	assert.Nil(err)
 	assert.NotNil(aco)
 	assert.Equal(ACOName, aco.Name)
-	assert.Equal("", aco.ClientID)
+	assert.Equal(acoUUID.String(), aco.ClientID)
 	assert.Equal(cmsID, *aco.CMSID)
 	pubKey, err := aco.GetPublicKey()
 	assert.NotNil(err)


### PR DESCRIPTION
### Fixes [BCDA-1365](https://jira.cms.gov/browse/BCDA-1365)
This is for BCDA's beta release: to set up ACO's, our process will be:
1. Create the ACO (using the CLI)
2. Upload the public key (step 1 of Jenkins job)
3. Create credentials (step 2 of Jenkins job)

Right now, this process fails because step 3 depends on the ACO having a `client_id`, and step 1 does not create it.  In the future there may be other ways to accomplish this, but for now, the simplest and least risky way to get to release is to have step 1 also set the `client_id`

### Proposed changes:
When calling `models.CreateACO()`, set the `acos.client_id` equal to the string value of `acos.uuid`.

### Security Implications
See ticket.

### Acceptance Validation
Unit testing confirms that the `client_id` is set.

### Feedback Requested
Can anything be improved?