### PR TITLE
BCDA-1433 Feature: Increased the BB connection timeout to 10 seconds.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem 
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us
       - BB_CHECK_CERT=false
-      - BB_TIMEOUT_MS=3000
+      - BB_TIMEOUT_MS=10000
       - BCDA_FHIR_MAX_RECORDS=10000
       - BB_HASH_PEPPER=6E6F747468657265616C706570706572
       - BB_HASH_ITER=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem 
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us
       - BB_CHECK_CERT=false
-      - BB_TIMEOUT_MS=500
+      - BB_TIMEOUT_MS=3000
       - BCDA_FHIR_MAX_RECORDS=10000
       - BB_HASH_PEPPER=6E6F747468657265616C706570706572
       - BB_HASH_ITER=2


### PR DESCRIPTION
Fixes [BCDA-1433](https://jira.cms.gov/browse/BCDA-1433)

Problem:
We would occasionally experience connection timeouts when making request, especially to our heavier data endpoints like EOB. This will hopefully keep our files from error-ing out so much.

Proposed changes:
docker-compose.yml - changed timeout from 500 --> 10,000 milliseconds

Security Implications:
No, this change **does not** deal with any PII/PHI.

Acceptance Validation:
Yes, all of our tests pass. And since this error was less consistent, time will tell us if this bug is truly resolved. 

Feedback Requested
Any and all 