### PR TITLE
BUG FIX: fix saving groupData to db by implementing sql.scanner interface

### DIFF
--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -1,6 +1,9 @@
 package ssas
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 
@@ -157,6 +160,23 @@ type GroupData struct {
 	Scopes    []string   `json:"scopes"`
 	System    System     `gorm:"foreignkey:GroupID;association_foreignkey:GroupID" json:"system"`
 	Resources []Resource `json:"resources"`
+}
+
+// Make the GroupData struct implement the driver.Valuer interface. This method
+// simply returns the JSON-encoded representation of the struct.
+func (gd GroupData) Value() (driver.Value, error) {
+	return json.Marshal(gd)
+}
+
+// Make the GroupData struct implement the sql.Scanner interface. This method
+// simply decodes a JSON-encoded value into the struct fields.
+func (gd *GroupData) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(b, &gd)
 }
 
 type Resource struct {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -72,6 +72,21 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	assert.Nil(s.T(), err)
 	g, err := CreateGroup(gd)
 	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), g)
+	assert.Equal(s.T(), "A12345", g.GroupID)
+	assert.Equal(s.T(), "A12345", g.Data.ID)
+	assert.Equal(s.T(), 3, len(g.Data.Users))
+
+	dbGroup := Group{}
+	db := GetGORMDbConnection()
+	defer Close(db)
+	if db.Where("id = ?", g.ID).Find(&dbGroup).RecordNotFound() {
+		assert.FailNow(s.T(), fmt.Sprintf("record not found for id=%d", g.ID))
+	}
+	assert.Equal(s.T(), "A12345", dbGroup.GroupID)
+	assert.Equal(s.T(), "A12345", dbGroup.Data.ID)
+	assert.Equal(s.T(), 3, len(dbGroup.Data.Users))
+
 	err = CleanDatabase(g)
 	assert.Nil(s.T(), err)
 	gd.ID = ""


### PR DESCRIPTION
### Fixes saving of group data to the db

### Proposed changes:
- satisfy the sql.scanner interface to save groupdata to the db

### Security Implications
no security implications.  this is just a functional bug fix that doesn't affect security

### Acceptance Validation
new test passes!