### PR TITLE
BCDA-1447 rename funcs to fit specs

### DIFF
--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -59,67 +59,67 @@ func (s *AlphaAuthPluginTestSuite) AfterTest(suiteName, testName string) {
 	}
 }
 
-func (s *AlphaAuthPluginTestSuite) TestRegisterClient() {
+func (s *AlphaAuthPluginTestSuite) TestRegisterSystem() {
 	cmsID := testUtils.RandomHexID()[0:4]
-	acoUUID, _ := models.CreateACO("TestRegisterClient", &cmsID)
-	c, err := s.p.RegisterClient(acoUUID.String())
+	acoUUID, _ := models.CreateACO("TestRegisterSystem", &cmsID)
+	c, err := s.p.RegisterSystem(acoUUID.String())
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), c)
 	assert.NotEqual(s.T(), "", c.ClientSecret)
 	assert.Equal(s.T(), acoUUID.String(), c.ClientID)
 	var aco models.ACO
 	aco.UUID = acoUUID
-	connections["TestRegisterClient"].Find(&aco, "UUID = ?", acoUUID)
+	connections["TestRegisterSystem"].Find(&aco, "UUID = ?", acoUUID)
 	assert.True(s.T(), auth.Hash(aco.AlphaSecret).IsHashOf(c.ClientSecret))
-	defer connections["TestRegisterClient"].Delete(&aco)
+	defer connections["TestRegisterSystem"].Delete(&aco)
 
-	c, err = s.p.RegisterClient(acoUUID.String())
+	c, err = s.p.RegisterSystem(acoUUID.String())
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), c.ClientID)
 	assert.Contains(s.T(), err.Error(), "has a secret")
 
-	c, err = s.p.RegisterClient("")
+	c, err = s.p.RegisterSystem("")
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), c.ClientID)
 	assert.Contains(s.T(), err.Error(), "provide a non-empty string")
 
-	c, err = s.p.RegisterClient(uuid.NewRandom().String())
+	c, err = s.p.RegisterSystem(uuid.NewRandom().String())
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), c.ClientID)
 	assert.Contains(s.T(), err.Error(), "no ACO record found")
 }
 
