### PR TITLE
Move needed tooling code into SSAS; removed bcda dependencies

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,6 +32,9 @@ services:
       - AUTH_HASH_ITERATIONS=130000
       - AUTH_HASH_KEY_LENGTH=64
       - AUTH_HASH_SALT_SIZE=32
+      - SSAS_HASH_ITERATIONS=130000
+      - SSAS_HASH_KEY_LENGTH=64
+      - SSAS_HASH_SALT_SIZE=32
       - CCLF_IMPORT_STATUS_RECORDS_INTERVAL=10
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,9 +114,9 @@ services:
       - OKTA_CLIENT_TOKEN=${OKTA_CLIENT_TOKEN}
       - BCDA_AUTH_PROVIDER=${BCDA_AUTH_PROVIDER}
       - OKTA_OAUTH_SERVER_ID=${OKTA_OAUTH_SERVER_ID}
-      - AUTH_HASH_ITERATIONS=130000
-      - AUTH_HASH_KEY_LENGTH=64
-      - AUTH_HASH_SALT_SIZE=32
+      - SSAS_HASH_ITERATIONS=130000
+      - SSAS_HASH_KEY_LENGTH=64
+      - SSAS_HASH_SALT_SIZE=32
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     ports:

--- a/ssas/README.md
+++ b/ssas/README.md
@@ -4,30 +4,28 @@ The SSAS can be run as a standalone web service or embedded as a library.
 
 # Code Organization
 
-The service package contains a standalone http service that encapsulates the authorization library. The service also exposes a CLI for useful tasks.
+The service package contains a standalone http service that encapsulates the authorization library.
 
-Imports always go up the directory tree from leaves; that is, go files in the top-level ssas package never import from other packages in this tree. Furthermore, the ssas package and packages in plugins must not import from packages in the service directory. 
+Imports always go up the directory tree from leaves; that is, parents do not import from their children. Children may import from their siblings. In order to maintain the service and library distinction, the ssas package and packages in plugins must not import from packages in the service directory. 
 
 The outline below shows physical the directory structure of the code, with package names highlighted. The service and plugins directories are used for organization, but are not packages themselves. The main package is located in the service directory. Currently, the go files listed are the intended locations of code that will be migrated from bcda auth when an in-progress refactor is completed. The go files currently in place are placeholders that served to set up the code tree and illustrate the intended relationship between the service (main.go) and the ssas. 
 
 Not shown: _test files for every .go file are assumed to be present parallel to their test subject.
 
 - **ssas**
+    - **cfg**
+      - envv.go
+      - _configuration management; nothing in cfg should import from ssas packages_
     - _service_
-      - **cli**
-        - credentials.go
-          - reset-system-secret()
-          - revoke-credentials()
-        - group.go
-          - upsert-group()
-        - system.go
-          - create-system()
-        - token.go
-          - revoke-token()
-      - **api**
+      - **admin**
         - api.go
         - middleware.go
         - router.go
+      - **public**
+        - api.go
+        - middleware.go
+        - router.go
+      - **server**
       - main.go
     - _plugins_
       - **alpha**
@@ -41,20 +39,30 @@ Not shown: _test files for every .go file are assumed to be present parallel to 
     - provider.go
     - logger.go
     - credentials.go
-      - data model and functions related to credentials
+      - _data model and functions related to credentials_
     - groups.go
-      - data model and functions related to groups
+      - _data model and functions related to groups_
     - systems.go
-      - data model and functions related to systems
+      - _data model and functions related to systems_
     - tokentools.go
-      - functions related to tokens; should perhaps be renamed tokens
+      - _functions related to tokens; should perhaps be renamed tokens_
+      
+# Configuration
+
+Required values must be present in the docker-compose.*.yml files.
+
+| Key                  | Required | Purpose | 
+| -------------------- |:--------:| ------- |
+| SSAS_HASH_ITERATIONS | Yes      | Controls how many iterations our secure hashing mechanism performs. Service will panic if this key does not have a value. |
+| SSAS_HASH_KEY_LENGTH | Yes      | Controls the key length used by our secure hashing mechanism. Service will panic if this key does not have a value. |
+| SSAS_HASH_SALT_SIZE  | Yes      | Controls salt size used by our secure hashing mechanism performs. Service will panic if this key does not have a value. |
 
 # Build
 
 Build the code with `make docker-bootstrap`. Alternatively, `docker-compose up ssas` will build and run the SSAS by itself.
 
