### PR TITLE
BCDA-1441: Additional error handling in smoke tests

### DIFF
--- a/decryption_utils/Go/decrypt.go
+++ b/decryption_utils/Go/decrypt.go
@@ -49,7 +49,7 @@ func init() {
 	uuid := strings.Split(filename, ".")[0]
 	if !r.MatchString(uuid) {
 		fmt.Printf("File name does not appear to be valid.\nPlease use the exact file name from the job status endpoint (i.e., of the format: <UUID>.ndjson).\n")
-		os.Exit(2)
+		os.Exit(1)
 	}
 }
 
@@ -78,13 +78,13 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 		sha256.New(), rand.Reader, privateKey, encryptedKey, []byte(base))
 	if err != nil {
 		fmt.Println("Failed to decrypt encrypted key. Error:", err)
-		os.Exit(3)
+		os.Exit(1)
 	}
 
 	ciphertext, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		fmt.Println("Failed to read encrypted file. Error:", err)
-		os.Exit(4)
+		os.Exit(1)
 	}
 
 	var plaintext []byte
@@ -93,7 +93,7 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 	plaintext, err = decryptCipher(ciphertext, &key)
 	if err != nil {
 		fmt.Println("Failed to decrypt file. Error:", err)
-		os.Exit(5)
+		os.Exit(1)
 	}
 
 	fmt.Printf("%s", plaintext)
