### PR TITLE
BCDA-711: Introduce retry mechanism in data retrieval from BB

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -143,8 +143,8 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID strin
 	addRequestHeaders(req, uuid.NewRandom())
 
 	tryCount := 0
-	maxTries := 3
-	retryInterval := 1000
+	maxTries := utils.GetEnvInt("BB_REQUEST_MAX_TRIES", 3)
+	retryInterval := utils.GetEnvInt("BB_REQUEST_RETRY_INTERVAL_MS", 1000)
 
 	for tryCount < maxTries {
 		tryCount++

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -140,7 +140,8 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID strin
 
 	req.URL.RawQuery = params.Encode()
 
-	addRequestHeaders(req, uuid.NewRandom())
+	queryID := uuid.NewRandom()
+	addRequestHeaders(req, queryID)
 
 	tryCount := 0
 	maxTries := utils.GetEnvInt("BB_REQUEST_MAX_TRIES", 3)
@@ -149,6 +150,7 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID strin
 	for tryCount < maxTries {
 		tryCount++
 		if tryCount > 1 {
+			logger.Infof("Retrying Blue Button request %s in %d ms...", queryID, retryInterval)
 			time.Sleep(time.Duration(retryInterval) * time.Millisecond)
 		}
 
@@ -160,7 +162,7 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID strin
 		return data, nil
 	}
 
-	return "", fmt.Errorf("Blue Button request %s failed %d time(s)", req.Header.Get("BlueButton-OriginalQueryId"), tryCount)
+	return "", fmt.Errorf("Blue Button request %s failed %d time(s)", queryID, tryCount)
 }
 
 func addRequestHeaders(req *http.Request, reqID uuid.UUID) {

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -150,7 +150,7 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID strin
 	for tryCount < maxTries {
 		tryCount++
 		if tryCount > 1 {
-			logger.Infof("Retrying Blue Button request %s in %d ms...", queryID, retryInterval)
+			logger.Infof("Blue Button request %s try #%d in %d ms...", queryID, tryCount, retryInterval)
 			time.Sleep(time.Duration(retryInterval) * time.Millisecond)
 		}
 

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -212,6 +212,12 @@ func (s *BBMockTestSuite) TestGetBlueButtonCoverageData() {
 	assert.NotContains(s.T(), c, "excludeSAMHSA=true")
 }
 
+func (s *BBMockTestSuite) TestGetBlueButtonCoverageData_500() {
+	p, err := s.bbClient.GetCoverageData("012345", "543210")
+	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Equal(s.T(), "", p)
+}
+
 func (s *BBMockTestSuite) TestGetBlueButtonExplanationOfBenefitData() {
 	e, err := s.bbClient.GetExplanationOfBenefitData("012345", "543210")
 	assert.Nil(s.T(), err)
@@ -219,11 +225,23 @@ func (s *BBMockTestSuite) TestGetBlueButtonExplanationOfBenefitData() {
 	assert.Contains(s.T(), e, "excludeSAMHSA=true")
 }
 
+func (s *BBMockTestSuite) TestGetBlueButtonExplanationOfBenefitData_500() {
+	p, err := s.bbClient.GetExplanationOfBenefitData("012345", "543210")
+	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Equal(s.T(), "", p)
+}
+
 func (s *BBMockTestSuite) TestGetBlueButtonMetadata() {
 	m, err := s.bbClient.GetMetadata()
 	assert.Nil(s.T(), err)
 	assert.Contains(s.T(), m, `{ "test": "ok"`)
 	assert.NotContains(s.T(), m, "excludeSAMHSA=true")
+}
+
+func (s *BBMockTestSuite) TestGetBlueButtonMetadata_500() {
+	p, err := s.bbClient.GetMetadata()
+	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Equal(s.T(), "", p)
 }
 
 // Sample values from https://confluence.cms.gov/pages/viewpage.action?spaceKey=BB&title=Getting+Started+with+Blue+Button+2.0%27s+Backend#space-menu-link-content

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/CMSgov/bcda-app/bcda/client"
@@ -14,27 +15,48 @@ import (
 
 type BBTestSuite struct {
 	suite.Suite
+}
+
+type BBMockTestSuite struct {
+	BBTestSuite
 	bbClient *client.BlueButtonClient
 	ts       *httptest.Server
 }
 
-func (s *BBTestSuite) SetupTest() {
-	s.ts = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+var ts200, ts500 *httptest.Server
+
+func (s *BBTestSuite) SetupSuite() {
+	os.Setenv("BB_CLIENT_CERT_FILE", "../../shared_files/bb-dev-test-cert.pem")
+	os.Setenv("BB_CLIENT_KEY_FILE", "../../shared_files/bb-dev-test-key.pem")
+	os.Setenv("BB_CLIENT_CA_FILE", "../../shared_files/localhost.crt")
+}
+
+func (s *BBMockTestSuite) SetupSuite() {
+	ts200 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", r.URL.Query().Get("_format"))
 		response := fmt.Sprintf("{ \"test\": \"ok\"; \"url\": %v}", r.URL.String())
 		fmt.Fprint(w, response)
 	}))
 
-	os.Setenv("BB_SERVER_LOCATION", s.ts.URL)
-	os.Setenv("BB_CLIENT_CERT_FILE", "../../shared_files/bb-dev-test-cert.pem")
-	os.Setenv("BB_CLIENT_KEY_FILE", "../../shared_files/bb-dev-test-key.pem")
-	os.Setenv("BB_CLIENT_CA_FILE", "../../shared_files/localhost.crt")
+	ts500 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Print("")
+	}))
 
 	if bbClient, err := client.NewBlueButtonClient(); err != nil {
 		s.Fail("Failed to create Blue Button client", err)
 	} else {
 		s.bbClient = bbClient
 	}
