### PR TITLE
BCDA-1204 Remove tokens table

### DIFF
--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -17,37 +17,18 @@ func InitializeGormModels() *gorm.DB {
 
 	// Migrate the schema
 	// Add your new models here
-	db.AutoMigrate(
-		&Token{},
-	)
-
-	// force manual deletion of foreign key and this related record (you can delete a Token, but not an aco with a token
-	db.Model(&Token{}).AddForeignKey("aco_id", "acos(uuid)", "RESTRICT", "RESTRICT")
+	db.AutoMigrate()
 
 	return db
 }
 
 type Token struct {
-	gorm.Model
-	// even though gorm.Model has an `id` field declared as the primary key, the following definition overrides that
-	UUID        uuid.UUID  `gorm:"primary_key" json:"uuid"`                      // uuid (primary key)
-	Value       string     `gorm:"type:varchar(511); unique" json:"value"`       // Deprecated: When can we drop Value without hurting existing alpha tokens?
-	Active      bool       `json:"active"`                                       // active
-	ACO         models.ACO `gorm:"foreignkey:ACOID;association_foreignkey:UUID"` // ACO needed here because user can belong to multiple ACOs
-	ACOID       uuid.UUID  `gorm:"type:uuid" json:"aco_id"`
-	IssuedAt    int64      `json:"issued_at"`  // standard token claim; unix date
-	ExpiresOn   int64      `json:"expires_on"` // standard token claim; unix date
-	TokenString string     `gorm:"-"`          // ignore; not for database
-}
-
-// When getting a Token out of the database, reconstruct its string value and store it in TokenString.
-func (t *Token) AfterFind() error {
-	s, err := GenerateTokenString(t.UUID.String(), t.ACOID.String(), t.IssuedAt, t.ExpiresOn)
-	if err == nil {
-		t.TokenString = s
-		return nil
-	}
-	return err
+	UUID        uuid.UUID `json:"uuid"`   // uuid (primary key)
+	Active      bool      `json:"active"` // active
+	ACOID       uuid.UUID `json:"aco_id"`
+	IssuedAt    int64     `json:"issued_at"`  // standard token claim; unix date
+	ExpiresOn   int64     `json:"expires_on"` // standard token claim; unix date
+	TokenString string    `json:"token_string"`
 }
 
 func GetACOByClientID(clientID string) (models.ACO, error) {

--- a/bcda/auth/models_test.go
+++ b/bcda/auth/models_test.go
@@ -45,21 +45,6 @@ func (s *ModelsTestSuite) TestTokenCreation() {
 
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), tokenString)
-
-	// Get the claims of the token to find the token ID that was created
-	token := auth.Token{
-		UUID:      tokenUUID,
-		Active:    true,
-		ACOID:     acoUUID,
-		IssuedAt:  issuedAt,
-		ExpiresOn: expiresOn,
-	}
-	s.db.Create(&token)
-
-	var savedToken auth.Token
-	s.db.Find(&savedToken, "UUID = ?", tokenUUID)
-	assert.NotNil(s.T(), savedToken)
-	assert.Equal(s.T(), tokenString, savedToken.TokenString)
 }
 
 func (s *ModelsTestSuite) TestCreateAlphaToken() {

--- a/db/migrations/20190614-drop-tokens-table.sql
+++ b/db/migrations/20190614-drop-tokens-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE tokens;


### PR DESCRIPTION
### Fixes [BCDA-1204](https://jira.cms.gov/browse/BCDA-1204)
Since we are no longer saving tokens to the db, we don't need a tokens table.  There is also some related code that will not be used

### Proposed changes:
- add migration to drop tokens table
- remove now unnecessary fields from the token model and some funcs using the token model as a receiver

### Security Implications
No security impact here.  We already aren't saving the tokens to the db so removing the tokens table does not affect security of the app

- [ ] This change adds new software dependencies
- [ ] This change alters security controls or supporting software
- [ ] This change introduces storage of new data
- [ ] A security checklist been completed for this change

### Acceptance Validation
Tests are passing and everything seems to work just as it did before removal

### Feedback Requested
Is there anything more that can be deleted?
