### PR TITLE
BCDA-1606: CLI for executing 1-800-MEDICARE suppression data ETL

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -357,18 +357,18 @@ func setUpApp() *cli.App {
 			},
 		},
 		{
-			Name:     "import-1800medicare-directory",
+			Name:     "import-suppression-directory",
 			Category: "Data import",
-			Usage:    "Import all 1-800-MEDICARE files from the specified directory",
+			Usage:    "Import all 1-800-MEDICARE suppression data files from the specified directory",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        "directory",
-					Usage:       "Directory where 1-800-MEDICARE files are located",
+					Usage:       "Directory where suppression files are located",
 					Destination: &filePath,
 				},
 			},
 			Action: func(c *cli.Context) error {
-				msg, err := import1800MedicareDirectory(filePath)
+				msg, err := importSuppressionDirectory(filePath)
 				if err != nil {
 					return err
 				}
@@ -578,7 +578,7 @@ func cleanupArchive(hrThreshold int) error {
 	return nil
 }
 
-func import1800MedicareDirectory(dir string) (string, error) {
+func importSuppressionDirectory(dir string) (string, error) {
 	// TODO
 	return "", nil
 }

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -314,7 +314,7 @@ func setUpApp() *cli.App {
 		{
 			Name:     "archive-job-files",
 			Category: "Cleanup",
-			Usage:    "Updates job statuses and moves files to an inaccessible location",
+			Usage:    "Update job statuses and move files to an inaccessible location",
 			Action: func(c *cli.Context) error {
 				threshold := utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24)
 				return archiveExpiring(threshold)
@@ -323,7 +323,7 @@ func setUpApp() *cli.App {
 		{
 			Name:     "cleanup-archive",
 			Category: "Cleanup",
-			Usage:    "Removes job directory and files from archive and updates job status to Expired",
+			Usage:    "Remove job directory and files from archive and update job status to Expired",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        "threshold",
@@ -342,11 +342,11 @@ func setUpApp() *cli.App {
 		{
 			Name:     "import-cclf-directory",
 			Category: "Data import",
-			Usage:    "Import all CCLF files in the directory",
+			Usage:    "Import all CCLF files from the specified directory",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        "directory",
-					Usage:       "Directory where CCLF Files are located",
+					Usage:       "Directory where CCLF files are located",
 					Destination: &filePath,
 				},
 			},
@@ -354,6 +354,26 @@ func setUpApp() *cli.App {
 				success, failure, skipped, err := cclf.ImportCCLFDirectory(filePath)
 				fmt.Fprintf(app.Writer, "Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)
 				return err
+			},
+		},
+		{
+			Name:     "import-1800medicare-directory",
+			Category: "Data import",
+			Usage:    "Import all 1-800-MEDICARE files from the specified directory",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "directory",
+					Usage:       "Directory where 1-800-MEDICARE files are located",
+					Destination: &filePath,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				msg, err := import1800MedicareDirectory(filePath)
+				if err != nil {
+					return err
+				}
+				fmt.Println(msg)
+				return nil
 			},
 		},
 		{
@@ -556,4 +576,9 @@ func cleanupArchive(hrThreshold int) error {
 	}
 
 	return nil
+}
+
+func import1800MedicareDirectory(dir string) (string, error) {
+	// TODO
+	return "", nil
 }

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -19,6 +19,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
+	"github.com/CMSgov/bcda-app/bcda/suppression"
 	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/bcda/web"
 	"github.com/bgentry/que-go"
@@ -368,12 +369,9 @@ func setUpApp() *cli.App {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				msg, err := importSuppressionDirectory(filePath)
-				if err != nil {
-					return err
-				}
-				fmt.Println(msg)
-				return nil
+				s, f, sk, err := suppression.ImportSuppressionDirectory(filePath)
+				fmt.Fprintf(app.Writer, "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
+				return err
 			},
 		},
 		{
@@ -576,9 +574,4 @@ func cleanupArchive(hrThreshold int) error {
 	}
 
 	return nil
-}
-
-func importSuppressionDirectory(dir string) (string, error) {
-	// TODO
-	return "", nil
 }

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -811,3 +811,19 @@ func (s *CLITestSuite) TestImportCCLFDirectory_SplitFiles() {
 
 	testUtils.ResetFiles(s.Suite, "../../shared_files/cclf_split/")
 }
+
+func (s *CLITestSuite) TestImport1800MedicareDirectory() {
+	assert := assert.New(s.T())
+
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+
+	buf := new(bytes.Buffer)
+	s.testApp.Writer = buf
+
+	args := []string{"bcda", "import-1800medicare-directory", "--directory", "../../shared_files/suppression/"}
+	err := s.testApp.Run(args)
+	assert.Nil(err)
+
+	// TODO
+}

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -812,7 +812,7 @@ func (s *CLITestSuite) TestImportCCLFDirectory_SplitFiles() {
 	testUtils.ResetFiles(s.Suite, "../../shared_files/cclf_split/")
 }
 
-func (s *CLITestSuite) TestImport1800MedicareDirectory() {
+func (s *CLITestSuite) TestImportSuppressionDirectory() {
 	assert := assert.New(s.T())
 
 	db := database.GetGORMDbConnection()
@@ -821,7 +821,7 @@ func (s *CLITestSuite) TestImport1800MedicareDirectory() {
 	buf := new(bytes.Buffer)
 	s.testApp.Writer = buf
 
-	args := []string{"bcda", "import-1800medicare-directory", "--directory", "../../shared_files/suppression/"}
+	args := []string{"bcda", "import-suppression-directory", "--directory", "../../shared_files/suppression/"}
 	err := s.testApp.Run(args)
 	assert.Nil(err)
 

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/utils"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/CMSgov/bcda-app/bcda/utils"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -80,8 +81,12 @@ func ImportSuppressionDirectory(filePath string) (success, failure, skipped int,
 func getSuppressionFileMetadata(suppresslist *[]suppressionFileMetadata, skipped *int) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			fmt.Printf("Error in checking suppression file %s: %s.\n", info.Name(), err)
-			err = errors.Wrapf(err, "error in checking suppression file: %s,", info.Name())
+			var fileName = "nil"
+			if info != nil {
+				fileName = info.Name()
+			}
+			fmt.Printf("Error in checking suppression file %s: %s.\n", fileName, err)
+			err = errors.Wrapf(err, "error in checking suppression file: %s,", fileName)
 			log.Error(err)
 			return err
 		}


### PR DESCRIPTION
### Fixes [BCDA-1606](https://jira.cms.gov/browse/BCDA-1606)
We need a way to import 1-800-MEDICARE suppression data from the CLI.

### Proposed changes:
Create a CLI command for importing suppression data.

### Change Details
* Adds `import-suppression-directory` command to CLI, taking flag `--directory` to indicate location of files to import (cli.go)
  * Includes tests for this command that result in success, failures, and skipped files (cli_test.go)

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
  - A security checklist exists for the suppression data ETL process: https://confluence.cms.gov/display/BCDA/1-800-Medicare+opt+outs+data+sourcing+-+Security+Checklist This PR does not create the ETL, but calls the functionality added in https://github.com/CMSgov/bcda-app/pull/349.

### Acceptance Validation
Tests included. Example of running from command line:
<img width="1042" alt="Screen Shot 2019-08-06 at 12 45 58 PM" src="https://user-images.githubusercontent.com/1923441/62559067-381b9a80-b848-11e9-9ac8-ae3c07d8ebf6.png">

### Feedback Requested
Any