-      
-
 # Test
 
 The SSAS can be tested by running `make test` or `make unit-test`.
+
+# Goland IDE

--- a/ssas/cfg/envv.go
+++ b/ssas/cfg/envv.go
@@ -1,0 +1,30 @@
+package cfg
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+// FromEnv always returns a string that is either a non-empty value from the environment variable named by key or
+// the string otherwise
+func FromEnv(key, otherwise string) string {
+	s := os.Getenv(key)
+	if s == "" {
+		logrus.Infof(`No %s value; using %s instead.`, key, otherwise)
+		return otherwise
+	}
+	return s
+}
+
+func GetEnvInt(varName string, defaultVal int) int {
+	v := os.Getenv(varName)
+	if v != "" {
+		i, err := strconv.Atoi(v)
+		if err == nil {
+			return i
+		}
+	}
+	return defaultVal
+}

--- a/ssas/connection.go
+++ b/ssas/connection.go
@@ -1,0 +1,48 @@
+package ssas
+
+import (
+	"database/sql"
+	"log"
+	"os"
+	"runtime"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+	_ "github.com/lib/pq"
+)
+
+// Variable substitution to support testing.
+var LogFatal = log.Fatal
+
+func GetDbConnection() *sql.DB {
+	databaseURL := os.Getenv("DATABASE_URL")
+	db, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		LogFatal(err)
+	}
+	pingErr := db.Ping()
+	if pingErr != nil {
+		LogFatal(pingErr)
+	}
+	return db
+}
+
+func GetGORMDbConnection() *gorm.DB {
+	databaseURL := os.Getenv("DATABASE_URL")
+	db, err := gorm.Open("postgres", databaseURL)
+	if err != nil {
+		LogFatal(err)
+	}
+	pingErr := db.DB().Ping()
+	if pingErr != nil {
+		LogFatal(pingErr)
+	}
+	return db
+}
+
+func Close(db *gorm.DB) {
+	if err := db.Close(); err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		Logger.Infof("failed to close db connection at %s#%d because %s", file, line, err)
+	}
+}

--- a/ssas/connection_test.go
+++ b/ssas/connection_test.go
@@ -1,0 +1,66 @@
+package ssas
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConnectionTestSuite struct {
+	suite.Suite
+	db     *sql.DB
+	gormdb *gorm.DB
+}
+
+func (suite *ConnectionTestSuite) TestDbConnections() {
+
+	// after this test, replace the original log.Fatal() function
+	origLogFatal := LogFatal
+	defer func() { LogFatal = origLogFatal }()
+
+	// create the mock version of log.Fatal()
+	LogFatal = func(args ...interface{}) {
+		fmt.Println("FATAL (NO-OP)")
+	}
+
+	// get the real database URL
+	actualDatabaseURL := os.Getenv("DATABASE_URL")
+
+	// set the database URL to a bogus value to test negative scenarios
+	os.Setenv("DATABASE_URL", "fake_db_url")
+
+	// attempt to open DB connection swith the bogus DB string
+	suite.db = GetDbConnection()
+	suite.gormdb = GetGORMDbConnection()
+
+	// asert that Ping returns an error
+	assert.NotNil(suite.T(), suite.db.Ping(), fmt.Sprint("Database should fail to connect (negative scenario)"))
+	assert.NotNil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Gorm database should fail to connect (negative scenario)"))
+
+	// close DBs to reset the test
+	suite.db.Close()
+	suite.gormdb.Close()
+
+	// set the database URL back to the real value to test the positive scenarios
+	os.Setenv("DATABASE_URL", actualDatabaseURL)
+
+	suite.db = GetDbConnection()
+	defer suite.db.Close()
+
+	suite.gormdb = GetGORMDbConnection()
+	defer suite.gormdb.Close()
+
+	// assert that Ping() does not return an error
+	assert.Nil(suite.T(), suite.db.Ping(), fmt.Sprint("Error connecting to sql database"))
+	assert.Nil(suite.T(), suite.gormdb.DB().Ping(), fmt.Sprint("Error connecting to gorm database "))
+
+}
+
+func TestConnectionTestSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionTestSuite))
+}

