### PR TITLE
BCDA-1505: Create create-system endpoint

### DIFF
--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -58,11 +58,11 @@ type AuthData struct {
 }
 
 type Credentials struct {
-	UserID       string
-	ClientID     string
-	ClientSecret string
-	Token        Token
-	ClientName   string
+	UserID       string `json:"user_id"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Token        Token  `json:"token"`
+	ClientName   string `json:"client_name"`
 }
 
 // Provider defines operations performed through an authentication provider.

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -58,11 +58,11 @@ type AuthData struct {
 }
 
 type Credentials struct {
-	UserID       string `json:"user_id"`
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	Token        Token  `json:"token"`
-	ClientName   string `json:"client_name"`
+	UserID       string
+	ClientID     string
+	ClientSecret string
+	Token        Token
+	ClientName   string
 }
 
 // Provider defines operations performed through an authentication provider.

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -9,11 +9,11 @@ import (
 
 func createSystem(w http.ResponseWriter, r *http.Request) {
 	type system struct {
-		GroupID    string `json:"group_id"`
-		ClientID   string `json:"client_id"`
 		ClientName string `json:"client_name"`
+		GroupID    string `json:"group_id"`
 		Scope      string `json:"scope"`
 		PublicKey  string `json:"public_key"`
+		TrackingID string `json:"tracking_id"`
 	}
 
 	sys := system{}
@@ -22,7 +22,7 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.ClientID)
+	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.TrackingID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusBadRequest)
 		return

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -22,6 +22,7 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ssas.OperationCalled(ssas.Event{Op: "RegisterClient", TrackingID: sys.TrackingID, Help: "calling from admin.createSystem()"})
 	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.TrackingID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusBadRequest)
@@ -36,5 +37,8 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	fmt.Fprint(w, string(credsJSON))
+	_, err = w.Write(credsJSON)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
 }

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -1,0 +1,41 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/CMSgov/bcda-app/ssas"
+	"net/http"
+)
+
+func createSystem(w http.ResponseWriter, r *http.Request) {
+	type system struct {
+		GroupID    string `json:"group_id"`
+		ClientID   string `json:"client_id"`
+		ClientName string `json:"client_name"`
+		ClientURI  string `json:"client_uri"`
+		Scope      string `json:"scope"`
+		PublicKey  string `json:"public_key"`
+	}
+
+	sys := system{}
+	if err := json.NewDecoder(r.Body).Decode(&sys); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	creds, err := ssas.RegisterSystem(sys.ClientID, sys.ClientName, sys.ClientURI, sys.GroupID, sys.Scope, sys.PublicKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	credsJSON, err := json.Marshal(creds)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprint(w, string(credsJSON))
+}

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -24,13 +24,13 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 
 	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.ClientID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusBadRequest)
 		return
 	}
 
 	credsJSON, err := json.Marshal(creds)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusInternalServerError)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
 		return
 	}
 

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -12,18 +12,17 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 		GroupID    string `json:"group_id"`
 		ClientID   string `json:"client_id"`
 		ClientName string `json:"client_name"`
-		ClientURI  string `json:"client_uri"`
 		Scope      string `json:"scope"`
 		PublicKey  string `json:"public_key"`
 	}
 
 	sys := system{}
 	if err := json.NewDecoder(r.Body).Decode(&sys); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		http.Error(w, "Could not create system due to invalid request body", http.StatusBadRequest)
 		return
 	}
 
-	creds, err := ssas.RegisterSystem(sys.ClientID, sys.ClientName, sys.ClientURI, sys.GroupID, sys.Scope, sys.PublicKey)
+	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.ClientID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusInternalServerError)
 		return

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -28,7 +28,10 @@ func (s *APITestSuite) TearDownSuite() {
 
 func (s *APITestSuite) TestCreateSystem() {
 	group := ssas.Group{GroupID: "T00000"}
-	s.db.Save(&group)
+	err := s.db.Save(&group).Error
+	if err != nil {
+		s.FailNow("Error creating test data", err.Error())
+	}
 
 	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_id": "a1b2c3", "client_name": "Test Client", "client_uri": "", "scope": "bcda-api", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
 	handler := http.HandlerFunc(createSystem)
@@ -39,10 +42,12 @@ func (s *APITestSuite) TestCreateSystem() {
 	var result map[string]interface{}
 	_ = json.Unmarshal(rr.Body.Bytes(), &result)
 	assert.NotNil(s.T(), result["user_id"])
-	assert.Equal(s.T(), "a1b2c3", result["client_id"])
+	assert.NotEmpty(s.T(), result["client_id"])
 	assert.NotEmpty(s.T(), result["client_secret"])
 	assert.NotNil(s.T(), result["token"])
 	assert.Equal(s.T(), "Test Client", result["client_name"])
+
+	_ = ssas.CleanDatabase(group)
 }
 
 func (s *APITestSuite) TestCreateSystem_InvalidRequest() {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -33,7 +33,7 @@ func (s *APITestSuite) TestCreateSystem() {
 		s.FailNow("Error creating test data", err.Error())
 	}
 
-	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_id": "a1b2c3", "client_name": "Test Client", "client_uri": "", "scope": "bcda-api", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_name": "Test Client", "scope": "bcda-api", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -55,6 +55,17 @@ func (s *APITestSuite) TestCreateSystem_InvalidRequest() {
 	s.db.Save(&group)
 
 	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader("{ badJSON }"))
+	handler := http.HandlerFunc(createSystem)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
+}
+
+func (s *APITestSuite) TestCreateSystem_MissingRequiredParam() {
+	group := ssas.Group{GroupID: "T00000"}
+	s.db.Save(&group)
+
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00001", "client_name": "Test Client 1", "scope": "bcda-api"}`))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -27,13 +27,13 @@ func (s *APITestSuite) TearDownSuite() {
 }
 
 func (s *APITestSuite) TestCreateSystem() {
-	group := ssas.Group{GroupID: "T00000"}
+	group := ssas.Group{GroupID: "test-group-id"}
 	err := s.db.Save(&group).Error
 	if err != nil {
 		s.FailNow("Error creating test data", err.Error())
 	}
 
-	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_name": "Test Client", "scope": "bcda-api", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"client_name": "Test Client", "group_id": "test-group-id", "scope": "bcda-api", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----", "tracking_id": "T00000"}`))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -51,9 +51,6 @@ func (s *APITestSuite) TestCreateSystem() {
 }
 
 func (s *APITestSuite) TestCreateSystem_InvalidRequest() {
-	group := ssas.Group{GroupID: "T00000"}
-	s.db.Save(&group)
-
 	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader("{ badJSON }"))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()
@@ -62,9 +59,6 @@ func (s *APITestSuite) TestCreateSystem_InvalidRequest() {
 }
 
 func (s *APITestSuite) TestCreateSystem_MissingRequiredParam() {
-	group := ssas.Group{GroupID: "T00000"}
-	s.db.Save(&group)
-
 	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00001", "client_name": "Test Client 1", "scope": "bcda-api"}`))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"encoding/json"
