### PR TITLE
BCDA-1459: Incorrect logging of IP

### DIFF
--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -56,6 +56,7 @@ func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 	logFields["http_method"] = r.Method
 
 	logFields["remote_addr"] = r.RemoteAddr
+	logFields["forwarded_for"] = r.Header.Get("X-Forwarded-For")
 	logFields["user_agent"] = r.UserAgent()
 
 	logFields["uri"] = fmt.Sprintf("%s://%s%s", scheme, r.Host, Redact(r.RequestURI))


### PR DESCRIPTION
### Fixes [BCDA-1459](https://jira.cms.gov/browse/BCDA-1459)
BCDA request logs include the `Request.RemoteAddr`, which may be the address of the load balancer rather than the originator.

### Proposed changes:
Add log entry field `forwarded_for`, containing the value of the `X-Forwarded-For` header.

### Security Implications
This change logs an additional value on requests, but it is data that BCDA already had.
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change

### Acceptance Validation
`forwarded_for` log entry field can be seen in the request logs in Splunk.
![Screen Shot 2019-08-08 at 10 26 36 AM](https://user-images.githubusercontent.com/1923441/62712436-cfa7f700-b9c8-11e9-8b9f-a1b9b9a02c8d.png)

### Feedback Requested
Any
