### PR TITLE
BCDA-1146 implement delete group endpoint

### DIFF
--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -66,6 +66,69 @@ func CreateGroup(gd GroupData) (Group, error) {
 	return g, nil
 }
 
+func DeleteGroup(id string) error {
+	event := Event{Op: "DeleteGroup", TrackingID: id}
+	OperationStarted(event)
+
+	db := GetGORMDbConnection()
+	defer Close(db)
+	g := Group{}
+	err := db.Where("id = ?", id).First(&g).Error
+	if err != nil {
+		event.Help = err.Error()
+		OperationFailed(event)
+		return err
+	}
+
+	err = cascadeDeleteGroup(g)
+	if err != nil {
+		event.Help = err.Error()
+		OperationFailed(event)
+		return err
+	}
+
+	OperationSucceeded(event)
+	return nil
+}
+
+func cascadeDeleteGroup(group Group) error {
+	var (
+		system        System
+		encryptionKey EncryptionKey
+		secret        Secret
+		systemIds     []int
+		db            = GetGORMDbConnection()
+	)
+	defer Close(db)
+
+	err := db.Table("systems").Where("group_id = ?", group.GroupID).Pluck("ID", &systemIds).Error
+	if err != nil {
+		return fmt.Errorf("unable to find associated systems: %s", err.Error())
+	}
+
+	err = db.Where("system_id IN (?)", systemIds).Delete(&encryptionKey).Error
+	if err != nil {
+		return fmt.Errorf("unable to delete encryption keys: %s", err.Error())
+	}
+
+	err = db.Where("system_id IN (?)", systemIds).Delete(&secret).Error
+	if err != nil {
+		return fmt.Errorf("unable to delete secrets: %s", err.Error())
+	}
+
+	err = db.Where("id IN (?)", systemIds).Delete(&system).Error
+	if err != nil {
+		return fmt.Errorf("unable to delete systems: %s", err.Error())
+	}
+
+	err = db.Delete(&group).Error
+	if err != nil {
+		return fmt.Errorf("unable to delete group: %s", err.Error())
+	}
+
+	return nil
+}
+
 type GroupData struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -79,34 +79,24 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 }
 
 func (s *GroupsTestSuite) TestDeleteGroup() {
-	group := Group{GroupID: "groups-test-delete-group"}
+	group := Group{GroupID: "groups-test-delete-group-id"}
 	err := s.db.Create(&group).Error
 	if err != nil {
 		s.FailNow(err.Error())
 	}
 
-	system := System{GroupID: group.GroupID, ClientID: "groups-test-delete-group"}
+	system := System{GroupID: group.GroupID, ClientID: "groups-test-delete-client-id"}
 	err = s.db.Create(&system).Error
 	if err != nil {
 		s.FailNow(err.Error())
 	}
 
-	key1Str := "publickey1"
-	encrKey1 := EncryptionKey{
+	keyStr := "publickey"
+	encrKey := EncryptionKey{
 		SystemID: system.ID,
-		Body:     key1Str,
+		Body:     keyStr,
 	}
-	err = s.db.Create(&encrKey1).Error
-	if err != nil {
-		s.FailNow(err.Error())
-	}
-
-	key2Str := "publickey2"
-	encrKey2 := EncryptionKey{
-		SystemID: system.ID,
-		Body:     key2Str,
-	}
-	err = s.db.Create(&encrKey2).Error
+	err = s.db.Create(&encrKey).Error
 	if err != nil {
 		s.FailNow(err.Error())
 	}

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -2,6 +2,7 @@ package ssas
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/jinzhu/gorm"
@@ -75,6 +76,43 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	gd.ID = ""
 	_, err = CreateGroup(gd)
 	assert.EqualError(s.T(), err, "group_id cannot be blank")
+}
+
+func (s *GroupsTestSuite) TestDeleteGroup() {
+	group := Group{GroupID: "groups-test-delete-group"}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	system := System{GroupID: group.GroupID, ClientID: "groups-test-delete-group"}
+	err = s.db.Create(&system).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	key1Str := "publickey1"
+	encrKey1 := EncryptionKey{
+		SystemID: system.ID,
+		Body:     key1Str,
+	}
+	err = s.db.Create(&encrKey1).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	key2Str := "publickey2"
+	encrKey2 := EncryptionKey{
+		SystemID: system.ID,
+		Body:     key2Str,
+	}
+	err = s.db.Create(&encrKey2).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	err = DeleteGroup(fmt.Sprint(group.ID))
+	assert.Nil(s.T(), err)
 }
 
 func TestGroupsTestSuite(t *testing.T) {

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -45,6 +45,7 @@ func deleteGroup(w http.ResponseWriter, r *http.Request) {
 	ssas.OperationCalled(ssas.Event{Op: "DeleteGroup", TrackingID: id, Help: "calling from admin.deleteGroup()"})
 	err := ssas.DeleteGroup(id)
 	if err != nil {
+		ssas.OperationFailed(ssas.Event{Op: "admin.deleteGroup", TrackingID: id, Help: err.Error()})
 		http.Error(w, fmt.Sprintf("Failed to delete group. Error: %s", err), http.StatusBadRequest)
 		return
 	}

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -39,6 +39,19 @@ func createGroup(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func deleteGroup(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	ssas.OperationCalled(ssas.Event{Op: "DeleteGroup", TrackingID: id, Help: "calling from admin.deleteGroup()"})
+	err := ssas.DeleteGroup(id)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to delete group. Error: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
 func createSystem(w http.ResponseWriter, r *http.Request) {
 	type system struct {
 		ClientName string `json:"client_name"`

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -15,6 +15,7 @@ func init() {
 func Routes() *chi.Mux {
 	r := chi.NewRouter()
 	r.Post("/group", createGroup)
+	r.Delete("/group/{id}", deleteGroup)
 	r.Post("/system", createSystem)
 	r.Put("/system/{systemID}/credentials", resetCredentials)
 	return r

--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -28,6 +28,14 @@ func (s *RouterTestSuite) TestPostGroupRoute() {
 	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 
+func (s *RouterTestSuite) TestDeleteGroup() {
+	req := httptest.NewRequest("DELETE", "/group/101", nil)
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	res := rr.Result()
+	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
+}
+
 func (s *RouterTestSuite) TestPostSystem() {
 	req := httptest.NewRequest("POST", "/system", nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
### Fixes [BCDA-1146](https://jira.cms.gov/browse/BCDA-1146)
This PR implements the DELETE method for the Group resource

### Proposed changes:
- add the delete route
- add the api func to process the request
- add the model func to delete the group and its associated system and encryption keys from the db
- add tests

### Security Implications
No security implications at this point.  This will be an admin endpoint with security to ensure only authorized parties can affect their attributed groups

### Acceptance Validation
tests are passing!

### Feedback Requested
any feedback is welcome!