### PR TITLE
BCDA-1144 add post group endpoint to admin routes

### DIFF
--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/CMSgov/bcda-app/ssas"
-
 	"github.com/jinzhu/gorm"
 	"github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -33,12 +31,12 @@ type Group struct {
 
 func CreateGroup(gd GroupData) (Group, error) {
 	event := Event{Op: "CreateGroup", TrackingID: gd.ID}
-	ssas.OperationStarted(event)
+	OperationStarted(event)
 
 	gdBytes, err := json.Marshal(gd)
 	if err != nil {
 		event.Help = err
-		ssas.OperationFailed(event)
+		OperationFailed(event)
 		return Group{}, err
 	}
 
@@ -52,11 +50,11 @@ func CreateGroup(gd GroupData) (Group, error) {
 	err = db.Save(&g).Error
 	if err != nil {
 		event.Help = err
-		ssas.OperationFailed(event)
+		OperationFailed(event)
 		return Group{}, err
 	}
 
-	ssas.OperationSucceeded(event)
+	OperationSucceeded(event)
 	return g, nil
 }
 

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -1,6 +1,7 @@
 package ssas
 
 import (
+	"encoding/json"
 	"log"
 
 	"github.com/jinzhu/gorm"
@@ -25,7 +26,29 @@ type Group struct {
 	Data    postgres.Jsonb `json:"data"`
 }
 
+func CreateGroup(gd GroupData) (Group, error) {
+	gdBytes, err := json.Marshal(gd)
+	if err != nil {
+		return Group{}, err
+	}
+
+	g := Group{
+		GroupID: gd.ID,
+		Data:    postgres.Jsonb{RawMessage: gdBytes},
+	}
+
+	db := GetGORMDbConnection()
+	defer Close(db)
+	err = db.Save(&g).Error
+	if err != nil {
+		return Group{}, err
+	}
+
+	return g, nil
+}
+
 type GroupData struct {
+	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	Users     []string   `json:"users"`
 	Scopes    []string   `json:"scopes"`

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -10,7 +10,7 @@ import (
 
 /*
 	InitializeGroupModels will call gorm.DB.AutoMigrate() for Group{}
- */
+*/
 func InitializeGroupModels() *gorm.DB {
 	log.Println("Initialize group models")
 	db := GetGORMDbConnection()
@@ -55,7 +55,7 @@ type GroupData struct {
 	Name      string     `json:"name"`
 	Users     []string   `json:"users"`
 	Scopes    []string   `json:"scopes"`
-	Systems   []System   `gorm:"foreignkey:GroupID;association_foreignkey:GroupID" json:"systems"`
+	System    System     `gorm:"foreignkey:GroupID;association_foreignkey:GroupID" json:"system"`
 	Resources []Resource `json:"resources"`
 }
 

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -2,6 +2,7 @@ package ssas
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/jinzhu/gorm"
@@ -33,9 +34,16 @@ func CreateGroup(gd GroupData) (Group, error) {
 	event := Event{Op: "CreateGroup", TrackingID: gd.ID}
 	OperationStarted(event)
 
+	if gd.ID == "" {
+		err := fmt.Errorf("group_id cannot be blank")
+		event.Help = err.Error()
+		OperationFailed(event)
+		return Group{}, err
+	}
+
 	gdBytes, err := json.Marshal(gd)
 	if err != nil {
-		event.Help = err
+		event.Help = err.Error()
 		OperationFailed(event)
 		return Group{}, err
 	}
@@ -49,7 +57,7 @@ func CreateGroup(gd GroupData) (Group, error) {
 	defer Close(db)
 	err = db.Save(&g).Error
 	if err != nil {
-		event.Help = err
+		event.Help = err.Error()
 		OperationFailed(event)
 		return Group{}, err
 	}

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -72,9 +72,8 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	assert.Nil(s.T(), err)
 	_ = CleanDatabase(g)
 	gd.ID = ""
-	g, err = CreateGroup(gd)
+	_, err = CreateGroup(gd)
 	assert.EqualError(s.T(), err, "group_id cannot be blank")
-	_ = CleanDatabase(g)
 }
 
 func TestGroupsTestSuite(t *testing.T) {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -54,6 +54,7 @@ type GroupsTestSuite struct {
 func (s *GroupsTestSuite) SetupSuite() {
 	s.db = GetGORMDbConnection()
 	InitializeGroupModels()
+	InitializeSystemModels()
 }
 
 func (s *GroupsTestSuite) TearDownSuite() {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -42,7 +42,7 @@ const SampleGroup string = `{
 		{  
 		"client_id":"4tuhiOIFIwriIOH3zn",
 		"software_id":"4NRB1-0XZABZI9E6-5SM3R",
-		"client_name":"ACO System A",
+		"client_name":"ACO System A"
 		}
 }`
 
@@ -70,7 +70,11 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	assert.Nil(s.T(), err)
 	g, err := CreateGroup(gd)
 	assert.Nil(s.T(), err)
-	s.db.Unscoped().Delete(&g)
+	CleanDatabase(g)
+	gd.ID = ""
+	g, err = CreateGroup(gd)
+	assert.EqualError(s.T(), err, "group_id cannot be blank")
+	CleanDatabase(g)
 }
 
 func TestGroupsTestSuite(t *testing.T) {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -9,6 +9,43 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const SampleGroup string = `{  
+	"id":"A12345",
+	"name":"ACO Corp Systems",
+	"users":[  
+		"00uiqolo7fEFSfif70h7",
+		"l0vckYyfyow4TZ0zOKek",
+		"HqtEi2khroEZkH4sdIzj"
+	],
+	"scopes":[  
+		"user-admin",
+		"system-admin"
+	],
+	"resources":[  
+		{  
+			"id":"xxx",
+			"name":"BCDA API",
+			"scopes":[  
+				"bcda-api"
+			]
+		},
+		{  
+			"id":"eft",
+			"name":"EFT CCLF",
+			"scopes":[  
+				"eft-app:download",
+				"eft-data:read"
+			]
+		}
+	],
+	"system":
+		{  
+		"client_id":"4tuhiOIFIwriIOH3zn",
+		"software_id":"4NRB1-0XZABZI9E6-5SM3R",
+		"client_name":"ACO System A",
+		}
+}`
+
 type GroupsTestSuite struct {
 	suite.Suite
 	db *gorm.DB
@@ -27,44 +64,7 @@ func (s *GroupsTestSuite) AfterTest() {
 }
 
 func (s *GroupsTestSuite) TestCreateGroup() {
-	groupBytes := []byte(`{
-		"id":"A12345",
-		"name":"ACO Corp Systems",
-		"users":[  
-			"00uiqolo7fEFSfif70h7",
-			"l0vckYyfyow4TZ0zOKek",
-			"HqtEi2khroEZkH4sdIzj"
-		],
-		"scopes":[  
-			"user-admin",
-			"system-admin"
-		],
-		"resources":[  
-			{  
-				"id":"xxx",
-				"name":"BCDA API",
-				"scopes":[  
-					"bcda-api"
-				]
-			},
-			{  
-				"id":"eft",
-				"name":"EFT CCLF",
-				"scopes":[  
-					"eft-app:download",
-					"eft-data:read"
-				]
-			}
-		],
-		"system":
-			{  
-				"client_id":"4tuhiOIFIwriIOH3zn",
-				"software_id":"4NRB1-0XZABZI9E6-5SM3R",
-				"client_name":"ACO System A",
-				"client_uri":"https://www.acocorpsite.com"
-			}
-	}`)
-
+	groupBytes := []byte(SampleGroup)
 	gd := GroupData{}
 	err := json.Unmarshal(groupBytes, &gd)
 	assert.Nil(s.T(), err)

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -70,11 +70,11 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	assert.Nil(s.T(), err)
 	g, err := CreateGroup(gd)
 	assert.Nil(s.T(), err)
-	CleanDatabase(g)
+	_ = CleanDatabase(g)
 	gd.ID = ""
 	g, err = CreateGroup(gd)
 	assert.EqualError(s.T(), err, "group_id cannot be blank")
-	CleanDatabase(g)
+	_ = CleanDatabase(g)
 }
 
 func TestGroupsTestSuite(t *testing.T) {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -26,57 +26,52 @@ func (s *GroupsTestSuite) TearDownSuite() {
 func (s *GroupsTestSuite) AfterTest() {
 }
 
-
-func (s *GroupsTestSuite) TestGroupModel() {
-groupBytes := []byte(`{  
-		"group_id":"A12345",
-		"data":{  
-			"name":"ACO Corp Systems",
-			"users":[  
-				"00uiqolo7fEFSfif70h7",
-				"l0vckYyfyow4TZ0zOKek",
-				"HqtEi2khroEZkH4sdIzj"
-			],
-			"scopes":[  
-				"user-admin",
-				"system-admin"
-			],
-			"resources":[  
-				{  
-					"id":"xxx",
-					"name":"BCDA API",
-					"scopes":[  
-						"bcda-api"
-					]
-				},
-				{  
-					"id":"eft",
-					"name":"EFT CCLF",
-					"scopes":[  
-						"eft-app:download",
-						"eft-data:read"
-					]
-				}
-			],
-			"systems":[  
-				{  
-					"client_id":"4tuhiOIFIwriIOH3zn",
-					"software_id":"4NRB1-0XZABZI9E6-5SM3R",
-					"client_name":"ACO System A",
-					"client_uri":"https://www.acocorpsite.com"
-				}
-			]
-		}
+func (s *GroupsTestSuite) TestCreateGroup() {
+	groupBytes := []byte(`{
+		"id":"A12345",
+		"name":"ACO Corp Systems",
+		"users":[  
+			"00uiqolo7fEFSfif70h7",
+			"l0vckYyfyow4TZ0zOKek",
+			"HqtEi2khroEZkH4sdIzj"
+		],
+		"scopes":[  
+			"user-admin",
+			"system-admin"
+		],
+		"resources":[  
+			{  
+				"id":"xxx",
+				"name":"BCDA API",
+				"scopes":[  
+					"bcda-api"
+				]
+			},
+			{  
+				"id":"eft",
+				"name":"EFT CCLF",
+				"scopes":[  
+					"eft-app:download",
+					"eft-data:read"
+				]
+			}
+		],
+		"systems":[  
+			{  
+				"client_id":"4tuhiOIFIwriIOH3zn",
+				"software_id":"4NRB1-0XZABZI9E6-5SM3R",
+				"client_name":"ACO System A",
+				"client_uri":"https://www.acocorpsite.com"
+			}
+		]
 	}`)
 
-group := Group{}
-err := json.Unmarshal(groupBytes, &group)
-assert.Nil(s.T(), err)
-db := GetGORMDbConnection()
-defer Close(db)
-err = db.Save(&group).Error
-assert.Nil(s.T(), err)
-db.Unscoped().Delete(&group)
+	gd := GroupData{}
+	err := json.Unmarshal(groupBytes, &gd)
+	assert.Nil(s.T(), err)
+	g, err := CreateGroup(gd)
+	assert.Nil(s.T(), err)
+	s.db.Unscoped().Delete(&g)
 }
 
 func TestGroupsTestSuite(t *testing.T) {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -56,14 +56,13 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 				]
 			}
 		],
-		"systems":[  
+		"system":
 			{  
 				"client_id":"4tuhiOIFIwriIOH3zn",
 				"software_id":"4NRB1-0XZABZI9E6-5SM3R",
 				"client_name":"ACO System A",
 				"client_uri":"https://www.acocorpsite.com"
 			}
-		]
 	}`)
 
 	gd := GroupData{}

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -16,6 +16,7 @@ func createGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ssas.OperationCalled(ssas.Event{Op: "CreateGroup", TrackingID: gd.ID, Help: "calling from admin.createGroup()"})
 	g, err := ssas.CreateGroup(gd)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to create group. Error: %s", err), http.StatusBadRequest)

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -1,0 +1,34 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/CMSgov/bcda-app/ssas"
+)
+
+func createGroup(w http.ResponseWriter, r *http.Request) {
+	gd := ssas.GroupData{}
+	err := json.NewDecoder(r.Body).Decode(&gd)
+	if err != nil {
+		http.Error(w, "Failed to create group due to invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	g, err := ssas.CreateGroup(gd)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create group. Error: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	groupJSON, err := json.Marshal(g)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprint(w, string(groupJSON))
+}

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -42,14 +42,13 @@ const sampleGroup = `{
 			]
 		}
 	],
-	"systems":[  
+	"system":
 		{  
-			"client_id":"4tuhiOIFIwriIOH3zn",
-			"software_id":"4NRB1-0XZABZI9E6-5SM3R",
-			"client_name":"ACO System A",
-			"client_uri":"https://www.acocorpsite.com"
+		"client_id":"4tuhiOIFIwriIOH3zn",
+		"software_id":"4NRB1-0XZABZI9E6-5SM3R",
+		"client_name":"ACO System A",
+		"client_uri":"https://www.acocorpsite.com"
 		}
-	]
 }`
 
 type APITestSuite struct {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -1,0 +1,86 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/CMSgov/bcda-app/ssas"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const sampleGroup = `{  
+	"id":"A12345",
+	"name":"ACO Corp Systems",
+	"users":[  
+		"00uiqolo7fEFSfif70h7",
+		"l0vckYyfyow4TZ0zOKek",
+		"HqtEi2khroEZkH4sdIzj"
+	],
+	"scopes":[  
+		"user-admin",
+		"system-admin"
+	],
+	"resources":[  
+		{  
+			"id":"xxx",
+			"name":"BCDA API",
+			"scopes":[  
+				"bcda-api"
+			]
+		},
+		{  
+			"id":"eft",
+			"name":"EFT CCLF",
+			"scopes":[  
+				"eft-app:download",
+				"eft-data:read"
+			]
+		}
+	],
+	"systems":[  
+		{  
+			"client_id":"4tuhiOIFIwriIOH3zn",
+			"software_id":"4NRB1-0XZABZI9E6-5SM3R",
+			"client_name":"ACO System A",
+			"client_uri":"https://www.acocorpsite.com"
+		}
+	]
+}`
+
+type APITestSuite struct {
+	suite.Suite
+	db *gorm.DB
+}
+
+func (s *APITestSuite) SetupSuite() {
+	s.db = ssas.GetGORMDbConnection()
+}
+
+func (s *APITestSuite) TearDownSuite() {
+	ssas.Close(s.db)
+}
+
+func (s *APITestSuite) TestCreateGroup() {
+	req := httptest.NewRequest("POST", "/group", strings.NewReader(sampleGroup))
+	handler := http.HandlerFunc(createGroup)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusCreated, rr.Result().StatusCode)
+	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
+}
+
+func (s *APITestSuite) TestCreateSystem_InvalidRequest() {
+	req := httptest.NewRequest("POST", "/group", strings.NewReader("{badJSON}"))
+	handler := http.HandlerFunc(createGroup)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
+}
+
+func TestAPITestSuite(t *testing.T) {
+	suite.Run(t, new(APITestSuite))
+}

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -46,7 +46,7 @@ const SampleGroup string = `{
 		{  
 		"client_id":"4tuhiOIFIwriIOH3zn",
 		"software_id":"4NRB1-0XZABZI9E6-5SM3R",
-		"client_name":"ACO System A",
+		"client_name":"ACO System A"
 		}
 }`
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -70,6 +70,9 @@ func (s *APITestSuite) TestCreateGroup() {
 	handler.ServeHTTP(rr, req)
 	assert.Equal(s.T(), http.StatusCreated, rr.Result().StatusCode)
 	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
+	g := ssas.Group{}
+	s.db.Last(&g)
+	ssas.CleanDatabase(g)
 }
 
 func (s *APITestSuite) TestCreateSystem() {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -72,7 +72,7 @@ func (s *APITestSuite) TestCreateGroup() {
 	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
 	g := ssas.Group{}
 	s.db.Last(&g)
-	ssas.CleanDatabase(g)
+	_ = ssas.CleanDatabase(g)
 }
 
 func (s *APITestSuite) TestCreateSystem() {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -71,7 +71,7 @@ func (s *APITestSuite) TestCreateGroup() {
 	assert.Equal(s.T(), http.StatusCreated, rr.Result().StatusCode)
 	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
 	g := ssas.Group{}
-	s.db.Last(&g)
+	s.db.Where("group_id = ?", "A12345").Find(&g)
 	_ = ssas.CleanDatabase(g)
 }
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const sampleGroup = `{  
+const SampleGroup string = `{  
 	"id":"A12345",
 	"name":"ACO Corp Systems",
 	"users":[  
@@ -47,7 +47,6 @@ const sampleGroup = `{
 		"client_id":"4tuhiOIFIwriIOH3zn",
 		"software_id":"4NRB1-0XZABZI9E6-5SM3R",
 		"client_name":"ACO System A",
-		"client_uri":"https://www.acocorpsite.com"
 		}
 }`
 
@@ -65,7 +64,7 @@ func (s *APITestSuite) TearDownSuite() {
 }
 
 func (s *APITestSuite) TestCreateGroup() {
-	req := httptest.NewRequest("POST", "/group", strings.NewReader(sampleGroup))
+	req := httptest.NewRequest("POST", "/group", strings.NewReader(SampleGroup))
 	handler := http.HandlerFunc(createGroup)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -3,15 +3,13 @@ package admin
 import (
 	"net/http"
 
-	"github.com/CMSgov/bcda-app/bcda/monitoring"
 	"github.com/go-chi/chi"
 )
 
 func NewRouter(middlewares ...func(http.Handler) http.Handler) http.Handler {
 	r := chi.NewRouter()
-	m := monitoring.GetMonitor()
 	r.Use(middlewares...)
-	r.Post(m.WrapHandler("/group", createGroup))
+	r.Post("/group", createGroup)
 	r.Post("/system", createSystem)
 	return r
 }

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -1,0 +1,16 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/CMSgov/bcda-app/bcda/monitoring"
+	"github.com/go-chi/chi"
+)
+
+func NewRouter(middlewares ...func(http.Handler) http.Handler) http.Handler {
+	r := chi.NewRouter()
+	m := monitoring.GetMonitor()
+	r.Use(middlewares...)
+	r.Post(m.WrapHandler("/group", createGroup))
+	return r
+}

--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -1,0 +1,31 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type RouterTestSuite struct {
+	suite.Suite
+	router http.Handler
+}
+
+func (s *RouterTestSuite) SetupTest() {
+	s.router = NewRouter()
+}
+
+func (s *RouterTestSuite) TestPostGroupRoute() {
+	req := httptest.NewRequest("POST", "/group", nil)
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	res := rr.Result()
+	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
+}
+
+func TestRouterTestSuite(t *testing.T) {
+	suite.Run(t, new(RouterTestSuite))
+}


### PR DESCRIPTION
### Fixes [BCDA-1144](https://jira.cms.gov/browse/BCDA-1144)
This adds the endpoint to create a group via the auth api according to the ssas tech spec

### Proposed changes:
- add a function to the group models to create a group in the db
- add a function to api.go to take a request and create the group
- add a route to route a post request to the api func to create a group
- add tests

### Security Implications
No security concerns here.  While this is still part of the BCDA API the same security should be applied to this new endpoint

### Acceptance Validation
Tests pass.  New and old

### Feedback Requested
Any feedback is welcome.  Should we add additional validation to the contents of the JSON that is stored in the groups table of the db?