-func (s *AlphaAuthPluginTestSuite) TestUpdateClient() {
-	c, err := s.p.UpdateClient([]byte(`{}`))
+func (s *AlphaAuthPluginTestSuite) TestUpdateSystem() {
+	c, err := s.p.UpdateSystem([]byte(`{}`))
 	assert.Nil(s.T(), c)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *AlphaAuthPluginTestSuite) TestDeleteClient() {
+func (s *AlphaAuthPluginTestSuite) TestDeleteSystem() {
 	cmsID := testUtils.RandomHexID()[0:4]
-	acoUUID, _ := models.CreateACO("TestRegisterClient", &cmsID)
-	c, _ := s.p.RegisterClient(acoUUID.String())
+	acoUUID, _ := models.CreateACO("TestRegisterSystem", &cmsID)
+	c, _ := s.p.RegisterSystem(acoUUID.String())
 	aco, _ := auth.GetACOByClientID(c.ClientID)
 	assert.NotEmpty(s.T(), aco.ClientID)
 	assert.NotEmpty(s.T(), aco.AlphaSecret)
 
-	err := s.p.DeleteClient(c.ClientID)
+	err := s.p.DeleteSystem(c.ClientID)
 	assert.Nil(s.T(), err)
 	aco, _ = auth.GetACOByClientID(c.ClientID)
 	assert.Empty(s.T(), aco.ClientID)
 	assert.Empty(s.T(), aco.AlphaSecret)
 }
 
-func (s *AlphaAuthPluginTestSuite) TestGenerateClientCredentials() {
+func (s *AlphaAuthPluginTestSuite) TestResetSecret() {
 	validClientID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
-	c, err := s.p.GenerateClientCredentials(validClientID)
+	c, err := s.p.ResetSecret(validClientID)
 	assert.Nil(s.T(), err)
 	assert.NotEqual(s.T(), "", c.ClientSecret)
 	assert.Equal(s.T(), validClientID, c.ClientID)
 
 	invalidClientID := "IDontexist"
-	c, err = s.p.GenerateClientCredentials(invalidClientID)
+	c, err = s.p.ResetSecret(invalidClientID)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), "", c.ClientSecret)
 	assert.Equal(s.T(), "", c.ClientID)
@@ -129,14 +129,14 @@ func (s *AlphaAuthPluginTestSuite) TestAccessToken() {
 	cmsID := testUtils.RandomHexID()[0:4]
 	acoUUID, _ := models.CreateACO("TestAccessToken", &cmsID)
 	user, _ := models.CreateUser("Test Access Token", "testaccesstoken@examplecom", acoUUID)
-	cc, err := s.p.RegisterClient(acoUUID.String())
+	cc, err := s.p.RegisterSystem(acoUUID.String())
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), cc)
 	ts, err := s.p.MakeAccessToken(auth.Credentials{ClientID: cc.ClientID, ClientSecret: cc.ClientSecret})
 	assert.Nil(s.T(), err)
 	assert.NotEmpty(s.T(), ts)
 	assert.Regexp(s.T(), regexp.MustCompile(`[^.\s]+\.[^.\s]+\.[^.\s]+`), ts)
-	t, _ := s.p.DecodeJWT(ts)
+	t, _ := s.p.VerifyToken(ts)
 	c := t.Claims.(*auth.CommonClaims)
 	assert.True(s.T(), c.ExpiresAt <= time.Now().Unix()+3600)
 
@@ -207,7 +207,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 	validToken := *jwt.New(jwt.SigningMethodRS512)
 	validToken.Claims = validClaims
 	validTokenString, _ := s.backend.SignJwtToken(validToken)
-	err := s.p.ValidateJWT(validTokenString)
+	err := s.p.AuthorizeAccess(validTokenString)
 	assert.Nil(s.T(), err)
 
 	unknownAco := *jwt.New(jwt.SigningMethodRS512)
@@ -219,17 +219,17 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(999999999)).Unix(),
 	}
 	unknownAcoString, _ := s.backend.SignJwtToken(unknownAco)
-	err = s.p.ValidateJWT(unknownAcoString)
+	err = s.p.AuthorizeAccess(unknownAcoString)
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "no ACO record found")
 
 	badSigningMethod := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImlUcVhYSTB6YkFuSkNLRGFvYmZoa00xZi02ck1TcFRmeVpNUnBfMnRLSTgifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.cJOP_w-hBqnyTsBm3T6lOE5WpcHaAkLuQGAs1QO-lg2eWs8yyGW8p9WagGjxgvx7h9X72H7pXmXqej3GdlVbFmhuzj45A9SXDOAHZ7bJXwM1VidcPi7ZcrsMSCtP1hiN"
-	err = s.p.ValidateJWT(badSigningMethod)
+	err = s.p.AuthorizeAccess(badSigningMethod)
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "unexpected signing method")
 
 	wrongKey := "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.MejLezWY6hjGgbIXkq6Qbvx_-q5vWaTR6qPiNHphvla-XaZD3up1DN6Ib5AEOVtuB3fC9l-0L36noK4qQA79lhpSK3gozXO6XPIcCp4C8MU_ACzGtYe7IwGnnK3Emr6IHQE0bpGinHX1Ak1pAuwJNawaQ6Nvmz2ozZPsyxmiwoo"
-	err = s.p.ValidateJWT(wrongKey)
+	err = s.p.AuthorizeAccess(wrongKey)
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "crypto/rsa: verification error")
 
@@ -240,7 +240,7 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"id":  "d63205a8-d923-456b-a01b-0992fcb40968",
 	}
 	missingClaimsString, _ := s.backend.SignJwtToken(missingClaims)
-	err = s.p.ValidateJWT(missingClaimsString)
+	err = s.p.AuthorizeAccess(missingClaimsString)
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "missing one or more required claims")
 
