### PR TITLE
BCDA-1347: The CCLF Cleanup functionality does not report errors properly

### DIFF
--- a/bcda/cclf/cclf_test.go
+++ b/bcda/cclf/cclf_test.go
@@ -547,7 +547,8 @@ func (s *CCLFTestSuite) TestCleanupCCLF() {
 		imported:  true,
 	}
 	cclfmap["A0001_18"] = []*cclfFileMetadata{cclf0metadata, cclf8metadata, cclf9metadata}
-	cleanupCCLF(cclfmap)
+	err := cleanupCCLF(cclfmap)
+	assert.Nil(err)
 
 	files, err := ioutil.ReadDir(os.Getenv("PENDING_DELETION_DIR"))
 	if err != nil {


### PR DESCRIPTION
### Fixes [BCDA-1347](https://jira.cms.gov/browse/BCDA-1347)
When `cleanupCCLF()` fails, error details are not provided.

### Proposed changes:
Add error value to printed and logged messages, and return an `error` from the function if one or more files was not cleaned up.

### Security Implications
This adds more information to logs and messages printed by the CLI to include the causes of errors when files are being moved. No PII or PHI is included.

### Acceptance Validation
Messages can be seen in tests (where cleanup was already failing) and `TestCleanupCCLF()` asserts that the returned `error` is nil.
<img width="908" alt="Screen Shot 2019-06-10 at 1 26 12 PM" src="https://user-images.githubusercontent.com/1923441/59213676-6c921380-8b83-11e9-91d4-0951a3148e0f.png">

### Feedback Requested
Any