+}
+
+func (s *BBMockTestSuite) BeforeTest(suiteName, testName string) {
+	if strings.Index(testName, "500") > -1 {
+		s.ts = ts500
+	} else {
+		s.ts = ts200
+	}
+	os.Setenv("BB_SERVER_LOCATION", s.ts.URL)
 }
 
 func (s *BBTestSuite) TestNewBlueButtonClientNoCertFile() {
@@ -161,41 +183,47 @@ func (s *BBTestSuite) TestNewBlueButtonClientInvalidCAFile() {
 	assert.EqualError(err, "could not append CA certificate(s)")
 }
 
-func (s *BBTestSuite) TestGetBlueButtonPatientData() {
-	p, err := s.bbClient.GetPatientData("012345", "543210")
-	assert.Nil(s.T(), err)
-	assert.Contains(s.T(), p, `{ "test": "ok"`)
-	assert.NotContains(s.T(), p, "excludeSAMHSA=true")
-}
-
-func (s *BBTestSuite) TestGetBlueButtonCoverageData() {
-	c, err := s.bbClient.GetCoverageData("012345", "543210")
-	assert.Nil(s.T(), err)
-	assert.Contains(s.T(), c, `{ "test": "ok"`)
-	assert.NotContains(s.T(), c, "excludeSAMHSA=true")
-}
-
-func (s *BBTestSuite) TestGetBlueButtonExplanationOfBenefitData() {
-	e, err := s.bbClient.GetExplanationOfBenefitData("012345", "543210")
-	assert.Nil(s.T(), err)
-
-	assert.Contains(s.T(), e, `{ "test": "ok"`)
-	assert.Contains(s.T(), e, "excludeSAMHSA=true")
-}
-
-func (s *BBTestSuite) TestGetBlueButtonMetadata() {
-	m, err := s.bbClient.GetMetadata()
-	assert.Nil(s.T(), err)
-	assert.Contains(s.T(), m, `{ "test": "ok"`)
-	assert.NotContains(s.T(), m, "excludeSAMHSA=true")
-}
-
 func (s *BBTestSuite) TestGetDefaultParams() {
 	params := client.GetDefaultParams()
 	assert.Equal(s.T(), "application/fhir+json", params.Get("_format"))
 	assert.Equal(s.T(), "", params.Get("patient"))
 	assert.Equal(s.T(), "", params.Get("beneficiary"))
 
+}
+
+/* Tests below use mock Blue Button client */
+func (s *BBMockTestSuite) TestGetBlueButtonPatientData() {
+	p, err := s.bbClient.GetPatientData("012345", "543210")
+	assert.Nil(s.T(), err)
+	assert.Contains(s.T(), p, `{ "test": "ok"`)
+	assert.NotContains(s.T(), p, "excludeSAMHSA=true")
+}
+
+func (s *BBMockTestSuite) TestGetBlueButtonPatientData_500() {
+	p, err := s.bbClient.GetPatientData("012345", "543210")
+	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Equal(s.T(), "", p)
+}
+
+func (s *BBMockTestSuite) TestGetBlueButtonCoverageData() {
+	c, err := s.bbClient.GetCoverageData("012345", "543210")
+	assert.Nil(s.T(), err)
+	assert.Contains(s.T(), c, `{ "test": "ok"`)
+	assert.NotContains(s.T(), c, "excludeSAMHSA=true")
+}
+
+func (s *BBMockTestSuite) TestGetBlueButtonExplanationOfBenefitData() {
+	e, err := s.bbClient.GetExplanationOfBenefitData("012345", "543210")
+	assert.Nil(s.T(), err)
+	assert.Contains(s.T(), e, `{ "test": "ok"`)
+	assert.Contains(s.T(), e, "excludeSAMHSA=true")
+}
+
+func (s *BBMockTestSuite) TestGetBlueButtonMetadata() {
+	m, err := s.bbClient.GetMetadata()
+	assert.Nil(s.T(), err)
+	assert.Contains(s.T(), m, `{ "test": "ok"`)
+	assert.NotContains(s.T(), m, "excludeSAMHSA=true")
 }
 
 // Sample values from https://confluence.cms.gov/pages/viewpage.action?spaceKey=BB&title=Getting+Started+with+Blue+Button+2.0%27s+Backend#space-menu-link-content
@@ -212,10 +240,11 @@ func (s *BBTestSuite) TestHashHICN() {
 	assert.NotEqual(s.T(), "b67baee938a551f06605ecc521cc329530df4e088e5a2d84bbdcc047d70faff4", HICNHash)
 }
 
-func (s *BBTestSuite) TearDownTest() {
+func (s *BBMockTestSuite) TearDownAllSuite() {
 	s.ts.Close()
 }
 
 func TestBBTestSuite(t *testing.T) {
 	suite.Run(t, new(BBTestSuite))
+	suite.Run(t, new(BBMockTestSuite))
 }

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -51,7 +51,7 @@ func (s *BBMockTestSuite) SetupSuite() {
 }
 
 func (s *BBMockTestSuite) BeforeTest(suiteName, testName string) {
-	if strings.Index(testName, "500") > -1 {
+	if strings.Contains(testName, "500") {
 		s.ts = ts500
 	} else {
 		s.ts = ts200


### PR DESCRIPTION
### Fixes [BCDA-711](https://jira.cms.gov/browse/BCDA-711)
When a request to Blue Button fails, an entry is added to the errors NDJSON file, with no way for users to re-request only the failed subset of data from BCDA. Some of these errors may be remedied by retrying failed BB requests.

### Proposed changes:
Add retry mechanism in Blue Button client.

### Change Details
* Adds retry logic in `BlueButtonClient.getData()`, using new environment variables:
  * `BB_REQUEST_MAX_TRIES` - Maximum attempts per Blue Button request
  * `BB_REQUEST_RETRY_INTERVAL_MS` - Length of pause, if any, that should happen between requests
* Splits bluebutton_test.go into two tests suites, to separate those that make requests from those that don't

### Security Implications
There is no change to how data is handled, but BCDA will now make more attempts to retrieve it from Blue Button if necessary.

### Acceptance Validation
Added tests with Blue Button client pointing to `httptest.Server` that returns only `500` responses.

### Feedback Requested
Any
