### PR TITLE
BCDA-1554 Feature: Updated expire logic to be based on job completion time

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -482,7 +482,7 @@ func archiveExpiring(hrThreshold int) error {
 
 	var lastJobError error
 	for _, j := range jobs {
-		t := j.CreatedAt
+		t := j.UpdatedAt
 		elapsed := time.Since(t).Hours()
 		if int(elapsed) >= hrThreshold {
 

--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -257,14 +257,14 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 
 	case "Completed":
 		// If the job should be expired, but the cleanup job hasn't run for some reason, still respond with 410
-		if job.CreatedAt.Add(GetJobTimeout()).Before(time.Now()) {
-			w.Header().Set("Expires", job.CreatedAt.Add(GetJobTimeout()).String())
+		if job.UpdatedAt.Add(GetJobTimeout()).Before(time.Now()) {
+			w.Header().Set("Expires", job.UpdatedAt.Add(GetJobTimeout()).String())
 			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Deleted)
 			responseutils.WriteError(oo, w, http.StatusGone)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Expires", job.CreatedAt.Add(GetJobTimeout()).String())
+		w.Header().Set("Expires", job.UpdatedAt.Add(GetJobTimeout()).String())
 		scheme := "http"
 		if servicemux.IsHTTPS(r) {
 			scheme = "https"
@@ -324,7 +324,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 	case "Archived":
 		fallthrough
 	case "Expired":
-		w.Header().Set("Expires", job.CreatedAt.Add(GetJobTimeout()).String())
+		w.Header().Set("Expires", job.UpdatedAt.Add(GetJobTimeout()).String())
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Deleted)
 		responseutils.WriteError(oo, w, http.StatusGone)
 	}

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -736,7 +736,7 @@ func (s *APITestSuite) TestJobStatusNotExpired() {
 	}
 
 	// s.db.Save(&j)
-	j.CreatedAt = time.Now().Add(-GetJobTimeout()).Add(-GetJobTimeout())
+	j.UpdatedAt = time.Now().Add(-GetJobTimeout()).Add(-GetJobTimeout())
 	s.db.Save(&j)
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/jobs/%d", j.ID), nil)
@@ -753,7 +753,7 @@ func (s *APITestSuite) TestJobStatusNotExpired() {
 
 	assert.Equal(s.T(), http.StatusGone, s.rr.Code)
 	// There seems to be some slight difference in precision here.  Match on first 20 chars sb fine.
-	assert.Equal(s.T(), j.CreatedAt.Add(GetJobTimeout()).String()[:20], s.rr.Header().Get("Expires")[:20])
+	assert.Equal(s.T(), j.UpdatedAt.Add(GetJobTimeout()).String()[:20], s.rr.Header().Get("Expires")[:20])
 	s.db.Delete(&j)
 }
 


### PR DESCRIPTION
Fixes [BCDA-1554](https://jira.cms.gov/browse/BCDA-1554)

Problem:
Our .ndjson files were set to prematurely expire before finishing completion. Our old logic used to expire files based on the job creation time, potentially cutting short the download window for our users. We've since updated this to be based on job completion time which will give them the full available window for downloading.

Proposed changes:
New code for expiration to be based on job completion time using the "updated_at" and not the "created_at" timestamp.

Change Details:
bcda/bcdacli/cli.go - changed archive expiring logic to be based on job completion time.
bcda/web/api.go - changed job status logic to be based on job completion time.
bcda/web/api_test.go - changed test to fit new logic

Security Implications:
[No] This change does not deal with any PII/PHI.
[No] This change adds new software dependencies
[No] This change alters security controls or supporting software
[No] This change introduces storage of new data
[No] A security checklist been completed for this change

Acceptance Validation:
Yes, all tests pass

Feedback Requested:
Any and all