### PR TITLE
BCDA-1580 update daily dev deployment time

### DIFF
--- a/ops/Jenkinsfile.build_trigger
+++ b/ops/Jenkinsfile.build_trigger
@@ -9,7 +9,7 @@ pipeline {
   }
   triggers {
      pollSCM 'H/2 * * * *'
-     cron 'H 8 * * 1-5'
+     cron 'H 7 * * 1-5'
   }
 
   stages {


### PR DESCRIPTION
### Fixes [BCDA-1580](https://jira.cms.gov/browse/BCDA-1580)

The Daily Deployment interferes with engineering workload. 

### Proposed changes:

Change the deployment time to be earlier in the morning.

### Change Details

Update this time from 9 to 8

### Security Implications
- [No] This change does not deal with any PII/PHI.
- [No] This change adds new software dependencies
- [No] This change alters security controls or supporting software
-  [No] This change introduces storage of new data
- [No] A security checklist been completed for this change


### Acceptance Validation
Unable to test until merged. Only changing one element of a cron though and should be safe.

### Feedback Requested
Please review