### PR TITLE
BCDA-1393 Security Update: Increase Hash Entropy

### DIFF
--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -20,7 +20,7 @@ import (
 // The time for hash comparison should be about 1s.  Increase hashIter if this is significantly faster in production.
 // Note that changing hashIter or hashKeyLen will result in invalidating existing stored hashes (e.g. credentials).
 const (
-	hashIter int = 900000
+	hashIter int = 130000
 	hashKeyLen int = 64
 	saltSize int = 32
 	hashMinTime = 1 * time.Second

--- a/bcda/auth/backend.go
+++ b/bcda/auth/backend.go
@@ -20,7 +20,7 @@ import (
 // The time for hash comparison should be about 1s.  Increase hashIter if this is significantly faster in production.
 // Note that changing hashIter or hashKeyLen will result in invalidating existing stored hashes (e.g. credentials).
 const (
-	hashIter int = 90000
+	hashIter int = 900000
 	hashKeyLen int = 64
 	saltSize int = 32
 	hashMinTime = 1 * time.Second

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -139,7 +140,7 @@ func (s *BackendTestSuite) TestHashUnique() {
 
 func (s *BackendTestSuite) TestHashCompatibility() {
 	uuidString := "96c5a0cd-b284-47ac-be6e-f33b14dc4697"
-	hash := auth.Hash("d3H4fX/uEk1jOW2gYrFezyuJoSv4ay2x3gH5C25KpWM=:kVqFm1he5S4R1/10oIkVNFot40VB3wTa+DXTp4TrwvyXHkQO7Dxjjo/OqwemiYP8p3UQ8r/HkmTQrSS99UXzaQ==")
+	hash := auth.Hash("YMkApwNDTca4xlM/ROE4ZsiPLrWhjBGbJWue5RghICs=:S/xW9ehijAxxBtsMrDH+R6MYc/l4Sr3Y2SNkPJizy7WW0yaw7FFoAQ1R95WdWnrbPWaM6U0St5U6fp8Bge5pIA==")
 	assert.True(s.T(), hash.IsHashOf(uuidString), "Possible change in hashing parameters or algorithm.  Known input/output does not match.  Merging this code will result in invalidating credentials.")
 }
 

--- a/bcda/auth/backend_test.go
+++ b/bcda/auth/backend_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"


### PR DESCRIPTION
### Fixes [BCDA-1393](https://jira.cms.gov/browse/BCDA-1393)
Our first benchmark of the `prod` environment suggests that we need many more iterations in our hashing to reach our target of at least 1 second spent creating each hash.  This PR increases the number of iterations from 90,000 to 130,000.

### Security Implications
More hash iterations adds protection to the credentials we hash, making attackers work harder to use the credentials should they have access to our database.

### Migration Strategy
All credentials in all environments will be invalidated by this change.  After merging this code, credentials used in Jenkins for smoke tests will be updated for `dev` and `test` environments.

### Feedback Requested
Are there any glaring errors in this PR?
