### PR TITLE
BCDA-1448 remove deprecated auth provider method and cli command

### DIFF
--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -193,43 +193,6 @@ func (p AlphaAuthPlugin) MakeAccessToken(credentials Credentials) (string, error
 	return GenerateTokenString(uuid, aco.UUID.String(), issuedAt, expiresAt)
 }
 
-// RequestAccessToken generates a token for the ACO (Deprecated, use MakeAccessToken()
-func (p AlphaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {
-	var err error
-	token := Token{}
-
-	if creds.ClientID == "" {
-		return token, fmt.Errorf("must provide ClientID")
-	}
-
-	if uuid.Parse(creds.ClientID) == nil {
-		return token, fmt.Errorf("ClientID must be a valid UUID")
-	}
-
-	if ttl < 0 {
-		return token, fmt.Errorf("invalid TTL: %d", ttl)
-	}
-
-	var aco models.ACO
-	aco, err = getACOFromDB(creds.ClientID)
-	if err != nil {
-		return token, err
-	}
-
-	token.UUID = uuid.NewRandom()
-	token.ACOID = aco.UUID
-	token.IssuedAt = time.Now().Unix()
-	token.ExpiresOn = time.Now().Add(time.Hour * time.Duration(ttl)).Unix()
-	token.Active = true
-
-	token.TokenString, err = GenerateTokenString(token.UUID.String(), token.ACOID.String(), token.IssuedAt, token.ExpiresOn)
-	if err != nil {
-		return Token{}, err
-	}
-
-	return token, nil
-}
-
 func (p AlphaAuthPlugin) RevokeAccessToken(tokenString string) error {
 	return fmt.Errorf("RevokeAccessToken is not implemented for alpha auth")
 }

--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -165,25 +165,6 @@ func (s *AlphaAuthPluginTestSuite) TestAccessToken() {
 	assert.Contains(s.T(), err.Error(), "invalid credentials")
 }
 
-func (s *AlphaAuthPluginTestSuite) TestRequestAccessToken() {
-	const acoID = "DBBD1CE1-AE24-435C-807D-ED45953077D3"
-	t, err := s.p.RequestAccessToken(auth.Credentials{ClientID: acoID}, 720)
-	assert.Nil(s.T(), err)
-	assert.IsType(s.T(), auth.Token{}, t)
-	assert.NotEmpty(s.T(), t.TokenString)
-
-	t, err = s.p.RequestAccessToken(auth.Credentials{}, 720)
-	assert.NotNil(s.T(), err)
-	assert.IsType(s.T(), auth.Token{}, t)
-	assert.Nil(s.T(), t.ACOID)
-	assert.Contains(s.T(), err.Error(), "must provide ClientID")
-
-	t, err = s.p.RequestAccessToken(auth.Credentials{ClientID: acoID}, -1)
-	assert.NotNil(s.T(), err)
-	assert.IsType(s.T(), auth.Token{}, t)
-	assert.Contains(s.T(), err.Error(), "invalid TTL")
-}
-
 func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 	err := s.p.RevokeAccessToken("token-value-is-not-significant-here")
 	assert.NotNil(s.T(), err)

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -84,11 +84,7 @@ func (o OktaAuthPlugin) RevokeClientCredentials(clientID string) error {
 }
 
 // Manufactures an access token for the given credentials
-func (o OktaAuthPlugin) MakeAccessToken(credentials Credentials) (string, error) {
-	return "", nil
-}
-
-func (o OktaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, error) {
+func (o OktaAuthPlugin) MakeAccessToken(creds Credentials) (string, error) {
 	clientID := creds.ClientID
 	// Also accept clientID via creds.UserID to match alpha auth implementation
 	if clientID == "" {
@@ -96,21 +92,21 @@ func (o OktaAuthPlugin) RequestAccessToken(creds Credentials, ttl int) (Token, e
 	}
 
 	if clientID == "" {
-		return Token{}, fmt.Errorf("client ID required")
+		return "", fmt.Errorf("client ID required")
 	}
 
 	if creds.ClientSecret == "" {
-		return Token{}, fmt.Errorf("client secret required")
+		return "", fmt.Errorf("client secret required")
 	}
 
 	clientCreds := client.Credentials{ClientID: clientID, ClientSecret: creds.ClientSecret}
 	ot, err := o.backend.RequestAccessToken(clientCreds)
 
 	if err != nil {
-		return Token{}, err
+		return "", err
 	}
 
-	return Token{TokenString: ot.AccessToken}, nil
+	return ot.AccessToken, nil
 }
 
 func (o OktaAuthPlugin) RevokeAccessToken(tokenString string) error {

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -84,19 +84,19 @@ func (s *OktaAuthPluginTestSuite) TestRevokeClientCredentials() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *OktaAuthPluginTestSuite) TestRequestAccessToken() {
-	t, err := s.o.RequestAccessToken(Credentials{ClientID: "", ClientSecret: ""}, 0)
-	assert.IsType(s.T(), Token{}, t)
-	assert.NotNil(s.T(), err)
+func (s *OktaAuthPluginTestSuite) TestMakeAccessToken() {
+	ts, err := s.o.MakeAccessToken(Credentials{ClientID: "", ClientSecret: ""})
+	assert.Empty(s.T(), ts)
+	assert.EqualError(s.T(), err, "client ID required")
 
 	mockID := "MockID"
 	mockSecret := "MockSecret"
-	t, err = s.o.RequestAccessToken(Credentials{ClientID: mockID, ClientSecret: mockSecret}, 0)
-	assert.IsType(s.T(), Token{}, t)
+	ts, err = s.o.MakeAccessToken(Credentials{ClientID: mockID, ClientSecret: mockSecret})
+	assert.NotEmpty(s.T(), ts)
 	assert.Nil(s.T(), err)
 
-	t, err = s.o.RequestAccessToken(Credentials{UserID: mockID, ClientSecret: mockSecret}, 0)
-	assert.IsType(s.T(), Token{}, t)
+	ts2, err := s.o.MakeAccessToken(Credentials{UserID: mockID, ClientSecret: mockSecret})
+	assert.NotEqual(s.T(), ts, ts2)
 	assert.Nil(s.T(), err)
 }
 

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -85,9 +85,6 @@ type Provider interface {
 	// MakeAccessToken mints an access token for the given credentials
 	MakeAccessToken(credentials Credentials) (string, error)
 
-	// RequestAccessToken mints an access token with a specific time-to-live for the given clientID
-	RequestAccessToken(credentials Credentials, ttl int) (Token, error)
-
 	// RevokeAccessToken a specific access token identified in a base64 encoded token string
 	RevokeAccessToken(tokenString string) error
 

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -4,10 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/cclf"
-	cclfUtils "github.com/CMSgov/bcda-app/bcda/cclf/testutils"
-	"github.com/CMSgov/bcda-app/bcda/constants"
-	"github.com/CMSgov/bcda-app/bcda/web"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,14 +12,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/utils"
-
 	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/cclf"
+	cclfUtils "github.com/CMSgov/bcda-app/bcda/cclf/testutils"
+	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
-
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
-
+	"github.com/CMSgov/bcda-app/bcda/utils"
+	"github.com/CMSgov/bcda-app/bcda/web"
 	"github.com/bgentry/que-go"
 	"github.com/jackc/pgx"
 	"github.com/pborman/uuid"
@@ -46,7 +43,7 @@ func setUpApp() *cli.App {
 	app.Name = Name
 	app.Usage = Usage
 	app.Version = constants.Version
-	var acoName, acoCMSID, acoID, userName, userEmail, tokenID, tokenSecret, accessToken, ttl, threshold, acoSize, filePath, dirToDelete, environment string
+	var acoName, acoCMSID, acoID, userName, userEmail, accessToken, ttl, threshold, acoSize, filePath, dirToDelete, environment string
 	app.Commands = []cli.Command{
 		{
 			Name:  "start-api",
@@ -218,29 +215,6 @@ func setUpApp() *cli.App {
 				}
 
 				fmt.Fprintf(app.Writer, "Public key saved for ACO %s\n", acoCMSID)
-				return nil
-			},
-		},
-		{
-			Name:     "create-token",
-			Category: "Authentication tools",
-			Usage:    "Create an access/session token",
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:        "id",
-					Usage:       "Client ID associated with token",
-					Destination: &tokenID,
-				}, cli.StringFlag{
-					Name:        "secret",
-					Usage:       "Credential secret for creating session tokens",
-					Destination: &tokenSecret,
-				}},
-			Action: func(c *cli.Context) error {
-				tokenValue, err := createAccessToken(tokenID, tokenSecret)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(app.Writer, "%s\n", tokenValue)
 				return nil
 			},
 		},
@@ -470,19 +444,6 @@ func createUser(acoID, name, email string) (string, error) {
 	}
 
 	return user.UUID.String(), nil
-}
-
-func createAccessToken(ID string, secret string) (string, error) {
-	if ID == "" {
-		return "", errors.New("ID (--id) must be provided")
-	}
-
-	token, err := auth.GetProvider().RequestAccessToken(auth.Credentials{ClientID: ID, ClientSecret: secret}, 72)
-	if err != nil {
-		return "", err
-	}
-
-	return token.TokenString, nil
 }
 
 func revokeAccessToken(accessToken string) error {

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -187,58 +187,6 @@ func (s *CLITestSuite) TestCreateUser() {
 	assert.Equal(0, buf.Len())
 }
 
-func (s *CLITestSuite) TestCreateToken() {
-	// Set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
-	buf := new(bytes.Buffer)
-	s.testApp.Writer = buf
-
-	assert := assert.New(s.T())
-	badUUID := "not_a_uuid"
-	clientID := "3461C774-B48F-11E8-96F8-529269fb1459"
-	clientSecret := "not_a_secret"
-
-	// Unexpected flag
-	args := []string{"bcda", "create-token", "--abcd", "efg"}
-	err := s.testApp.Run(args)
-	assert.Equal("flag provided but not defined: -abcd", err.Error())
-	assert.Contains(buf.String(), "Incorrect Usage: flag provided but not defined")
-	buf.Reset()
-
-	// No parameters
-	args = []string{"bcda", "create-token"}
-	err = s.testApp.Run(args)
-	assert.Equal("ID (--id) must be provided", err.Error())
-	assert.Equal(0, buf.Len())
-	buf.Reset()
-
-	// Blank ID
-	args = []string{"bcda", "create-token", "--id", "", "--secret", clientSecret}
-	err = s.testApp.Run(args)
-	assert.Equal("ID (--id) must be provided", err.Error())
-	assert.Equal(0, buf.Len())
-	buf.Reset()
-
-	// Alpha auth section
-	originalAuthProvider := auth.GetProviderName()
-	defer auth.SetProvider(originalAuthProvider)
-	auth.SetProvider("alpha")
-	// Test alpha auth bad ID
-	args = []string{"bcda", "create-token", "--id", badUUID}
-	err = s.testApp.Run(args)
-	assert.Contains(err.Error(), "must be a valid UUID")
-	buf.Reset()
-
-	// Test alpha auth successful creation
-	args = []string{"bcda", "create-token", "--id", clientID, "--secret", clientSecret}
-	err = s.testApp.Run(args)
-	assert.Nil(err)
-	assert.NotNil(buf)
-	accessTokenString := strings.TrimSpace(buf.String())
-	assert.Nil(err)
-	assert.NotEmpty(accessTokenString)
-	buf.Reset()
-}
-
 func (s *CLITestSuite) TestSavePublicKeyCLI() {
 	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
 	buf := new(bytes.Buffer)
@@ -269,7 +217,7 @@ func (s *CLITestSuite) TestSavePublicKeyCLI() {
 	assert.Contains(buf.String(), "")
 
 	// Unspecified File
-	args = []string{"bcda", "save-public-key", "--cms-id", "A9901", }
+	args = []string{"bcda", "save-public-key", "--cms-id", "A9901"}
 	err = s.testApp.Run(args)
 	assert.Equal("key-file is required", err.Error())
 	assert.Contains(buf.String(), "")


### PR DESCRIPTION
### Fixes [BCDA-1448](https://jira.cms.gov/browse/BCDA-1448)
RequestAccessToken is no longer being used so it can be removed from the auth interface

### Proposed changes:
- remove RequestAccessToken from alpha and alpha tests
- move RequestAccessToken functionality to MakeAccessToken for okta auth provider
- remove RequestAccessToken from auth provider interface
- remove create-token cli command

### Security Implications
MakeAccessToken is already being used by the /token endpoint so this does not change our security posture.  If anything, this PR increases security because it is removing a CLI command that allowed access tokens to be created with a clientID only

### Acceptance Validation
tests pass!

### Feedback Requested
Any is welcome