### PR TITLE
BCDA-1414 add test for a new token's expiration claim

### DIFF
--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -136,6 +136,10 @@ func (s *AlphaAuthPluginTestSuite) TestAccessToken() {
 	assert.Nil(s.T(), err)
 	assert.NotEmpty(s.T(), ts)
 	assert.Regexp(s.T(), regexp.MustCompile(`[^.\s]+\.[^.\s]+\.[^.\s]+`), ts)
+	t, _ := s.p.DecodeJWT(ts)
+	c := t.Claims.(*auth.CommonClaims)
+	assert.True(s.T(), c.ExpiresAt <= time.Now().Unix()+3600)
+	assert.False(s.T(), c.ExpiresAt > time.Now().Unix()+3600)
 
 	ts, err = s.p.MakeAccessToken(auth.Credentials{ClientID: cc.ClientID, ClientSecret: "not_the_right_secret"})
 	assert.NotNil(s.T(), err)

--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -139,7 +139,6 @@ func (s *AlphaAuthPluginTestSuite) TestAccessToken() {
 	t, _ := s.p.DecodeJWT(ts)
 	c := t.Claims.(*auth.CommonClaims)
 	assert.True(s.T(), c.ExpiresAt <= time.Now().Unix()+3600)
-	assert.False(s.T(), c.ExpiresAt > time.Now().Unix()+3600)
 
 	ts, err = s.p.MakeAccessToken(auth.Credentials{ClientID: cc.ClientID, ClientSecret: "not_the_right_secret"})
 	assert.NotNil(s.T(), err)


### PR DESCRIPTION
### Fixes [BCDA-1414](https://jira.cms.gov/browse/BCDA-1414)
We were accidentally creating tokens that expired much later in the future than desired.  this has been fixed and deployed but we still need to add a test to make sure that the expiration dates are as intended on newly generated access tokens

### Proposed changes:
- add unit tests to make sure that a newly generated access token has an expiration date less than 60 minutes from generation and never later than 60 minutes after generation

### Security Implications
No negative security implications here.  The way we are generating tokens remains the same.  We get a little bit more secure by testing to make sure expiration dates are correct after this PR

### Acceptance Validation
The newly added unit tests pass

### Feedback Requested
Is this testing sufficient?  How could it be more robust?