### PR TITLE
BCDA-1487 Feature: Returns an "un-nested" resource property in our ndjson responses.

### DIFF
--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -315,24 +315,25 @@ func fhirBundleToResourceNDJSON(w *bufio.Writer, jsonData, jsonType, beneficiary
 		appendErrorToFile(fileUUID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error unmarshaling %s resources from data for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
 		return
 	}
-
 	entries := jsonOBJ["entry"]
 
 	// There might be no entries.  If this happens we can't iterate over them.
 	if entries != nil {
-
 		for _, entry := range entries.([]interface{}) {
-			entryJSON, err := json.Marshal(entry)
-			// This is unlikely to happen because we just unmarshalled this data a few lines above.
-			if err != nil {
-				log.Error(err)
-				appendErrorToFile(fileUUID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error marshaling %s to JSON for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
-				continue
-			}
-			_, err = w.WriteString(string(entryJSON) + "\n")
-			if err != nil {
-				log.Error(err)
-				appendErrorToFile(fileUUID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error writing %s to file for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
+			entrymap := entry.(map[string]interface{})
+			if len(entrymap) != 0 {
+				entryJSON, err := json.Marshal(entrymap["resource"])
+				// This is unlikely to happen because we just unmarshalled this data a few lines above.
+				if err != nil {
+					log.Error(err)
+					appendErrorToFile(fileUUID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error marshaling %s to JSON for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
+					continue
+				}
+				_, err = w.WriteString(string(entryJSON) + "\n")
+				if err != nil {
+					log.Error(err)
+					appendErrorToFile(fileUUID, responseutils.Exception, responseutils.InternalErr, fmt.Sprintf("Error writing %s to file for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
+				}
 			}
 		}
 	}

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -104,6 +104,8 @@ func TestWriteEOBDataToFile(t *testing.T) {
 			var jsonOBJ map[string]interface{}
 			err := json.Unmarshal(scanner.Bytes(), &jsonOBJ)
 			assert.Nil(t, err)
+			assert.NotNil(t, jsonOBJ["status"], "JSON should contain a value for `status`.")
+			assert.NotNil(t, jsonOBJ["type"], "JSON should contain a value for `type`.")
 		}
 		assert.False(t, scanner.Scan(), "There should be only 66 entries in the file.")
 

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -104,8 +104,6 @@ func TestWriteEOBDataToFile(t *testing.T) {
 			var jsonOBJ map[string]interface{}
 			err := json.Unmarshal(scanner.Bytes(), &jsonOBJ)
 			assert.Nil(t, err)
-			assert.NotNil(t, jsonOBJ["fullUrl"], "JSON should contain a value for `fullUrl`.")
-			assert.NotNil(t, jsonOBJ["resource"], "JSON should contain a value for `resource`.")
 		}
 		assert.False(t, scanner.Scan(), "There should be only 66 entries in the file.")
 


### PR DESCRIPTION
Fixes [BCDA-1487](https://jira.cms.gov/browse/BCDA-1487)

Problem:
Prior to this change, our ndjson responses were returning values from an entries array as key value pairs of a resource map. We now just return the value portion of the resource map, as opposed to each individual entry.

Proposed changes:
Instead of returning each entry from our json object, we now return each resource value of that entry.

Change Details:
bcdaworker/main.go - grabs the resource value from the resource map.
bcdaworker/main_test.go - removes the "fullUrl" and "resource" strings from our tests. These are no longer included with the new way we drill down into the data. see here: http://hl7.org/fhir/STU3/bundle.html

Security Implications:
No, this change does not deal with any PII/PHI.

Acceptance Validation:
Yes all tests pass.

Screenshot:
Before: 
<img width="1210" alt="before" src="https://user-images.githubusercontent.com/42976557/60840193-f17d4680-a19c-11e9-9a5b-5082e2080bda.png">
After: 
<img width="1108" alt="after" src="https://user-images.githubusercontent.com/42976557/60840202-f8a45480-a19c-11e9-8c99-049215168e79.png">

Feedback Requested:
Any and all