@@ -104,7 +104,7 @@ func getPrivateKey(loc string) *rsa.PrivateKey {
 	pkFile, err := os.Open(filepath.Clean(loc))
 	if err != nil {
 		fmt.Println("Failed to open private key. Error:", err)
-		os.Exit(6)
+		os.Exit(1)
 	}
 
 	pemfileinfo, _ := pkFile.Stat()
@@ -115,20 +115,20 @@ func getPrivateKey(loc string) *rsa.PrivateKey {
 	_, err = buffer.Read(pembytes)
 	if err != nil {
 		fmt.Println("Failed to read private key. Error:", err)
-		os.Exit(7)
+		os.Exit(1)
 	}
 
 	data, _ := pem.Decode([]byte(pembytes))
 	err = pkFile.Close()
 	if err != nil {
 		fmt.Println("Failed to close private key. Error:", err)
-		os.Exit(8)
+		os.Exit(1)
 	}
 
 	imported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
 	if err != nil {
 		fmt.Println("Failed to parse private Key as PKCS1. Error:", err)
-		os.Exit(9)
+		os.Exit(1)
 	}
 
 	return imported
@@ -138,7 +138,7 @@ func main() {
 	ek, err := hex.DecodeString(encryptedKey)
 	if err != nil {
 		fmt.Println("Failed to decode encrypted key. Error:", err)
-		os.Exit(10)
+		os.Exit(1)
 	}
 	pk := getPrivateKey(private)
 	decryptFile(pk, ek, encryptedfilepath)

--- a/encryption_utils/Go/decrypt.go
+++ b/encryption_utils/Go/decrypt.go
@@ -14,31 +14,42 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
 
-var private, encryptedKey, filepath string
+var private, encryptedKey, encryptedfilepath string
 
 func init() {
 	flag.StringVar(&encryptedKey, "key", "", "encrypted symmetric key used for file decryption (hex-encoded string)")
-	flag.StringVar(&filepath, "file", "", "location of encrypted file")
+	flag.StringVar(&encryptedfilepath, "file", "", "location of encrypted file")
 	flag.StringVar(&private, "pk", "", "location of private key to use for decryption of symmetric key")
 	flag.Parse()
 
-	if encryptedKey == "" || filepath == "" || private == "" {
-		fmt.Println("missing argument(s)")
+	var missingArgs []string
+	if encryptedKey == "" {
+		missingArgs = append(missingArgs, "key")
+	}
+	if encryptedfilepath == "" {
+		missingArgs = append(missingArgs, "file")
+	}
+	if private == "" {
+		missingArgs = append(missingArgs, "pk")
+	}
+	if len(missingArgs) > 0 {
+		fmt.Printf("Missing argument(s): %s\n", strings.Join(missingArgs, ", "))
 		os.Exit(1)
 	}
+
 	r, _ := regexp.Compile("^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}")
-	filename := path.Base(filepath)
+	filename := path.Base(encryptedfilepath)
 	uuid := strings.Split(filename, ".")[0]
 	if !r.MatchString(uuid) {
 		fmt.Printf("File name does not appear to be valid.\nPlease use the exact file name from the job status endpoint (i.e., of the format: <UUID>.ndjson).\n")
-		os.Exit(1)
+		os.Exit(2)
 	}
 }
 
@@ -66,12 +77,14 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 	decryptedKey, err := rsa.DecryptOAEP(
 		sha256.New(), rand.Reader, privateKey, encryptedKey, []byte(base))
 	if err != nil {
-		panic(err)
+		fmt.Println("Failed to decrypt encrypted key. Error:", err)
+		os.Exit(3)
 	}
-	/* #nosec -- Command line util requires reading a file that is passed via an argument */
-	ciphertext, err := ioutil.ReadFile(filename)
+
+	ciphertext, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
-		panic(err)
+		fmt.Println("Failed to read encrypted file. Error:", err)
+		os.Exit(4)
 	}
 
 	var plaintext []byte
@@ -79,38 +92,43 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 	copy(key[:], decryptedKey[0:32])
 	plaintext, err = decryptCipher(ciphertext, &key)
 	if err != nil {
-		panic(err)
+		fmt.Println("Failed to decrypt file. Error:", err)
+		os.Exit(5)
 	}
 
 	fmt.Printf("%s", plaintext)
 }
 
 func getPrivateKey(loc string) *rsa.PrivateKey {
-	/* #nosec -- Command line util requires reading a file that is passed via an argument */
-	pkFile, err := os.Open(loc)
+
+	pkFile, err := os.Open(filepath.Clean(loc))
 	if err != nil {
-		panic(err)
+		fmt.Println("Failed to open private key. Error:", err)
+		os.Exit(6)
 	}
 
 	pemfileinfo, _ := pkFile.Stat()
-	var size int64 = pemfileinfo.Size()
+	var size = pemfileinfo.Size()
 	pembytes := make([]byte, size)
 	buffer := bufio.NewReader(pkFile)
 
 	_, err = buffer.Read(pembytes)
 	if err != nil {
-		log.Panic(err)
+		fmt.Println("Failed to read private key. Error:", err)
+		os.Exit(7)
 	}
 
 	data, _ := pem.Decode([]byte(pembytes))
 	err = pkFile.Close()
 	if err != nil {
-		log.Panic(err)
+		fmt.Println("Failed to close private key. Error:", err)
+		os.Exit(8)
 	}
 
 	imported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
 	if err != nil {
-		log.Panic(err)
+		fmt.Println("Failed to parse private Key as PKCS1. Error:", err)
+		os.Exit(9)
 	}
 
 	return imported
@@ -119,8 +137,9 @@ func getPrivateKey(loc string) *rsa.PrivateKey {
 func main() {
 	ek, err := hex.DecodeString(encryptedKey)
 	if err != nil {
-		panic(err)
+		fmt.Println("Failed to decode encrypted key. Error:", err)
+		os.Exit(10)
 	}
 	pk := getPrivateKey(private)
-	decryptFile(pk, ek, filepath)
+	decryptFile(pk, ek, encryptedfilepath)
 }

--- a/encryption_utils/Go/decrypt.go
+++ b/encryption_utils/Go/decrypt.go
@@ -49,7 +49,7 @@ func init() {
 	uuid := strings.Split(filename, ".")[0]
 	if !r.MatchString(uuid) {
 		fmt.Printf("File name does not appear to be valid.\nPlease use the exact file name from the job status endpoint (i.e., of the format: <UUID>.ndjson).\n")
-		os.Exit(2)
+		os.Exit(1)
 	}
 }
 
@@ -78,13 +78,13 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 		sha256.New(), rand.Reader, privateKey, encryptedKey, []byte(base))
 	if err != nil {
 		fmt.Println("Failed to decrypt encrypted key. Error:", err)
-		os.Exit(3)
+		os.Exit(1)
 	}
 
 	ciphertext, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		fmt.Println("Failed to read encrypted file. Error:", err)
-		os.Exit(4)
+		os.Exit(1)
 	}
 
 	var plaintext []byte
@@ -93,7 +93,7 @@ func decryptFile(privateKey *rsa.PrivateKey, encryptedKey []byte, filename strin
 	plaintext, err = decryptCipher(ciphertext, &key)
 	if err != nil {
 		fmt.Println("Failed to decrypt file. Error:", err)
-		os.Exit(5)
+		os.Exit(1)
 	}
 
 	fmt.Printf("%s", plaintext)
@@ -104,7 +104,7 @@ func getPrivateKey(loc string) *rsa.PrivateKey {
 	pkFile, err := os.Open(filepath.Clean(loc))
 	if err != nil {
 		fmt.Println("Failed to open private key. Error:", err)
-		os.Exit(6)
+		os.Exit(1)
 	}
 
 	pemfileinfo, _ := pkFile.Stat()
@@ -115,20 +115,20 @@ func getPrivateKey(loc string) *rsa.PrivateKey {
 	_, err = buffer.Read(pembytes)
 	if err != nil {
 		fmt.Println("Failed to read private key. Error:", err)
-		os.Exit(7)
+		os.Exit(1)
 	}
 
 	data, _ := pem.Decode([]byte(pembytes))
 	err = pkFile.Close()
 	if err != nil {
 		fmt.Println("Failed to close private key. Error:", err)
-		os.Exit(8)
+		os.Exit(1)
 	}
 
 	imported, err := x509.ParsePKCS1PrivateKey(data.Bytes)
 	if err != nil {
 		fmt.Println("Failed to parse private Key as PKCS1. Error:", err)
-		os.Exit(9)
+		os.Exit(1)
 	}
 
 	return imported
@@ -138,7 +138,7 @@ func main() {
 	ek, err := hex.DecodeString(encryptedKey)
 	if err != nil {
 		fmt.Println("Failed to decode encrypted key. Error:", err)
-		os.Exit(10)
+		os.Exit(1)
 	}
 	pk := getPrivateKey(private)
 	decryptFile(pk, ek, encryptedfilepath)

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -208,8 +208,16 @@ func main() {
 
 						fmt.Println("decrypting the file...")
 						encryptedKey := string(encryptData[path.Base(data[0].Url)])
+						if encryptedKey == "" {
+							fmt.Println("Error: no key found in data")
+							os.Exit(1)
+						}
 
 						privateKeyFile := os.Getenv("ATO_PRIVATE_KEY_FILE")
+						if privateKeyFile == "" {
+							fmt.Println("Error: private key file path not set")
+							os.Exit(1)
+						}
 
 						// execute the golang decryptor
 						var cmdOut []byte


### PR DESCRIPTION
### Fixes [BCDA-1441](https://jira.cms.gov/browse/BCDA-1441)
There are intermittent decryption errors when the smoke tests are run, but not enough information to determine the cause.

### Proposed changes:
Check for more scenarios that could cause decryption to fail and print errors to stdout.

### Change Details
* Go decryptor errors print to stdout
* bcda_client.go checks for `encryptedKey` and `privateKeyFile`, and prints an error and exits if either does not exist

### Security Implications
No security impact. These changes apply to smoke tests, which run with synthetic data.

### Acceptance Validation
A few examples of errors from the Go decryptor and test client.
![Screen Shot 2019-06-17 at 2 37 42 PM](https://user-images.githubusercontent.com/1923441/59699553-c6b45980-91bf-11e9-879a-082c8e902b6c.png)
![Screen Shot 2019-06-17 at 2 39 16 PM](https://user-images.githubusercontent.com/1923441/59699566-ca47e080-91bf-11e9-87c4-e6eb27472a00.png)

### Feedback Requested
Any. Can you think of other places where the smoke tests or decryptors need to print more information?