-	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/ssas"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
@@ -19,11 +18,11 @@ type APITestSuite struct {
 }
 
 func (s *APITestSuite) SetupSuite() {
-	s.db = database.GetGORMDbConnection()
+	s.db = ssas.GetGORMDbConnection()
 }
 
 func (s *APITestSuite) TearDownSuite() {
-	database.Close(s.db)
+	ssas.Close(s.db)
 }
 
 func (s *APITestSuite) TestCreateSystem() {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -30,7 +30,7 @@ func (s *APITestSuite) TestCreateSystem() {
 	group := ssas.Group{GroupID: "T00000"}
 	s.db.Save(&group)
 
-	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_id": "a1b2c3", "client_name": "Test Client", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_id": "a1b2c3", "client_name": "Test Client", "client_uri": "", "scope": "bcda-api", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -38,7 +38,22 @@ func (s *APITestSuite) TestCreateSystem() {
 	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
 	var result map[string]interface{}
 	_ = json.Unmarshal(rr.Body.Bytes(), &result)
+	assert.NotNil(s.T(), result["user_id"])
 	assert.Equal(s.T(), "a1b2c3", result["client_id"])
+	assert.NotEmpty(s.T(), result["client_secret"])
+	assert.NotNil(s.T(), result["token"])
+	assert.Equal(s.T(), "Test Client", result["client_name"])
+}
+
+func (s *APITestSuite) TestCreateSystem_InvalidRequest() {
+	group := ssas.Group{GroupID: "T00000"}
+	s.db.Save(&group)
+
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader("{ badJSON }"))
+	handler := http.HandlerFunc(createSystem)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
 }
 
 func TestAPITestSuite(t *testing.T) {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -1,0 +1,46 @@
+package admin
+
+import (
+	"encoding/json"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/ssas"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type APITestSuite struct {
+	suite.Suite
+	db *gorm.DB
+}
+
+func (s *APITestSuite) SetupSuite() {
+	s.db = database.GetGORMDbConnection()
+}
+
+func (s *APITestSuite) TearDownSuite() {
+	database.Close(s.db)
+}
+
+func (s *APITestSuite) TestCreateSystem() {
+	group := ssas.Group{GroupID: "T00000"}
+	s.db.Save(&group)
+
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"group_id": "T00000", "client_id": "a1b2c3", "client_name": "Test Client", "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\nHwIDAQAB\n-----END PUBLIC KEY-----"}`))
+	handler := http.HandlerFunc(createSystem)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusCreated, rr.Result().StatusCode)
+	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
+	var result map[string]interface{}
+	_ = json.Unmarshal(rr.Body.Bytes(), &result)
+	assert.Equal(s.T(), "a1b2c3", result["client_id"])
+}
+
+func TestAPITestSuite(t *testing.T) {
+	suite.Run(t, new(APITestSuite))
+}

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -1,16 +1,13 @@
 package admin
 
 import (
-	"net/http"
-
-	"github.com/CMSgov/bcda-app/bcda/monitoring"
 	"github.com/go-chi/chi"
+	"net/http"
 )
 
 func NewRouter(middlewares ...func(http.Handler) http.Handler) http.Handler {
 	r := chi.NewRouter()
-	m := monitoring.GetMonitor()
 	r.Use(middlewares...)
-	r.Post(m.WrapHandler("/system", createSystem))
+	r.Post("/system", createSystem)
 	return r
 }

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -11,6 +11,6 @@ func NewRouter(middlewares ...func(http.Handler) http.Handler) http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
 	r.Use(middlewares...)
-	r.Post(m.WrapHandler("/auth/system", createSystem))
+	r.Post(m.WrapHandler("/system", createSystem))
 	return r
 }

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -1,0 +1,16 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/CMSgov/bcda-app/bcda/monitoring"
+	"github.com/go-chi/chi"
+)
+
+func NewRouter(middlewares ...func(http.Handler) http.Handler) http.Handler {
+	r := chi.NewRouter()
+	m := monitoring.GetMonitor()
+	r.Use(middlewares...)
+	r.Post(m.WrapHandler("/auth/system", createSystem))
+	return r
+}

--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -1,0 +1,30 @@
+package admin
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type RouterTestSuite struct {
+	suite.Suite
+	router  http.Handler
+}
+
+func (s *RouterTestSuite) SetupTest() {
+	s.router = NewRouter()
+}
+
+func (s *RouterTestSuite) TestPostSystemRoute() {
+	req := httptest.NewRequest("POST", "/system", nil)
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	res := rr.Result()
+	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
+}
+
+func TestRouterTestSuite(t *testing.T) {
+	suite.Run(t, new(RouterTestSuite))
+}

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -260,12 +260,12 @@ func (system *System) GenerateSystemKeyPair() (string, error) {
 }
 
 type Credentials struct {
-	UserID       string
-	ClientID     string
-	ClientSecret string
-	TokenString  string
-	ClientName   string
-	ExpiresAt    time.Time
+	UserID       string    `json:"user_id"`
+	ClientID     string    `json:"client_id"`
+	ClientSecret string    `json:"client_secret"`
+	TokenString  string    `json:"token"`
+	ClientName   string    `json:"client_name"`
+	ExpiresAt    time.Time `json:"expires_at"`
 }
 
 /*


### PR DESCRIPTION
### Fixes [BCDA-1505](https://jira.cms.gov/browse/BCDA-1505)
The SSAS should include a way for either an SGA (e.g., ACO-MS) or a resource server (e.g., bcda) to add systems to the auth service and get credentials. An SGA might use this endpoint to add a system after creating a group. The resource server might use this endpoint for creating systems for integration tests.

### Proposed changes:
Add an endpoint that creates a system and returns credentials.

### Change Details
* Sets up `/ssas/service/admin` directory with:
  * api.go
  * api_test.go
  * router.go
  * router_test.go
* Creates SSAS admin router with `POST /system` path
* Creates handler function for `POST /system` in api.go, parsing request body and calling `RegisterSystem()`
* Some changes copied from another pull request, https://github.com/CMSgov/bcda-app/pull/311, so that should be merged first

### Security Implications
This adds an API endpoint for SGAs and resource servers to create systems in the auth service, which returns credentials including a client ID and secret.

### Acceptance Validation
Tests have been added for route (router_test.go) and handler function (api_test.go).

### Feedback Requested
Any
