### PR TITLE
BCDA-1608: Incorporate 1-800-MEDICARE ETL into Docker pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ load-fixtures:
 	sleep 5
 	docker-compose run db psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /var/db/fixtures.sql
 	$(MAKE) load-synthetic-cclf-data
+	$(MAKE) load-synthetic-suppression-data
 
 load-synthetic-cclf-data:
 	docker-compose up -d api
@@ -84,6 +85,11 @@ load-synthetic-cclf-data:
 	docker-compose run api sh -c 'tmp/bcda import-synthetic-cclf-package --acoSize=medium --environment=test'
 	docker-compose run api sh -c 'tmp/bcda import-synthetic-cclf-package --acoSize=large --environment=test'
 	docker-compose run api sh -c 'tmp/bcda import-synthetic-cclf-package --acoSize=extra-large --environment=test'
+
+load-synthetic-suppression-data:
+	docker-compose up -d api
+	docker-compose up -d db
+	docker-compose run api sh -c 'tmp/bcda import-suppression-directory --directory=../shared_files/synthetic1800MedicareFiles'
 
 docker-build:
 	docker-compose build --force-rm
@@ -113,4 +119,4 @@ debug-worker:
 	@-bash -c "trap 'docker-compose stop' EXIT; \
 		docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --no-deps -T --rm -v $(shell pwd):/go/src/github.com/CMSgov/bcda-app worker dlv debug"
 
-.PHONY: docker-build docker-bootstrap load-fixtures load-synthetic-cclf-data test debug-api debug-worker api-shell worker-shell package release smoke-test postman unit-test performance-test lint
+.PHONY: docker-build docker-bootstrap load-fixtures load-synthetic-cclf-data load-synthetic-suppression-data test debug-api debug-worker api-shell worker-shell package release smoke-test postman unit-test performance-test lint


### PR DESCRIPTION
### Fixes [BCDA-1608](https://jira.cms.gov/browse/BCDA-1608)
Incorporating the 1-800-MEDICARE suppression data ETL into our Docker pipeline would help our local environments more closely mimic the production workflow.

### Proposed changes:
* Create Make target `load-synthetic-suppression-data` that calls CLI `import-suppression-directory` command
* Add new make target to `load-fixtures`

### Security Implications
This work is for importing synthetic data in local Docker environments. The 1-800-MEDICARE suppression data ETL checklist is here: https://confluence.cms.gov/display/BCDA/1-800-Medicare+opt+outs+data+sourcing+-+Security+Checklist The work in this pull request calls the ETL logic to import synthetic data, but does not change the production ETL process.
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change

### Acceptance Validation
Can be tested by running `make load-fixtures` locally. Near the end of the output will be the message `Completed 1-800-MEDICARE suppression data import.`

### Feedback Requested
Any
