### PR TITLE
BCDA-1419: Make request for BB data only if BCDA successfully receives BB beneficiary ID	

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -391,7 +391,7 @@ func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (bl
 	}
 
 	if len(patient.Entry) == 0 {
-		err = fmt.Errorf("patient identifier not found at BlueButton for cclfBenficiary ID: %v", cclfBeneficiary.ID)
+		err = fmt.Errorf("patient identifier not found at Blue Button for CCLF beneficiary ID: %v", cclfBeneficiary.ID)
 		log.Error(err)
 		return "", err
 	}

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -224,16 +224,17 @@ func writeBBDataToFile(bb client.APIClient, acoID string, cclfBeneficiaryIDs []s
 			log.Error(err)
 			errorCount++
 			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving BlueButton ID for cclfBeneficiary %s", cclfBeneficiaryID), jobID)
-		}
-		cclfBeneficiary.BlueButtonID = blueButtonID
-		db.Save(&cclfBeneficiary)
-		pData, err := bbFunc(blueButtonID, jobID)
-		if err != nil {
-			log.Error(err)
-			errorCount++
-			appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving %s for beneficiary %s in ACO %s", t, blueButtonID, acoID), jobID)
 		} else {
-			fhirBundleToResourceNDJSON(w, pData, t, cclfBeneficiaryID, acoID, jobID)
+			cclfBeneficiary.BlueButtonID = blueButtonID
+			db.Save(&cclfBeneficiary)
+			pData, err := bbFunc(blueButtonID, jobID)
+			if err != nil {
+				log.Error(err)
+				errorCount++
+				appendErrorToFile(acoID, responseutils.Exception, responseutils.BbErr, fmt.Sprintf("Error retrieving %s for beneficiary %s in ACO %s", t, blueButtonID, acoID), jobID)
+			} else {
+				fhirBundleToResourceNDJSON(w, pData, t, cclfBeneficiaryID, acoID, jobID)
+			}
 		}
 		failPct := (float64(errorCount) / totalBeneIDs) * 100
 		if failPct >= failThreshold {


### PR DESCRIPTION
### Fixes [BCDA-1419](https://jira.cms.gov/browse/BCDA-1419)
BCDA currently does not handle cases where the Blue Button beneficiary ID can't be retrieved when making a request to /Patient by hashed HICN. When that happens, the application should not try to make additional requests to Blue Button for data for that beneficiary because it will cause the beneficiary ID parameter to be null.

### Proposed changes:
If an error is returned from a call to `GetBlueButtonID()`, skip logic to retrieve data from Blue Button by BB beneficiary ID. (Split out of earlier PR: https://github.com/CMSgov/bcda-app/pull/284)

### Security Implications
This change prevents BCDA from making requests to Blue Button that are guaranteed to fail. No PII or PHI is retrieved.

### Acceptance Validation
TBD

### Feedback Requested
Any