@@ -253,15 +253,15 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 		"exp": time.Now().Add(time.Duration(-1) * time.Minute).Unix(),
 	}
 	expiredTokenString, _ := s.backend.SignJwtToken(expiredToken)
-	err = s.p.ValidateJWT(expiredTokenString)
+	err = s.p.AuthorizeAccess(expiredTokenString)
 	assert.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "Token is expired")
 }
 
-func (s *AlphaAuthPluginTestSuite) TestDecodeJWT() {
+func (s *AlphaAuthPluginTestSuite) TestVerifyToken() {
 	acoID := uuid.NewRandom().String()
 	ts, _ := auth.TokenStringWithIDs(uuid.NewRandom().String(), acoID)
-	t, err := s.p.DecodeJWT(ts)
+	t, err := s.p.VerifyToken(ts)
 	assert.NotNil(s.T(), t)
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), &jwt.Token{}, t)

--- a/bcda/auth/api_test.go
+++ b/bcda/auth/api_test.go
@@ -90,7 +90,7 @@ func (s *AuthAPITestSuite) TestAuthToken() {
 	// Success!?
 	s.rr = httptest.NewRecorder()
 	t := TokenResponse{}
-	creds, err := auth.GetProvider().RegisterClient(constants.DEVACOUUID)
+	creds, err := auth.GetProvider().RegisterSystem(constants.DEVACOUUID)
 	assert.Nil(s.T(), err)
 	assert.NotEmpty(s.T(), creds.ClientID)
 	assert.NotEmpty(s.T(), creds.ClientSecret)

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -37,7 +37,7 @@ func ParseToken(next http.Handler) http.Handler {
 		}
 
 		tokenString := authSubmatches[1]
-		token, err := GetProvider().DecodeJWT(tokenString)
+		token, err := GetProvider().VerifyToken(tokenString)
 		if err != nil {
 			log.Errorf("Unable to decode Authorization header value; %s", err)
 			next.ServeHTTP(w, r)
@@ -90,7 +90,7 @@ func RequireTokenAuth(next http.Handler) http.Handler {
 		}
 
 		if token, ok := token.(*jwt.Token); ok {
-			err := GetProvider().ValidateJWT(token.Raw)
+			err := GetProvider().AuthorizeAccess(token.Raw)
 			if err != nil {
 				log.Error(err)
 				respond(w, http.StatusUnauthorized)

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -94,7 +94,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthWithInvalidToken() {
 	tokenString, err := auth.TokenStringWithIDs(tokenID, acoID)
 	assert.Nil(s.T(), err)
 
-	token, err := auth.GetProvider().DecodeJWT(tokenString)
+	token, err := auth.GetProvider().VerifyToken(tokenString)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), token)
 	token.Valid = false
@@ -176,7 +176,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchWithWrongACO() {
 	tokenString, err := auth.TokenStringWithIDs(tokenID, acoID)
 	assert.Nil(s.T(), err)
 
-	token, err := auth.GetProvider().DecodeJWT(tokenString)
+	token, err := auth.GetProvider().VerifyToken(tokenString)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), token)
 
@@ -214,7 +214,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchWithRightACO() {
 	tokenString, err := auth.TokenStringWithIDs(tokenID, acoID)
 	assert.Nil(s.T(), err)
 
-	token, err := auth.GetProvider().DecodeJWT(tokenString)
+	token, err := auth.GetProvider().VerifyToken(tokenString)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), token)
 
@@ -259,7 +259,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenACOMatchInvalidToken() {
 	tokenString, err := auth.TokenStringWithIDs(tokenID, acoID)
 	assert.Nil(s.T(), err)
 
-	token, err := auth.GetProvider().DecodeJWT(tokenString)
+	token, err := auth.GetProvider().VerifyToken(tokenString)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), token)
 	token.Claims = nil

--- a/bcda/auth/models.go
+++ b/bcda/auth/models.go
@@ -65,7 +65,7 @@ func CreateAlphaToken(ttl int, acoCMSID string) (string, error) {
 		return "", err
 	}
 
