### PR TITLE
BCDA-1507: Create /auth/system/credentials DELETE endpoint

### DIFF
--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/CMSgov/bcda-app/ssas"
+	"github.com/go-chi/chi"
 )
 
 func createGroup(w http.ResponseWriter, r *http.Request) {
@@ -71,4 +72,22 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 	}
+}
+
+func deactivateSystemCredentials(w http.ResponseWriter, r *http.Request) {
+	systemID := chi.URLParam(r, "systemID")
+
+	system, err := ssas.GetSystemByID(systemID)
+	if err != nil {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+
+	err = system.DeactivateSecrets()
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -16,5 +16,6 @@ func Routes() *chi.Mux {
 	r := chi.NewRouter()
 	r.Post("/group", createGroup)
 	r.Post("/system", createSystem)
+	r.Delete("/system/{systemID}/credentials", deactivateSystemCredentials)
 	return r
 }

--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -34,6 +34,15 @@ func (s *RouterTestSuite) TestPostSystemRoute() {
 	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 
+func (s *RouterTestSuite) TestDeactivateSystemCredentials() {
+	req := httptest.NewRequest("DELETE", "/system/1/credentials", nil)
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	res := rr.Result()
+	// TODO Something else here? Not a useful test atm.
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+}
+
 func TestRouterTestSuite(t *testing.T) {
 	suite.Run(t, new(RouterTestSuite))
 }

--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -3,7 +3,10 @@ package admin
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+
+	"github.com/CMSgov/bcda-app/ssas"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -34,13 +37,21 @@ func (s *RouterTestSuite) TestPostSystemRoute() {
 	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 
-func (s *RouterTestSuite) TestDeactivateSystemCredentials() {
-	req := httptest.NewRequest("DELETE", "/system/1/credentials", nil)
+func (s *RouterTestSuite) TestDeleteSystemCredentials() {
+	db := ssas.GetGORMDbConnection()
+	group := ssas.Group{GroupID: "delete-system-credentials-test-group"}
+	db.Create(&group)
+	system := ssas.System{GroupID: group.GroupID, ClientID: "delete-system-credentials-test-system"}
+	db.Create(&system)
+	systemID := strconv.FormatUint(uint64(system.ID), 10)
+
+	req := httptest.NewRequest("DELETE", "/system/"+systemID+"/credentials", nil)
 	rr := httptest.NewRecorder()
 	s.router.ServeHTTP(rr, req)
 	res := rr.Result()
-	// TODO Something else here? Not a useful test atm.
-	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
+
+	_ = ssas.CleanDatabase(group)
 }
 
 func TestRouterTestSuite(t *testing.T) {

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -98,13 +98,11 @@ func (system *System) SaveSecret(hashedSecret string) error {
 		SystemID: system.ID,
 	}
 
-	err := system.DeactivateSecrets()
-	if err != nil {
-		return fmt.Errorf("unable to soft delete previous secrets for clientID %s: %s", system.ClientID, err.Error())
+	if err := system.DeactivateSecrets(); err != nil {
+		return err
 	}
 
-	err = db.Create(&secret).Error
-	if err != nil {
+	if err := db.Create(&secret).Error; err != nil {
 		return fmt.Errorf("could not save secret for clientID %s: %s", system.ClientID, err.Error())
 	}
 	SecretCreated(Event{Op: "SaveSecret", TrackingID: uuid.NewRandom().String(), ClientID: system.ClientID})

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -526,8 +526,8 @@ func (s *SystemsTestSuite) TestDeactivateSecrets() {
 	s.db.Find(&systemSecrets, "system_id = ?", system.ID)
 	assert.NotEmpty(s.T(), systemSecrets)
 
-	system.DeactivateSecrets()
-
+	err := system.DeactivateSecrets()
+	assert.Nil(s.T(), err)
 	s.db.Find(&systemSecrets, "system_id = ?", system.ID)
 	assert.Empty(s.T(), systemSecrets)
 }

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -8,11 +8,12 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
@@ -513,18 +514,36 @@ func (s *SystemsTestSuite) TestSaveSecret() {
 	assert.Nil(err)
 }
 
+func (s *SystemsTestSuite) TestDeactivateSecrets() {
+	group := Group{GroupID: "test-deactivate-secrets-group"}
+	s.db.Create(&group)
+	system := System{GroupID: group.GroupID, ClientID: "test-deactivate-secrets-client"}
+	s.db.Create(&system)
+	secret := Secret{Hash: "test-deactivate-secrets-hash", SystemID: system.ID}
+	s.db.Create(&secret)
+
+	var systemSecrets []Secret
+	s.db.Find(&systemSecrets, "system_id = ?", system.ID)
+	assert.NotEmpty(s.T(), systemSecrets)
+
+	system.DeactivateSecrets()
+
+	s.db.Find(&systemSecrets, "system_id = ?", system.ID)
+	assert.Empty(s.T(), systemSecrets)
+}
+
 func (s *SystemsTestSuite) TestScopeEnvSuccess() {
 	key := "SSAS_DEFAULT_SYSTEM_SCOPE"
-	new_scope := "my_scope"
-	old_scope := os.Getenv(key)
-	err := os.Setenv(key, new_scope)
+	newScope := "my_scope"
+	oldScope := os.Getenv(key)
+	err := os.Setenv(key, newScope)
 	if err != nil {
 		s.FailNow(err.Error())
 	}
 	getEnvVars()
 
-	assert.Equal(s.T(), new_scope, DefaultScope)
-	err = os.Setenv(key, old_scope)
+	assert.Equal(s.T(), newScope, DefaultScope)
+	err = os.Setenv(key, oldScope)
 	assert.Nil(s.T(), err)
 }
 


### PR DESCRIPTION
### Fixes [BCDA-1507](https://jira.cms.gov/browse/BCDA-1507)
SSAS needs a system's credentials to be managed separately from all of the other data associated with it. Deactivation is one part of that credential management.

### Proposed changes:
Create an endpoint for deactivating credentials for a system.

### Change Details
* Creates `DELETE /system/[id]/credentials` path
* Adds functions:
  * api.go: `deactivateSystemCredentials()`
  * systems.go: `DeactivateSecrets()`

### Security Implications
These changes allow a system's secret to be deactivated, preventing the system from being authenticated or authorized by the service.
- This change **does not** add new software dependencies
- This change **does not** alter security controls or supporting software
- This change **does not** introduce storage of new data
- A security checklist **has not** been completed for this change

### Acceptance Validation
Old and new tests pass.

### Feedback Requested
Any