--- a/ssas/credentials.go
+++ b/ssas/credentials.go
@@ -1,9 +1,0 @@
-package ssas
-
-type Credentials struct {
-	UserID       string
-	ClientID     string
-	ClientSecret string
-	TokenString	 string
-	ClientName   string
-}

--- a/ssas/credentials.go
+++ b/ssas/credentials.go
@@ -1,0 +1,9 @@
+package ssas
+
+type Credentials struct {
+	UserID       string
+	ClientID     string
+	ClientSecret string
+	TokenString	 string
+	ClientName   string
+}

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -1,16 +1,16 @@
 package ssas
 
 import (
-	"github.com/CMSgov/bcda-app/bcda/database"
+	"log"
+
 	"github.com/jinzhu/gorm"
 	"github.com/jinzhu/gorm/dialects/postgres"
-	"log"
 )
 
 func InitializeGroupModels() *gorm.DB {
 	log.Println("Initialize group models")
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	db.AutoMigrate(
 		&Group{},

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -2,11 +2,11 @@ package ssas
 
 import (
 	"encoding/json"
-	"github.com/CMSgov/bcda-app/bcda/database"
+	"testing"
+
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type GroupsTestSuite struct {
@@ -15,12 +15,12 @@ type GroupsTestSuite struct {
 }
 
 func (s *GroupsTestSuite) SetupSuite() {
-	s.db = database.GetGORMDbConnection()
+	s.db = GetGORMDbConnection()
 	InitializeGroupModels()
 }
 
 func (s *GroupsTestSuite) TearDownSuite() {
-	database.Close(s.db)
+	Close(s.db)
 }
 
 func (s *GroupsTestSuite) AfterTest() {
@@ -72,8 +72,8 @@ groupBytes := []byte(`{
 group := Group{}
 err := json.Unmarshal(groupBytes, &group)
 assert.Nil(s.T(), err)
-db := database.GetGORMDbConnection()
-defer database.Close(db)
+db := GetGORMDbConnection()
+defer Close(db)
 err = db.Save(&group).Error
 assert.Nil(s.T(), err)
 db.Unscoped().Delete(&group)

--- a/ssas/hash.go
+++ b/ssas/hash.go
@@ -1,0 +1,87 @@
+package ssas
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/CMSgov/bcda-app/ssas/cfg"
+)
+
+var (
+	hashIter int
+	hashKeyLen int
+	saltSize int
+)
+
+// Hash is a cryptographically hashed string
+type Hash string
+
+// The time for hash comparison should be about 1s.  Increase hashIter if this is significantly faster in production.
+// Note that changing hashIter or hashKeyLen will result in invalidating existing stored hashes (e.g. credentials).
+func init() {
+	hashIter = cfg.GetEnvInt("SSAS_HASH_ITERATIONS", 0)
+	hashKeyLen = cfg.GetEnvInt("SSAS_HASH_KEY_LENGTH", 0)
+	saltSize = cfg.GetEnvInt("SSAS_HASH_SALT_SIZE", 0)
+
+	if hashIter == 0 || hashKeyLen == 0 || saltSize == 0 {
+		// ServiceHalted(Event{Help:"SSAS_HASH_ITERATIONS, SSAS_HASH_KEY_LENGTH and SSAS_HASH_SALT_SIZE environment values must be set"})
+		panic("SSAS_HASH_ITERATIONS, SSAS_HASH_KEY_LENGTH and SSAS_HASH_SALT_SIZE environment values must be set")
+	}
+}
+
+// NewHash creates a Hash value from a source string
+// The HashValue consists of the salt and hash separated by a colon ( : )
+// If the source of randomness fails it returns an error.
+func NewHash(source string) (Hash, error) {
+	if source == "" {
+		return Hash(""), errors.New("empty string provided to hash function")
+	}
+
+	salt := make([]byte, saltSize)
+	_, err := rand.Read(salt)
+	if err != nil {
+		return Hash(""), err
+	}
+
+	start := time.Now()
+	h := pbkdf2.Key([]byte(source), salt, hashIter, hashKeyLen, sha512.New)
+	hashCreationTime := time.Since(start)
+	hashEvent := Event{Elapsed: hashCreationTime}
+	SecureHashTime(hashEvent)
+
+	return Hash(fmt.Sprintf("%s:%s", base64.StdEncoding.EncodeToString(salt), base64.StdEncoding.EncodeToString(h))), nil
+}
+
+// IsHashOf accepts an unhashed string, which it first hashes and then compares to itself
+func (h Hash) IsHashOf(source string) bool {
+	// Avoid comparing with an empty source so that a hash of an empty string is never successful
+	if source == "" {
+		return false
+	}
+
+	hashAndPass := strings.Split(h.String(), ":")
+	if len(hashAndPass) != 2 {
+		return false
+	}
+
+	hash := hashAndPass[1]
+	salt, err := base64.StdEncoding.DecodeString(hashAndPass[0])
+	if err != nil {
+		return false
+	}
+
+	sourceHash := pbkdf2.Key([]byte(source), salt, hashIter, hashKeyLen, sha512.New)
+	return hash == base64.StdEncoding.EncodeToString(sourceHash)
+}
+
+func (h Hash) String() string {
+	return string(h)
+}
+

--- a/ssas/logger.go
+++ b/ssas/logger.go
@@ -7,8 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TODO: Remove auth.logger
-var logger *logrus.Logger
+var Logger *logrus.Logger
 
 type Event struct {
 	ClientID   string
@@ -22,27 +21,27 @@ type Event struct {
 // maybe we should just use plain standard logging and pass in json. We don't use the level
 // designation to tune logging in non-local envs, so is logrus complexity worth it?
 func init() {
-	logger = logrus.New()
-	logger.Formatter = &logrus.JSONFormatter{}
-	logger.Formatter.(*logrus.JSONFormatter).TimestampFormat = time.RFC3339Nano
+	Logger = logrus.New()
+	Logger.Formatter = &logrus.JSONFormatter{}
+	Logger.Formatter.(*logrus.JSONFormatter).TimestampFormat = time.RFC3339Nano
 
-	filePath, success := os.LookupEnv("AUTH_LOG")
+	filePath, success := os.LookupEnv("SSAS_LOG")
 	if success {
 		/* #nosec -- 0640 permissions required for Splunk ingestion */
 		file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
 
 		if err == nil {
-			logger.SetOutput(file)
+			Logger.SetOutput(file)
 		} else {
-			logger.Info("Failed to open Auth log file; using default stderr")
+			Logger.Info("Failed to open SSAS log file; using default stderr")
 		}
 	} else {
-		logger.Info("No Auth log location provided; using default stderr")
+		Logger.Info("No SSAS log location provided; using default stderr")
 	}
 }
 
 func mergeNonEmpty(data Event) *logrus.Entry {
-	var entry = logrus.NewEntry(logger)
+	var entry = logrus.NewEntry(Logger)
 
 	if data.ClientID != "" {
 		entry = entry.WithField("clientID", data.ClientID)

--- a/ssas/logger_test.go
+++ b/ssas/logger_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOperationLogging(t*testing.T){
-	testLogger := test.NewLocal(logger)
+	testLogger := test.NewLocal(Logger)
 	OperationStarted(Event{Op: "TestOperation", Help: "A little more to the right"})
 
 	assert.Equal(t, 1, len(testLogger.Entries))

--- a/ssas/rsakeys.go
+++ b/ssas/rsakeys.go
@@ -1,0 +1,95 @@
+package ssas
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+const RSAKEYMINBITS = 2048
+
+func ReadPublicKey (publicKey string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(publicKey))
+	if block == nil {
+		return nil, fmt.Errorf("not able to decode PEM-formatted public key")
+	}
+
+	publicKeyImported, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse public key: %s", err.Error())
+	}
+
+	rsaPub, ok := publicKeyImported.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not able to cast key as *rsa.PublicKey")
+	}
+
+	if rsaPub.Size() < RSAKEYMINBITS / 8 {
+		return nil, fmt.Errorf("insecure key length (%d bytes)", rsaPub.Size())
+	}
+
+	return rsaPub, nil
+}
+
+// Modified from source at: https://play.golang.org/p/mLpOxS-5Fy
+func ConvertJWKToPEM(jwks string) (string, error) {
+	j := map[string]string{}
+	err := json.Unmarshal([]byte(jwks), &j)
+	if err != nil {
+		return "", errors.New("unable to parse JSON for jwk: " + err.Error())
+	}
+
+	if j["kty"] != "RSA" {
+		return "", errors.New("invalid key type: " + j["kty"] + "; only 'RSA' accepted")
+	}
+
+	if j["use"] != "" && j["use"] != "enc" {
+		return "", errors.New("invalid use type: " + j["use"] + "; only 'enc' accepted")
+	}
+
+	nb, err := base64.RawURLEncoding.DecodeString(j["n"])
+	if err != nil {
+		return "", errors.New("base64 error in key n value: " + err.Error())
+	}
+	nv := new(big.Int).SetBytes(nb)
+
+	eb, err := base64.RawURLEncoding.DecodeString(j["e"])
+	if err != nil {
+		return "", errors.New("base64 error in key exponent: " + err.Error())
+	}
+
+	bigE := new(big.Int).SetBytes(eb)
+	if !bigE.IsInt64() {
+		return "", errors.New("key exponent too large: " + bigE.String())
+	}
+	ev := int(bigE.Int64())
+
+	pk := &rsa.PublicKey{
+		N: nv,
+		E: ev,
+	}
+
+	der, err := x509.MarshalPKIXPublicKey(pk)
+	if err != nil {
+		return "", errors.New("unable to marshal public key: " + err.Error())
+	}
+
+	block := &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: der,
+	}
+
+	var out bytes.Buffer
+	err = pem.Encode(&out, block)
+	if err != nil {
+		return "", errors.New("unable to encode key in PEM format: " + err.Error())
+	}
+
+	return out.String(), nil
+}

--- a/ssas/rsakeys.go
+++ b/ssas/rsakeys.go
@@ -14,6 +14,8 @@ import (
 
 const RSAKEYMINBITS = 2048
 
+// ReadPublicKey reads a string containing a PEM-formatted public key and returns a pointer to an rsa.PublicKey type
+// or an error. The key must have a length of at least 2048 bits, and it must be an rsa key.
 func ReadPublicKey (publicKey string) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode([]byte(publicKey))
 	if block == nil {
@@ -37,6 +39,7 @@ func ReadPublicKey (publicKey string) (*rsa.PublicKey, error) {
 	return rsaPub, nil
 }
 
+// ConvertJWKToPEM extracts the (hopefully single) public key contained in a jwks.
 // Modified from source at: https://play.golang.org/p/mLpOxS-5Fy
 func ConvertJWKToPEM(jwks string) (string, error) {
 	j := map[string]string{}

--- a/ssas/rsakeys_test.go
+++ b/ssas/rsakeys_test.go
@@ -1,0 +1,64 @@
+package ssas
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type KeyToolsTestSuite struct {
+	suite.Suite
+}
+
+func (s *KeyToolsTestSuite) SetupSuite() {
+}
+
+func (s *KeyToolsTestSuite) TearDownSuite() {
+}
+
+func (s *KeyToolsTestSuite) AfterTest() {
+}
+
+func (s *KeyToolsTestSuite) TestConvertJWKToPEMValid() {
+	var jwk1 = `{"alg":"RS256","e":"AQAB","n":"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw","kid":"wyMwK4A6CL9Qw11uofVeyQ119XyX-xykymkkXygZ5OM","kty":"RSA","use":"enc"}`
+	var jwk2 = `{"e":"AAEAAQ","n":"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw","kty":"RSA"}`
+
+	pem1, err := ConvertJWKToPEM(jwk1)
+	assert.Nil(s.T(), err)
+	assert.NotEmpty(s.T(), pem1)
+	pub1, err := ReadPublicKey(pem1)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), pub1)
+
+	pem2, err := ConvertJWKToPEM(jwk2)
+	assert.Nil(s.T(), err)
+	assert.NotEmpty(s.T(), pem2)
+	pub2, err := ReadPublicKey(pem2)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), pub2)
+}
+
+func (s *KeyToolsTestSuite) TestConvertJWKToPEMInvalid() {
+	jwkForSig := `{"alg":"RS256","e":"AQAB","n":"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw","kty":"RSA","use":"sig"}`
+	jwkECKeyType := `{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","use":"enc","kid":"1"}`
+	jwkCorruptKey := `{"alg":"RS256","e":"AQAB","n":"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbW","kty":"RSA","use":"enc"}`
+
+	pem1, err := ConvertJWKToPEM(jwkForSig)
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "use type")
+	assert.Empty(s.T(), pem1)
+
+	pem2, err := ConvertJWKToPEM(jwkECKeyType)
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "key type")
+	assert.Empty(s.T(), pem2)
+
+	pem3, err := ConvertJWKToPEM(jwkCorruptKey)
+	assert.NotNil(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "error in key n value")
+	assert.Empty(s.T(), pem3)
+}
+
+func TestKeyToolsTestSuite(t *testing.T) {
+	suite.Run(t, new(KeyToolsTestSuite))
+}

--- a/ssas/service/main.go
+++ b/ssas/service/main.go
@@ -1,38 +1,12 @@
 package main
 
 import (
-	"os"
-	"time"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/CMSgov/bcda-app/ssas"
 )
 
-var logger *logrus.Logger
-
-func init() {
-	logger = logrus.New()
-	logger.Formatter = &logrus.JSONFormatter{}
-	logger.Formatter.(*logrus.JSONFormatter).TimestampFormat = time.RFC3339Nano
-	filePath, success := os.LookupEnv("SSAS_LOG_FILE")
-	if success {
-		/* #nosec -- 0640 permissions required for Splunk ingestion */
-		file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
-
-		if err == nil {
-			logger.SetOutput(file)
-		} else {
-			logger.Info("Failed to open SSAS log file; using default stderr")
-		}
-	} else {
-		logger.Info("No SSAS log location provided; using default stderr")
-	}
-}
-
 func main() {
-	logger.Info("Future home of the System-to-System Authentication Service")
-	logger.Infof("SSAS gave me %s", ssas.Provide())
+	ssas.Logger.Info("Future home of the System-to-System Authentication Service")
+	ssas.Logger.Infof("SSAS gave me %s", ssas.Provide())
 }
 
 func hello() string {

--- a/ssas/service/main_test.go
+++ b/ssas/service/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/CMSgov/bcda-app/ssas"
 )
 
 func TestHello(t *testing.T) {
@@ -14,7 +16,7 @@ func TestHello(t *testing.T) {
 
 func TestSSASMain(t *testing.T) {
 	var str bytes.Buffer
-	logger.SetOutput(&str)
+	ssas.Logger.SetOutput(&str)
 	main()
 	s := str.String()
 	if !strings.Contains(s, "Future home of") {

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -218,6 +218,14 @@ func (system *System) GenerateSystemKeyPair() (string, error) {
 	return string(privateKeyBytes), nil
 }
 
+type Credentials struct {
+	UserID       string
+	ClientID     string
+	ClientSecret string
+	TokenString	 string
+	ClientName   string
+}
+
 func RegisterSystem(clientID string, clientName string, clientURI string, groupID string, scope string, publicKeyPEM string) (Credentials, error) {
 	db := GetGORMDbConnection()
 	defer Close(db)
@@ -350,7 +358,6 @@ func GetSystemByClientID(clientID string) (System, error) {
 	return system, err
 }
 
-// TODO: put this as a public function in the new plugin or in backend.go
 func GenerateSecret() (string, error) {
 	b := make([]byte, 40)
 	_, err := rand.Read(b)

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -7,22 +7,20 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/auth/rsautils"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/jinzhu/gorm"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/url"
+
+	"github.com/jinzhu/gorm"
 )
 
 const DEFAULT_SCOPE = "bcda-api"
 
 func InitializeSystemModels() *gorm.DB {
 	log.Println("Initialize system models")
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	db.AutoMigrate(
 		&System{},
@@ -64,8 +62,8 @@ type Secret struct {
 }
 
 func (system *System) SaveSecret(hashedSecret string) error {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	secret := Secret{
 		Hash:     hashedSecret,
@@ -86,8 +84,8 @@ func (system *System) SaveSecret(hashedSecret string) error {
 }
 
 func (system *System) GetSecret() (string, error) {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	secret := Secret{}
 
@@ -104,8 +102,8 @@ func (system *System) GetSecret() (string, error) {
 }
 
 func (system *System) GetPublicKey() (*rsa.PublicKey, error) {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	var encryptionKey EncryptionKey
 	err := db.Where("system_id = ?", system.ID).Find(&encryptionKey).Error
@@ -113,19 +111,19 @@ func (system *System) GetPublicKey() (*rsa.PublicKey, error) {
 		return nil, fmt.Errorf("cannot find public key for clientID %s: %s", system.ClientID, err.Error())
 	}
 
-	return rsautils.ReadPublicKey(encryptionKey.Body)
+	return ReadPublicKey(encryptionKey.Body)
 }
 
 func (system *System) SavePublicKey(publicKey io.Reader) error {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	k, err := ioutil.ReadAll(publicKey)
 	if err != nil {
 		return fmt.Errorf("cannot read public key for clientID %s: %s", system.ClientID, err.Error())
 	}
 
-	key, err := rsautils.ReadPublicKey(string(k))
+	key, err := ReadPublicKey(string(k))
 	if err != nil {
 		return fmt.Errorf("invalid public key for clientID %s: %s", system.ClientID, err.Error())
 	}
@@ -155,8 +153,8 @@ func (system *System) SavePublicKey(publicKey io.Reader) error {
 // RevokeSystemKeyPair soft deletes the active encryption key
 // for the specified system so that it can no longer be used
 func (system *System) RevokeSystemKeyPair() error {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	var encryptionKey EncryptionKey
 
@@ -177,8 +175,8 @@ func (system *System) RevokeSystemKeyPair() error {
  GenerateSystemKeyPair creates a keypair for a system. The public key is saved to the database and the private key is returned.
 */
 func (system *System) GenerateSystemKeyPair() (string, error) {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	var key EncryptionKey
 	if !db.Where("system_id = ?", system.ID).Find(&key).RecordNotFound() {
@@ -220,9 +218,9 @@ func (system *System) GenerateSystemKeyPair() (string, error) {
 	return string(privateKeyBytes), nil
 }
 
-func RegisterSystem(clientID string, clientName string, clientURI string, groupID string, scope string, publicKeyPEM string) (auth.Credentials, error) {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+func RegisterSystem(clientID string, clientName string, clientURI string, groupID string, scope string, publicKeyPEM string) (Credentials, error) {
+	db := GetGORMDbConnection()
+	defer Close(db)
 
 	// A system is not valid without an active public key and a hashed secret.  However, they are stored separately in the
 	// encryption_keys and secrets tables, requiring multiple INSERT statement.  To ensure we do not get into an invalid state,
@@ -234,7 +232,7 @@ func RegisterSystem(clientID string, clientName string, clientURI string, groupI
 		}
 	}()
 
-	creds := auth.Credentials{}
+	creds := Credentials{}
 
 	regEvent := Event{Op: "RegisterSystem", TrackingID: clientID}
 	OperationStarted(regEvent)
@@ -265,7 +263,7 @@ func RegisterSystem(clientID string, clientName string, clientURI string, groupI
 		return creds, errors.New(regEvent.Help)
 	}
 
-	_, err := rsautils.ReadPublicKey(publicKeyPEM)
+	_, err := ReadPublicKey(publicKeyPEM)
 	if err != nil {
 		regEvent.Help = "error in public key: " + err.Error()
 		OperationFailed(regEvent)
@@ -304,7 +302,7 @@ func RegisterSystem(clientID string, clientName string, clientURI string, groupI
 		return creds, errors.New(regEvent.Help)
 	}
 
-	hashedSecret, err := auth.NewHash(clientSecret)
+	hashedSecret, err := NewHash(clientSecret)
 	if err != nil {
 		regEvent.Help = fmt.Sprintf("cannot generate hash of secret for clientID %s: %s", system.ClientID, err.Error())
 		OperationFailed(regEvent)
@@ -340,11 +338,11 @@ func RegisterSystem(clientID string, clientName string, clientURI string, groupI
 
 func GetSystemByClientID(clientID string) (System, error) {
 	var (
-		db = database.GetGORMDbConnection()
+		db = GetGORMDbConnection()
 		system System
 		err error
 	)
-	defer database.Close(db)
+	defer Close(db)
 
 	if db.Find(&system, "client_id = ?", clientID).RecordNotFound() {
 		err = errors.New("no System record found for " + clientID)

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -8,13 +8,12 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/auth"
-	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/jinzhu/gorm"
-	"github.com/pborman/uuid"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/jinzhu/gorm"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -24,13 +23,13 @@ type SystemsTestSuite struct {
 }
 
 func (s *SystemsTestSuite) SetupSuite() {
-	s.db = database.GetGORMDbConnection()
+	s.db = GetGORMDbConnection()
 	InitializeGroupModels()
 	InitializeSystemModels()
 }
 
 func (s *SystemsTestSuite) TearDownSuite() {
-	database.Close(s.db)
+	Close(s.db)
 }
 
 func (s *SystemsTestSuite) AfterTest() {
@@ -447,7 +446,7 @@ func (s *SystemsTestSuite) TestSaveSecret() {
 	if err != nil {
 		s.FailNow("cannot generate random secret")
 	}
-	hashedSecret1, err := auth.NewHash(secret1)
+	hashedSecret1, err := NewHash(secret1)
 	if err != nil {
 		s.FailNow("cannot hash random secret")
 	}
@@ -462,7 +461,7 @@ func (s *SystemsTestSuite) TestSaveSecret() {
 	if err != nil {
 		s.FailNow("cannot generate random secret")
 	}
-	hashedSecret2, err := auth.NewHash(secret2)
+	hashedSecret2, err := NewHash(secret2)
 	if err != nil {
 		s.FailNow("cannot hash random secret")
 	}
@@ -477,7 +476,7 @@ func (s *SystemsTestSuite) TestSaveSecret() {
 	if err != nil {
 		s.FailNow(err.Error())
 	}
-	assert.True(auth.Hash(savedHash).IsHashOf(secret2))
+	assert.True(Hash(savedHash).IsHashOf(secret2))
 
 	err = s.cleanDatabase(group)
 	assert.Nil(err)


### PR DESCRIPTION
### Fixes [BCDA-1450](https://jira.cms.gov/browse/BCDA-1450)

To maintain SSAS as a standalone code base, it needs to have its own implementations of tooling that currently exists in bcda. This PR brings over much of that needed tooling.

### Proposed changes:
Uses of code in these bcda packages needed to be addressed:
- bcda/database
- bcda/auth/Hash
- bcda/auth/rsautils
- bcda/utils
- auth/Credentials

### Change Details
- the functions formerly provided in the database package are now part of the ssas package, and are implemented in connections.go
- the Hash struct and its functions are now part of the ssas package, and are implemented in hash.go
- the functions formerly provided in the rsautils package are now part of the ssas package, and are implemented in rsakeys.go
- the functions formerly provided in the utils package are now part of the cfg package, and are implemented in envv.go
- the Credentials struct is now in the ssas package, hanging out all by itself in credentials.go.

### Security Implications
None, given that this PR moves code that has already been reviewed from one code tree to another. The most significant code is the Hash structure, which has been thoroughly reviewed and was the subject of a SIA.

### Acceptance Validation
All tests run and pass.

### Feedback Requested
Consider these specific changes:
- moved connections.go into ssas instead of keeping it in a database package. I think it's too specific to our use and too small to justify a separate package.
- similarly, Hash, Credentials and rsautils are all in the ssas package. Perhaps credentials belongs in systems.go
- established a cfg package for configuration-related code, because I think this code will grow.

