### PR TITLE
BCDA-1417: Fix BB client logging statements for responses

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -32,7 +32,6 @@ type APIClient interface {
 	GetExplanationOfBenefitData(patientID, jobID string) (string, error)
 	GetPatientData(patientID, jobID string) (string, error)
 	GetCoverageData(beneficiaryID, jobID string) (string, error)
-
 	GetBlueButtonIdentifier(hashedHICN string) (string, error)
 }
 

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -144,8 +144,11 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID strin
 
 	addRequestHeaders(req, reqID)
 
+	go logRequest(req, jobID)
 	resp, err := bbc.httpClient.Do(req)
-	logRequest(req, resp, jobID)
+	if resp != nil {
+		logResponse(req, resp, jobID)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -181,23 +184,23 @@ func addRequestHeaders(req *http.Request, reqID uuid.UUID) {
 	req.Header.Add("BlueButton-BackendCall", "")
 }
 
-func logRequest(req *http.Request, resp *http.Response, jobID string) {
+func logRequest(req *http.Request, jobID string) {
 	logger.WithFields(logrus.Fields{
 		"bb_query_id": req.Header.Get("BlueButton-OriginalQueryId"),
 		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
 		"bb_uri":      req.Header.Get("BlueButton-OriginalUrl"),
 		"job_id":      jobID,
 	}).Infoln("request")
+}
 
-	if resp != nil {
-		logger.WithFields(logrus.Fields{
-			"resp_code":      resp.StatusCode,
-			"bb_query_id":    req.Header.Get("BlueButton-OriginalQueryId"),
-			"bb_query_ts":    req.Header.Get("BlueButton-OriginalQueryTimestamp"),
-			"bb_uri":         req.Header.Get("BlueButton-OriginalUrl"),
-			"job_id":         jobID,
-		}).Infoln("response")
-	}
+func logResponse(req *http.Request, resp *http.Response, jobID string) {
+	logger.WithFields(logrus.Fields{
+		"resp_code":   resp.StatusCode,
+		"bb_query_id": req.Header.Get("BlueButton-OriginalQueryId"),
+		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
+		"bb_uri":      req.Header.Get("BlueButton-OriginalUrl"),
+		"job_id":      jobID,
+	}).Infoln("response")
 }
 
 func GetDefaultParams() (params url.Values) {

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -32,6 +32,7 @@ type APIClient interface {
 	GetExplanationOfBenefitData(patientID, jobID string) (string, error)
 	GetPatientData(patientID, jobID string) (string, error)
 	GetCoverageData(beneficiaryID, jobID string) (string, error)
+
 	GetBlueButtonIdentifier(hashedHICN string) (string, error)
 }
 
@@ -98,7 +99,7 @@ type BeneDataFunc func(string, string) (string, error)
 func (bbc *BlueButtonClient) GetPatientData(patientID, jobID string) (string, error) {
 	params := GetDefaultParams()
 	params.Set("_id", patientID)
-	return bbc.getData(blueButtonBasePath+"/Patient/", params, "")
+	return bbc.getData(blueButtonBasePath+"/Patient/", params, jobID)
 }
 
 func (bbc *BlueButtonClient) GetBlueButtonIdentifier(hashedHICN string) (string, error) {
@@ -111,7 +112,7 @@ func (bbc *BlueButtonClient) GetBlueButtonIdentifier(hashedHICN string) (string,
 func (bbc *BlueButtonClient) GetCoverageData(beneficiaryID, jobID string) (string, error) {
 	params := GetDefaultParams()
 	params.Set("beneficiary", beneficiaryID)
-	return bbc.getData(blueButtonBasePath+"/Coverage/", params, "")
+	return bbc.getData(blueButtonBasePath+"/Coverage/", params, jobID)
 }
 
 func (bbc *BlueButtonClient) GetExplanationOfBenefitData(patientID string, jobID string) (string, error) {
@@ -187,17 +188,16 @@ func logRequest(req *http.Request, resp *http.Response, jobID string) {
 		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
 		"bb_uri":      req.Header.Get("BlueButton-OriginalUrl"),
 		"job_id":      jobID,
-	}).Infoln("Blue Button request")
+	}).Infoln("request")
 
 	if resp != nil {
 		logger.WithFields(logrus.Fields{
 			"resp_code":      resp.StatusCode,
-			"bb_query_id":    resp.Header.Get("BlueButton-OriginalQueryId"),
-			"bb_query_ts":    resp.Header.Get("BlueButton-OriginalQueryTimestamp"),
-			"bb_uri":         resp.Header.Get("BlueButton-OriginalUrl"),
+			"bb_query_id":    req.Header.Get("BlueButton-OriginalQueryId"),
+			"bb_query_ts":    req.Header.Get("BlueButton-OriginalQueryTimestamp"),
+			"bb_uri":         req.Header.Get("BlueButton-OriginalUrl"),
 			"job_id":         jobID,
-			"content_length": resp.ContentLength,
-		}).Infoln("Blue Button response")
+		}).Infoln("response")
 	}
 }
 


### PR DESCRIPTION
### Fixes [BCDA-1417](https://jira.cms.gov/browse/BCDA-1417)
Log entries for Blue Button responses are missing values. 

### Proposed changes:
Add missing values and remove fields where the value is unknown.

### Change Details
* Uses headers from the request to populate `bb_query_id`, `bb_query_ts`, `bb_uri`
* Removes `content_length` because Go will always set it to -1
* Adds `jobID` parameter to `getData` calls from `GetPatientData` and `GetCoverageData`
* Shortens messages to simply `request` or `response` (previously 'Blue Button request' and 'Blue Button response`) as these entries are part of the Blue Button request log and have other indicators that they are to/from BB
* Separates request and response logging into two functions, called before the request is made and after the response is received

### Security Implications
No new information has been added; all values being logged in responses are already logged under requests. The Blue Button URI may contain a Blue Button patient ID or hashed HICN.

### Acceptance Validation
Log entry examples of requests to and responses from BB dev environment. `beneficiary` ID is synthetic.
<img width="1007" alt="Screen Shot 2019-06-13 at 1 28 45 PM" src="https://user-images.githubusercontent.com/1923441/59457223-022cdd80-8de6-11e9-9646-9ddc9d75ae15.png">
![Screen Shot 2019-06-14 at 12 19 02 PM](https://user-images.githubusercontent.com/1923441/59523188-a8d4b500-8e9e-11e9-9f07-28da1d3ce111.png)


### Feedback Requested
Any