### PR TITLE
BCDA-1375: Bug fix: Swagger bearer auth now works

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -23,7 +23,8 @@ Until you click logout your token will be presented with every request made.  To
      SecurityDefinitions:
      bearer_token:
           type: apiKey
-          name: The bulkData endpoints require a Bearer Token. 1) Put your credentials in Basic Authentication, 2) Request a bearer token from /auth/token, 3) Put "Bearer {TOKEN}" in this field (no quotes) using the bearer token retrieved in step 2
+          name: Authorization
+          description: The bulkData endpoints require a Bearer Token. 1) Put your credentials in Basic Authentication, 2) Request a bearer token from /auth/token, 3) Put "Bearer {TOKEN}" in this field (no quotes) using the bearer token retrieved in step 2
           in: header
      basic_auth:
           type: basic


### PR DESCRIPTION
### Fixes [BCDA-1375](https://jira.cms.gov/browse/BCDA-1375)
Swagger has been broken, not accepting tokens because the bearer token description was put in the `name:` field.  This PR fixes the issue.

### Proposed changes:
* Use "Authorization" as the name of the bearer token authentication method

### Security Implications
This change only affects Swagger documentation, essentially reverting it to a prior state, and thus does not negatively impact security.

### Acceptance Validation
Auth dialogue documentation:
<img width="519" alt="Screen Shot 2019-05-30 at 2 33 38 PM" src="https://user-images.githubusercontent.com/2533561/58656261-f02d4400-82e9-11e9-9a43-f100b4047a3c.png">

Proof of functioning token:
<img width="908" alt="Screen Shot 2019-05-30 at 2 34 48 PM" src="https://user-images.githubusercontent.com/2533561/58655668-9710e080-82e8-11e9-8779-548c24097c9c.png">

### Feedback Requested
* Does it run for you?
* Are there any other necessary changes?
