### PR TITLE
BCDA-1596 Feature: Added db model for suppression data

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -357,7 +357,7 @@ type Suppression struct {
 	SAMHSASourceCode    string `gorm:"type:varchar(5)"`
 	SAMHSAEffectiveDt   time.Time
 	SAMHSAPrefIndicator string `gorm:"type:char(1)"`
-	ACOCMSID            string `gorm:"column:aco_cms_id"`
+	ACOCMSID            string `gorm:"column:aco_cms_id;type:char(5)"`
 	BeneficiaryLinkKey  int
 }
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -351,10 +351,10 @@ type CCLFBeneficiary struct {
 type Suppression struct {
 	gorm.Model
 	HICN                string `gorm:"type:varchar(11);not null"`
-	SourceCode          string `json:"source_code"`
+	SourceCode          string `gorm:"type:varchar(5)"`
 	EffectiveDt         time.Time
 	PrefIndicator       string `gorm:"type:char(1)"`
-	SAMHSASourceCode    string `json:"samhsa_source_code"`
+	SAMHSASourceCode    string `gorm:"type:varchar(5)"`
 	SAMHSAEffectiveDt   time.Time
 	SAMHSAPrefIndicator string `gorm:"type:char(1)"`
 	ACOCMSID            string `gorm:"type:char(5)"`

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -357,7 +357,7 @@ type Suppression struct {
 	SAMHSASourceCode    string `gorm:"type:varchar(5)"`
 	SAMHSAEffectiveDt   time.Time
 	SAMHSAPrefIndicator string `gorm:"type:char(1)"`
-	ACOCMSID            string `gorm:"type:char(5)"`
+	ACOCMSID            string `gorm:"column:aco_cms_id"`
 	BeneficiaryLinkKey  int
 }
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -43,6 +43,7 @@ func InitializeGormModels() *gorm.DB {
 		&CCLFBeneficiaryXref{},
 		&CCLFFile{},
 		&CCLFBeneficiary{},
+		&Suppression{},
 	)
 
 	db.Model(&CCLFBeneficiary{}).AddForeignKey("file_id", "cclf_files(id)", "RESTRICT", "RESTRICT")
@@ -345,6 +346,19 @@ type CCLFBeneficiary struct {
 	HICN         string `gorm:"type:varchar(11);not null"`
 	MBI          string `gorm:"type:char(11);not null"`
 	BlueButtonID string `gorm:"type: text"`
+}
+
+type Suppression struct {
+	gorm.Model
+	HICN                string `gorm:"type:varchar(11);not null"`
+	SourceCode          string `json:"source_code"`
+	EffectiveDt         time.Time
+	PrefIndicator       string `gorm:"type:char(1)"`
+	SAMHSASourceCode    string `json:"samhsa_source_code"`
+	SAMHSAEffectiveDt   time.Time
+	SAMHSAPrefIndicator string `gorm:"type:char(1)"`
+	ACOCMSID            string `gorm:"type:char(5)"`
+	BeneficiaryLinkKey  int
 }
 
 // This method will ensure that a valid BlueButton ID is returned.

--- a/db/api.sql
+++ b/db/api.sql
@@ -69,3 +69,19 @@ create table cclf_beneficiary_xrefs (
     updated_at timestamp with time zone not null default now(),
     deleted_at timestamp with time zone
 );
+
+create table suppressions (
+    id serial primary key,
+    hicn varchar(11) not null,
+    source_code varchar,
+    effective_date timestamp with time zone,
+    preference_indicator char(1),
+    samhsa_source_code varchar,
+    samhsa_effective_date timestamp with time zone,
+    samhsa_preference_indicator char(1),
+    aco_cms_id char(5),
+    beneficiary_link_key integer,
+    created_at timestamp with time zone not null default now(),
+    updated_at timestamp with time zone not null default now(),
+    deleted_at timestamp with time zone
+);

--- a/db/api.sql
+++ b/db/api.sql
@@ -73,10 +73,10 @@ create table cclf_beneficiary_xrefs (
 create table suppressions (
     id serial primary key,
     hicn varchar(11) not null,
-    source_code varchar,
+    source_code varchar(5),
     effective_date timestamp with time zone,
     preference_indicator char(1),
-    samhsa_source_code varchar,
+    samhsa_source_code varchar(5),
     samhsa_effective_date timestamp with time zone,
     samhsa_preference_indicator char(1),
     aco_cms_id char(5),


### PR DESCRIPTION
Fixes [BCDA-1596](https://jira.cms.gov/browse/BCDA-1596)

Problem:
We need to have our db models in place before implementing the 1-800 medicare suppression ETL.

Proposed changes:
Added db model for 1-800 medicare suppression data.

Change Details:
bcda/models/models.go - gorm db model code
db/api.sql - db schema updates

Security Implications:
Yes, this code **will** handle files containing PII/PHI.
This change does **not** add new software dependencies
This change does **not** alter security controls or supporting software
This change does **not** introduce storage of new data
A security checklist **has** been completed for this change

Acceptance Validation:
Yes, all tests pass

Feedback Requested:
Any and all