-	creds, err := GetProvider().RegisterClient(aco.UUID.String())
+	creds, err := GetProvider().RegisterSystem(aco.UUID.String())
 	if err != nil {
 		return "", fmt.Errorf("could not register client for %s (%s) because %s", aco.UUID.String(), aco.Name, err.Error())
 	}
@@ -73,7 +73,7 @@ func CreateAlphaToken(ttl int, acoCMSID string) (string, error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 	// Only update aco.ClientID.  Other attributes of this ACO (AlphaSecret) may have been altered in the database by the
-	// RegisterClient() call above, so we should not save these potentially stale values.
+	// RegisterSystem() call above, so we should not save these potentially stale values.
 	err = db.Model(&aco).Update("client_id", creds.ClientID).Error
 	if err != nil {
 		return "", fmt.Errorf("could not save ClientID %s to ACO %s (%s) because %s", aco.ClientID, aco.UUID.String(), aco.Name, err.Error())

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -38,7 +38,7 @@ func NewOktaAuthPlugin(backend OktaBackend) OktaAuthPlugin {
 	return OktaAuthPlugin{backend}
 }
 
-func (o OktaAuthPlugin) RegisterClient(localID string) (Credentials, error) {
+func (o OktaAuthPlugin) RegisterSystem(localID string) (Credentials, error) {
 	if localID == "" {
 		return Credentials{}, errors.New("you must provide a localID")
 	}
@@ -52,15 +52,15 @@ func (o OktaAuthPlugin) RegisterClient(localID string) (Credentials, error) {
 	}, err
 }
 
-func (o OktaAuthPlugin) UpdateClient(params []byte) ([]byte, error) {
+func (o OktaAuthPlugin) UpdateSystem(params []byte) ([]byte, error) {
 	return nil, errors.New("not yet implemented")
 }
 
-func (o OktaAuthPlugin) DeleteClient(clientID string) error {
+func (o OktaAuthPlugin) DeleteSystem(clientID string) error {
 	return errors.New("not yet implemented")
 }
 
-func (o OktaAuthPlugin) GenerateClientCredentials(clientID string) (Credentials, error) {
+func (o OktaAuthPlugin) ResetSecret(clientID string) (Credentials, error) {
 	clientSecret, err := o.backend.GenerateNewClientSecret(clientID)
 	if err != nil {
 		return Credentials{}, err
@@ -74,7 +74,7 @@ func (o OktaAuthPlugin) GenerateClientCredentials(clientID string) (Credentials,
 	return c, nil
 }
 
-func (o OktaAuthPlugin) RevokeClientCredentials(clientID string) error {
+func (o OktaAuthPlugin) RevokeSystemCredentials(clientID string) error {
 	err := o.backend.DeactivateApplication(clientID)
 	if err != nil {
 		return err
@@ -117,8 +117,8 @@ func (o OktaAuthPlugin) RevokeAccessToken(tokenString string) error {
 	return errors.New("not yet implemented")
 }
 
-func (o OktaAuthPlugin) ValidateJWT(tokenString string) error {
-	t, err := o.DecodeJWT(tokenString)
+func (o OktaAuthPlugin) AuthorizeAccess(tokenString string) error {
+	t, err := o.VerifyToken(tokenString)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (o OktaAuthPlugin) ValidateJWT(tokenString string) error {
 	return nil
 }
 
-func (o OktaAuthPlugin) DecodeJWT(tokenString string) (*jwt.Token, error) {
+func (o OktaAuthPlugin) VerifyToken(tokenString string) (*jwt.Token, error) {
 	keyFinder := func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -50,37 +50,37 @@ func (s *OktaAuthPluginTestSuite) SetupTest() {
 	s.o = NewOktaAuthPlugin(s.m)
 }
 
-func (s *OktaAuthPluginTestSuite) TestOktaRegisterClient() {
-	c, err := s.o.RegisterClient(KnownFixtureACO)
+func (s *OktaAuthPluginTestSuite) TestOktaRegisterSystem() {
+	c, err := s.o.RegisterSystem(KnownFixtureACO)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), c)
 	assert.Regexp(s.T(), regexp.MustCompile("[!-~]+"), c.ClientID)
 }
 
-func (s *OktaAuthPluginTestSuite) TestOktaUpdateClient() {
-	c, err := s.o.UpdateClient([]byte("{}"))
+func (s *OktaAuthPluginTestSuite) TestOktaUpdateSystem() {
+	c, err := s.o.UpdateSystem([]byte("{}"))
 	assert.Nil(s.T(), c)
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestOktaDeleteClient() {
-	err := s.o.DeleteClient("")
+func (s *OktaAuthPluginTestSuite) TestOktaDeleteSystem() {
+	err := s.o.DeleteSystem("")
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestGenerateClientCredentials() {
+func (s *OktaAuthPluginTestSuite) TestResetSecret() {
 	validClientID := "0oaj4590j9B5uh8rC0h7"
-	c, err := s.o.GenerateClientCredentials(validClientID)
+	c, err := s.o.ResetSecret(validClientID)
 	assert.Nil(s.T(), err)
 	assert.NotEqual(s.T(), "", c.ClientSecret)
 
 	invalidClientID := "IDontexist"
-	c, err = s.o.GenerateClientCredentials(invalidClientID)
+	c, err = s.o.ResetSecret(invalidClientID)
 	assert.Equal(s.T(), "404 Not Found", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestRevokeClientCredentials() {
-	err := s.o.RevokeClientCredentials("fakeClientID")
+func (s *OktaAuthPluginTestSuite) TestRevokeSystemCredentials() {
+	err := s.o.RevokeSystemCredentials("fakeClientID")
 	assert.Nil(s.T(), err)
 }
 
@@ -105,37 +105,37 @@ func (s *OktaAuthPluginTestSuite) TestOktaRevokeAccessToken() {
 	assert.Equal(s.T(), "not yet implemented", err.Error())
 }
 
-func (s *OktaAuthPluginTestSuite) TestValidateJWT() {
+func (s *OktaAuthPluginTestSuite) TestAuthorizeAccess() {
 	// happy path
 	token, err := s.m.NewToken(KnownClientID)
 	require.Nil(s.T(), err)
-	err = s.o.ValidateJWT(token)
+	err = s.o.AuthorizeAccess(token)
 	require.Nil(s.T(), err)
 
 	// a variety of unhappy paths
 	token, err = s.m.NewCustomToken(OktaToken{ClientID: randomClientID()})
 	require.Nil(s.T(), err)
-	err = s.o.ValidateJWT(token)
+	err = s.o.AuthorizeAccess(token)
 	require.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "invalid cid")
 
 	token, err = s.m.NewCustomToken(OktaToken{ClientID: KnownClientID, Issuer: "not_our_okta_server"})
 	require.Nil(s.T(), err)
-	err = s.o.ValidateJWT(token)
+	err = s.o.AuthorizeAccess(token)
 	require.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "invalid iss")
 
 	token, err = s.m.NewCustomToken(OktaToken{ClientID: KnownClientID, ExpiresIn: -1})
 	require.Nil(s.T(), err)
-	err = s.o.ValidateJWT(token)
+	err = s.o.AuthorizeAccess(token)
 	require.NotNil(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "expired")
 }
 
-func (s *OktaAuthPluginTestSuite) TestOktaDecodeJWT() {
+func (s *OktaAuthPluginTestSuite) TestOktaVerifyToken() {
 	token, err := s.m.NewToken(KnownClientID)
 	require.Nil(s.T(), err, "could not create token")
-	t, err := s.o.DecodeJWT(token)
+	t, err := s.o.VerifyToken(token)
 	assert.IsType(s.T(), &jwt.Token{}, t)
 	require.Nil(s.T(), err, "no error should have occurred")
 	assert.True(s.T(), t.Valid)

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -67,20 +67,20 @@ type Credentials struct {
 
 // Provider defines operations performed through an authentication provider.
 type Provider interface {
-	// RegisterClient adds a software client for the ACO identified by localID.
-	RegisterClient(localID string) (Credentials, error)
+	// RegisterSystem adds a software client for the ACO identified by localID.
+	RegisterSystem(localID string) (Credentials, error)
 
-	// UpdateClient changes data associated with the registered software client identified by clientID
-	UpdateClient(params []byte) ([]byte, error)
+	// UpdateSystem changes data associated with the registered software client identified by clientID
+	UpdateSystem(params []byte) ([]byte, error)
 
-	// DeleteClient deletes the registered software client identified by clientID, revoking an active tokens
-	DeleteClient(clientID string) error
+	// DeleteSystem deletes the registered software client identified by clientID, revoking an active tokens
+	DeleteSystem(clientID string) error
 
-	// GenerateClientCredentials new or replace existing Credentials for the given clientID
-	GenerateClientCredentials(clientID string) (Credentials, error)
+	// ResetSecret new or replace existing Credentials for the given clientID
+	ResetSecret(clientID string) (Credentials, error)
 
-	// RevokeClientCredentials any existing Credentials for the given clientID
-	RevokeClientCredentials(clientID string) error
+	// RevokeSystemCredentials any existing Credentials for the given clientID
+	RevokeSystemCredentials(clientID string) error
 
 	// MakeAccessToken mints an access token for the given credentials
 	MakeAccessToken(credentials Credentials) (string, error)
@@ -91,9 +91,9 @@ type Provider interface {
 	// RevokeAccessToken a specific access token identified in a base64 encoded token string
 	RevokeAccessToken(tokenString string) error
 
-	// ValidateJWT asserts that a base64 encoded token string is valid for accessing the BCDA API
-	ValidateJWT(tokenString string) error
+	// AuthorizeAccess asserts that a base64 encoded token string is valid for accessing the BCDA API
+	AuthorizeAccess(tokenString string) error
 
-	// DecodeJWT decodes a base64 encoded token string into a structured token
-	DecodeJWT(tokenString string) (*jwt.Token, error)
+	// VerifyToken decodes a base64 encoded token string into a structured token
+	VerifyToken(tokenString string) (*jwt.Token, error)
 }

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -312,14 +312,14 @@ func setUpApp() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 
-				// Get ACO by CMS ID (since GenerateClientCredentials interface expects a Client ID)
+				// Get ACO by CMS ID (since ResetSecret interface expects a Client ID)
 				aco, err := auth.GetACOByCMSID(acoCMSID)
 				if err != nil {
 					return err
 				}
 
 				// Generate new credentials
-				creds, err := auth.GetProvider().GenerateClientCredentials(aco.ClientID)
+				creds, err := auth.GetProvider().ResetSecret(aco.ClientID)
 				if err != nil {
 					return err
 				}

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -299,7 +299,7 @@ func (s *CLITestSuite) TestSavePublicKeyCLI() {
 	assert.Contains(buf.String(), "Public key saved for ACO")
 }
 
-func (s *CLITestSuite) TestGenerateClientCredentialsCLI() {
+func (s *CLITestSuite) TestResetSecretCLI() {
 
 	// set up the test app writer (to redirect CLI responses from stdout to a byte buffer)
 	buf := new(bytes.Buffer)

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -236,7 +236,7 @@ func RegisterSystem(clientID string, clientName string, clientURI string, groupI
 
 	creds := auth.Credentials{}
 
-	regEvent := Event{Op: "RegisterClient", TrackingID: clientID}
+	regEvent := Event{Op: "RegisterSystem", TrackingID: clientID}
 	OperationStarted(regEvent)
 
 	if clientID == "" {


### PR DESCRIPTION
### Fixes [BCDA-1447](https://jira.cms.gov/browse/BCDA-1447)
Since specs have changed over time, some function names do not accurately represent what the functions do.  This PR renames those functions

### Proposed changes:
- rename functions that have outdated names

### Security Implications
no security implications on this one.  just some simple renaming

### Acceptance Validation
tests still pass!

### Feedback Requested
is there anything else that should be renamed while I'm here?