### PR TITLE
BCDA-1535, BCDA-1538: BCDA's SSAS auth provider gets tokens from and verifies them with SSAS

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "golang.org/x/crypto"
+  name = "github.com/golang/x"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,10 +47,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/golang/x"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/go-chi/chi"
 
 [[constraint]]

--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -51,7 +51,7 @@ func NewSSASClient() (*SSASClient, error) {
 		transport = &http.Transport{}
 		err       error
 	)
-	if os.Getenv("SSAS_USE_TLS") != "false" {
+	if os.Getenv("SSAS_USE_TLS") == "true" {
 		transport, err = tlsTransport()
 		if err != nil {
 			return nil, errors.Wrap(err, "SSAS client could not be created")
@@ -160,7 +160,7 @@ func (c *SSASClient) GetToken(credentials Credentials) ([]byte, error) {
 	req.SetBasicAuth(credentials.ClientID, credentials.ClientSecret)
 	req.Header.Add("Accept", "application/json")
 
-	resp, err := client().Do(req)
+	resp, err := c.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "token request failed")
 	}
@@ -184,7 +184,7 @@ func (c *SSASClient) GetToken(credentials Credentials) ([]byte, error) {
 func (c *SSASClient) VerifyPublicToken(tokenString string) ([]byte, error) {
 	public := os.Getenv("SSAS_PUBLIC_URL")
 	url := fmt.Sprintf("%s/introspect", public)
-	body := strings.NewReader(`"token="`+tokenString+`""`)
+	body := strings.NewReader("token="+tokenString)
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "bad request structure")
@@ -194,7 +194,7 @@ func (c *SSASClient) VerifyPublicToken(tokenString string) ([]byte, error) {
 	req.SetBasicAuth(os.Getenv("BCDA_SSAS_CLIENT_ID"), os.Getenv("BCDA_SSAS_SECRET"))
 	req.Header.Add("Accept", "application/json")
 
-	resp, err := client().Do(req)
+	resp, err := c.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "introspect request failed")
 	}

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -34,18 +34,7 @@ func (s *SSASClientTestSuite) TestNewSSASClient_TLSFalse() {
 	assert.IsType(s.T(), &authclient.SSASClient{}, client)
 }
 
-func (s *SSASClientTestSuite) TestNewSSASClient_NoKeypair() {
-	client, err := authclient.NewSSASClient()
-	assert.NotNil(s.T(), err)
-	assert.Nil(s.T(), client)
-	assert.EqualError(s.T(), err, "SSAS client could not be created: could not load SSAS keypair: open : no such file or directory")
-}
-
-func (s *SSASClientTestSuite) TestNewSSASClient_TLSFalseNoURL() {
-	origSSASUseTLS := os.Getenv("SSAS_USE_TLS")
-	defer os.Setenv("SSAS_USE_TLS", origSSASUseTLS)
-	os.Setenv("SSAS_USE_TLS", "false")
-
+func (s *SSASClientTestSuite) TestNewSSASClient_NoURL() {
 	origSSASURL := os.Getenv("SSAS_URL")
 	defer os.Setenv("SSAS_URL", origSSASURL)
 	os.Unsetenv("SSAS_URL")
@@ -54,6 +43,21 @@ func (s *SSASClientTestSuite) TestNewSSASClient_TLSFalseNoURL() {
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), client)
 	assert.EqualError(s.T(), err, "SSAS client could not be created: no URL provided")
+}
+
+func (s *SSASClientTestSuite) TestNewSSASClient_TLSTrueNoKey() {
+	origSSASUseTLS := os.Getenv("SSAS_USE_TLS")
+	defer os.Setenv("SSAS_USE_TLS", origSSASUseTLS)
+	os.Setenv("SSAS_USE_TLS", "true")
+
+	origSSASClientCertFile := os.Getenv("SSAS_CLIENT_CERT_FILE")
+	defer os.Setenv("SSAS_CLIENT_CERT_FILE", origSSASClientCertFile)
+	os.Unsetenv("SSAS_CLIENT_CERT_FILE")
+
+	client, err := authclient.NewSSASClient()
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), client)
+	assert.EqualError(s.T(), err, "SSAS client could not be created: could not load SSAS keypair: open : no such file or directory")
 }
 
 func (s *SSASClientTestSuite) TestCreateSystem() {}

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -50,7 +50,11 @@ func GetProvider() Provider {
 	case Okta:
 		return NewOktaAuthPlugin(client.NewOktaClient())
 	case SSAS:
-		return SSASPlugin{}
+		c, err := client.NewSSASClient()
+		if err != nil {
+			log.Fatalf("no client for SSAS; %s", err.Error())
+		}
+		return SSASPlugin{client:c}
 	default:
 		return AlphaAuthPlugin{}
 	}

--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/CMSgov/bcda-app/bcda/auth/client"
 	jwt "github.com/dgrijalva/jwt-go"
+
+	"github.com/CMSgov/bcda-app/bcda/auth/client"
 )
 
 // SSASPlugin is an implementation of Provider that uses the SSAS API.
@@ -41,7 +43,19 @@ func (s SSASPlugin) RevokeSystemCredentials(ssasID string) error {
 
 // MakeAccessToken mints an access token for the given credentials.
 func (s SSASPlugin) MakeAccessToken(credentials Credentials) (string, error) {
-	return "", errors.New("Not yet implemented")
+	ssas, err := client.NewSSASClient()
+	if err != nil {
+		logger.Errorf("failed to create SSAS client; %s", err.Error())
+		return "", err
+	}
+
+	ts, err := ssas.GetToken(client.Credentials{ClientID:credentials.ClientID, ClientSecret:credentials.ClientSecret})
+	if err != nil {
+		logger.Errorf("Failed to get token; %s", err.Error())
+		return "", err
+	}
+
+	return string(ts), nil
 }
 
 // RevokeAccessToken revokes a specific access token identified in a base64-encoded token string.

--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -1,10 +1,10 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
 
-	"github.com/CMSgov/bcda-app/bcda/auth/client"
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 
 	"github.com/CMSgov/bcda-app/bcda/auth/client"
 )
@@ -17,12 +17,12 @@ type SSASPlugin struct {
 // RegisterSystem adds a software client for the ACO identified by localID.
 func (s SSASPlugin) RegisterSystem(localID string) (Credentials, error) {
 	// s.client.CreateSystem()
-	return Credentials{}, errors.New("Not yet implemented")
+	return Credentials{}, errors.New("not yet implemented")
 }
 
 // UpdateSystem changes data associated with the registered software client identified by clientID.
 func (s SSASPlugin) UpdateSystem(params []byte) ([]byte, error) {
-	return nil, errors.New("Not yet implemented")
+	return nil, errors.New("not yet implemented")
 }
 
 // DeleteSystem deletes the registered software client identified by clientID, revoking any active tokens.
@@ -33,7 +33,7 @@ func (s SSASPlugin) DeleteSystem(clientID string) error {
 // ResetSecret creates new or replaces existing credentials for the given clientID.
 func (s SSASPlugin) ResetSecret(clientID string) (Credentials, error) {
 	// s.client.ResetCredentials()
-	return Credentials{}, errors.New("Not yet implemented")
+	return Credentials{}, errors.New("not yet implemented")
 }
 
 // RevokeSystemCredentials revokes any existing credentials for the given clientID.
@@ -49,7 +49,7 @@ func (s SSASPlugin) MakeAccessToken(credentials Credentials) (string, error) {
 		return "", err
 	}
 
-	ts, err := ssas.GetToken(client.Credentials{ClientID:credentials.ClientID, ClientSecret:credentials.ClientSecret})
+	ts, err := ssas.GetToken(client.Credentials{ClientID: credentials.ClientID, ClientSecret: credentials.ClientSecret})
 	if err != nil {
 		logger.Errorf("Failed to get token; %s", err.Error())
 		return "", err
@@ -60,15 +60,35 @@ func (s SSASPlugin) MakeAccessToken(credentials Credentials) (string, error) {
 
 // RevokeAccessToken revokes a specific access token identified in a base64-encoded token string.
 func (s SSASPlugin) RevokeAccessToken(tokenString string) error {
-	return errors.New("Not yet implemented")
+	return errors.New("not yet implemented")
 }
 
 // AuthorizeAccess asserts that a base64 encoded token string is valid for accessing the BCDA API.
 func (s SSASPlugin) AuthorizeAccess(tokenString string) error {
-	return errors.New("Not yet implemented")
+	return errors.New("not yet implemented")
 }
 
 // VerifyToken decodes a base64-encoded token string into a structured token.
 func (s SSASPlugin) VerifyToken(tokenString string) (*jwt.Token, error) {
-	return nil, errors.New("Not yet implemented")
+	ssas, err := client.NewSSASClient()
+	if err != nil {
+		logger.Errorf("failed to create SSAS client; %s", err.Error())
+		return nil, err
+	}
+
+	b, err := ssas.VerifyPublicToken(tokenString)
+	if err != nil {
+		logger.Errorf("Failed to verify token; %s", err.Error())
+		return nil, err
+	}
+	var ir map[string]interface{}
+	if err = json.Unmarshal(b, &ir); err != nil {
+		return nil, err
+	}
+	if ir["active"] == false {
+		return nil, errors.New("inactive token")
+	}
+	parser := jwt.Parser{}
+	token, _, err := parser.ParseUnverified( tokenString, &jwt.MapClaims{})
+	return token, err
 }

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -120,8 +120,8 @@ func (s *SSASPluginTestSuite) TestVerifyToken() {
 		}
 
 		if clientId == os.Getenv("BCDA_SSAS_CLIENT_ID") && secret == os.Getenv("BCDA_SSAS_SECRET") {
-			b, err := json.Marshal(struct{ Active bool `json:"active"` }{Active: true})
-			if _, err = w.Write(b); err != nil {
+			b, _ := json.Marshal(struct{ Active bool `json:"active"` }{Active: true})
+			if _, err := w.Write(b); err != nil {
 				log.Fatal(err)
 			}
 		} else {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -53,6 +53,8 @@ services:
       - SSAS_MFA_CHALLENGE_REQUEST_MILLISECONDS=0
       - SSAS_MFA_TOKEN_TIMEOUT_MINUTES=60
       - SSAS_MFA_PROVIDER=${SSAS_MFA_PROVIDER}
+      - SSAS_URL=http://ssas:3004
+      - SSAS_PUBLIC_URL=http://ssas:3003
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
   postman_test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,8 +140,8 @@ services:
       - SSAS_MFA_CHALLENGE_REQUEST_MILLISECONDS=0
       - SSAS_MFA_TOKEN_TIMEOUT_MINUTES=60
       - SSAS_MFA_PROVIDER=${SSAS_MFA_PROVIDER}
-      - SSAS_URL=${SSAS_URL}
-      - SSAS_PUBLIC_URL=${SSAS_PUBLIC_URL}
+      - SSAS_URL=http://ssas:3004
+      - SSAS_PUBLIC_URL=http://ssas:3003
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,11 @@ services:
       - AUTH_HASH_KEY_LENGTH=64
       - AUTH_HASH_SALT_SIZE=32
       - CCLF_IMPORT_STATUS_RECORDS_INTERVAL=1000
+      - BCDA_SSAS_CLIENT_ID=${BCDA_SSAS_CLIENT_ID}
+      - BCDA_SSAS_SECRET=${BCDA_SSAS_SECRET}
+      - SSAS_USE_TLS=false
+      - SSAS_URL=${SSAS_URL}
+      - SSAS_PUBLIC_URL=${SSAS_PUBLIC_URL}
     volumes:
      - .:/go/src/github.com/CMSgov/bcda-app
     ports:
@@ -118,6 +123,8 @@ services:
       - OKTA_MFA_USER_ID=${OKTA_MFA_USER_ID}
       - OKTA_MFA_USER_PASSWORD=${OKTA_MFA_USER_PASSWORD}
       - OKTA_MFA_SMS_FACTOR_ID=${OKTA_MFA_SMS_FACTOR_ID}
+      - BCDA_SSAS_CLIENT_ID=${BCDA_SSAS_CLIENT_ID}
+      - BCDA_SSAS_SECRET=${BCDA_SSAS_SECRET}
       - SSAS_ADMIN_SIGNING_KEY_PATH=../shared_files/ssas/admin_test_signing_key.pem
       - SSAS_PUBLIC_SIGNING_KEY_PATH=../shared_files/ssas/public_test_signing_key.pem
       - SSAS_ADMIN_PORT=:3003
@@ -133,6 +140,8 @@ services:
       - SSAS_MFA_CHALLENGE_REQUEST_MILLISECONDS=0
       - SSAS_MFA_TOKEN_TIMEOUT_MINUTES=60
       - SSAS_MFA_PROVIDER=${SSAS_MFA_PROVIDER}
+      - SSAS_URL=${SSAS_URL}
+      - SSAS_PUBLIC_URL=${SSAS_PUBLIC_URL}
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     ports:

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -199,12 +199,12 @@ func cascadeDeleteGroup(group Group) error {
 }
 
 type GroupData struct {
-	ID        string     `json:"id"`
-	Name      string     `json:"name"`
-	Users     []string   `json:"users"`
-	Scopes    []string   `json:"scopes"`
-	System    System     `gorm:"foreignkey:GroupID;association_foreignkey:GroupID" json:"system"`
-	Resources []Resource `json:"resources"`
+	ID        string      `json:"id"`
+	Name      string      `json:"name"`
+	Users     []string    `json:"users"`
+	Scopes    []string    `json:"scopes"`
+	System    System      `gorm:"foreignkey:GroupID;association_foreignkey:GroupID" json:"system"`
+	Resources []Resource  `json:"resources"`
 }
 
 // Make the GroupData struct implement the driver.Valuer interface. This method
@@ -228,4 +228,17 @@ type Resource struct {
 	ID     string   `json:"id"`
 	Name   string   `json:"name"`
 	Scopes []string `json:"scopes"`
+}
+
+func FindByGroupID(groupID string) (Group, error){
+	db := GetGORMDbConnection()
+	defer Close(db)
+
+	group := Group{GroupID:groupID}
+	err := db.Find(&group).Error
+	if err != nil {
+		return group, err
+	}
+
+	return group, nil
 }

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/CMSgov/bcda-app/ssas"
 	"github.com/go-chi/chi"
 	"github.com/pborman/uuid"
+
+	"github.com/CMSgov/bcda-app/ssas"
 )
 
 func createGroup(w http.ResponseWriter, r *http.Request) {

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -1,18 +1,36 @@
 package admin
 
 import (
+	"fmt"
+	"os"
+	"time"
+
 	"github.com/go-chi/chi"
+
+	"github.com/CMSgov/bcda-app/ssas/service"
 )
 
-var Version = "latest"
-var InfoMap = map[string][]string{}
+var version = "latest"
+var infoMap map[string][]string
+var adminSigningKeyPath string
+var server *service.Server
 
 func init() {
-	InfoMap = make(map[string][]string)
-	InfoMap["admin"] = []string{"system", "group"}
+	infoMap = make(map[string][]string)
+	adminSigningKeyPath = os.Getenv("SSAS_ADMIN_SIGNING_KEY_PATH")
 }
 
-func Routes() *chi.Mux {
+func Server() *service.Server {
+	server = service.NewServer("admin", ":3004", version, infoMap, routes(), true, adminSigningKeyPath, 20 * time.Minute)
+	if server != nil {
+		r, _ := server.ListRoutes()
+		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "admin", ":3004")}
+		infoMap["routes"] = r
+	}
+	return server
+}
+
+func routes() *chi.Mux {
 	r := chi.NewRouter()
 	r.Post("/group", createGroup)
 	r.Get("/group", listGroups)

--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -18,7 +18,7 @@ type RouterTestSuite struct {
 }
 
 func (s *RouterTestSuite) SetupTest() {
-	s.router = Routes()
+	s.router = routes()
 }
 
 func (s *RouterTestSuite) TestPostGroup() {

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -16,7 +16,6 @@ import (
 var startMeUp bool
 var migrateAndStart bool
 var unsafeMode bool
-var adminSigningKeyPath string
 
 func init() {
 	const usageStart = "start the service"

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-chi/chi"
 
 	"github.com/CMSgov/bcda-app/ssas"
-	"github.com/CMSgov/bcda-app/ssas/service"
 	"github.com/CMSgov/bcda-app/ssas/service/admin"
 	"github.com/CMSgov/bcda-app/ssas/service/public"
 )
@@ -27,7 +26,6 @@ func init() {
 	flag.BoolVar(&migrateAndStart, "migrate", false, usageMigrate)
 	flag.BoolVar(&migrateAndStart, "m", false, usageMigrate+" (shorthand)")
 	unsafeMode = os.Getenv("HTTP_ONLY") == "true"
-	adminSigningKeyPath = os.Getenv("SSAS_ADMIN_SIGNING_KEY_PATH")
 }
 
 func main() {
@@ -48,24 +46,23 @@ func main() {
 func start() {
 	ssas.Logger.Infof("%s", "Starting ssas...")
 
-	ps, err := public.MakeServer()
-	if err != nil {
-		ssas.Logger.Fatalf("unable to start public server because %s", err.Error())
+	ps := public.Server()
+	if ps == nil {
+		ssas.Logger.Error("unable to create public server")
+		os.Exit(-1)
 	}
-
 	ps.LogRoutes()
 	ps.Serve()
 
-	as := service.NewServer("admin", ":3004", admin.Version, admin.InfoMap, admin.Routes(), unsafeMode)
-	// the signing key is separate from the [future] cert / private key used for https or tls or whatever
-	if err := as.SetSigningKeys(adminSigningKeyPath); err != nil {
-		ssas.Logger.Fatalf("unable to get signing key for admin server because %s; can't start", err.Error())
+	as := admin.Server()
+	if as == nil {
+		ssas.Logger.Error("unable to create admin server")
+		os.Exit(-1)
 	}
-
 	as.LogRoutes()
 	as.Serve()
 
-	// Accepts and redirects HTTP requests to HTTPS.
+	// Accepts and redirects HTTP requests to HTTPS. Not sure we should do this.
 	forwarder := &http.Server{
 		Handler:      newForwardingRouter(),
 		Addr:         ":3005",

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -183,7 +183,7 @@ func addRegDataContext(req *http.Request, groupID string, groupIDs []string) *ht
 }
 
 func (s *APITestSuite) TestTokenSuccess() {
-	groupID := "T0007"
+	groupID := ssas.RandomHexID()[0:4]
 	group := ssas.Group{GroupID: groupID}
 	err := s.db.Create(&group).Error
 	if err != nil {
@@ -214,6 +214,58 @@ func (s *APITestSuite) TestTokenSuccess() {
 	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
 	assert.NotEmpty(s.T(), t)
 	assert.NotEmpty(s.T(), t.AccessToken)
+
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestIntrospectSuccess() {
+	groupID := ssas.RandomHexID()[0:4]
+
+	group := ssas.Group{GroupID: groupID}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	_, pubKey, err := ssas.GenerateTestKeys(2048)
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+	creds, err := ssas.RegisterSystem("Introspect Test", groupID, ssas.DefaultScope, pemString, uuid.NewRandom().String())
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), "Introspect Test", creds.ClientName)
+	assert.NotNil(s.T(), creds.ClientSecret)
+
+	_ = Server()
+	req := httptest.NewRequest("POST", "/token", nil)
+	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
+	req.Header.Add("Accept", "application/json")
+	handler := http.HandlerFunc(token)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	t := TokenResponse{}
+	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
+	assert.NotEmpty(s.T(), t)
+	assert.NotEmpty(s.T(), t.AccessToken)
+
+	body := strings.NewReader(fmt.Sprintf(`{"token":"%s"}`, t.AccessToken))
+	req = httptest.NewRequest("POST", "/introspect", body)
+	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	handler = http.HandlerFunc(introspect)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+
+	var v map[string]bool
+	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&v))
+	assert.NotEmpty(s.T(), v)
+	assert.True(s.T(), v["active"])
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -203,7 +203,7 @@ func (s *APITestSuite) TestTokenSuccess() {
 	assert.Equal(s.T(), "Token Test", creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
-	_, _ = MakeServer()
+	_ = Server()
 	req := httptest.NewRequest("POST", "/token", nil)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
 	req.Header.Add("Accept", "application/json")

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -1,7 +1,9 @@
 package public
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-chi/chi"
 
@@ -15,17 +17,17 @@ var server *service.Server
 
 func init() {
 	infoMap = make(map[string][]string)
-	infoMap["public"] = []string{"token", "register", "authn/challenge", "authn/verify"}
 	publicSigningKeyPath = os.Getenv("SSAS_PUBLIC_SIGNING_KEY_PATH")
 }
 
-func MakeServer() (*service.Server, error) {
-	server = service.NewServer("public", ":3003", version, infoMap, routes(), true)
-	// the signing key is separate from the [future] cert / private key used for https or tls or whatever
-	if err := server.SetSigningKeys(publicSigningKeyPath); err != nil {
-		return &service.Server{}, err
+func Server() (*service.Server) {
+	server = service.NewServer("public", ":3003", version, infoMap, routes(), true, publicSigningKeyPath, 20 * time.Minute)
+	if server != nil {
+		r, _ := server.ListRoutes()
+		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "public", ":3003")}
+		infoMap["routes"] = r
 	}
-	return server, nil
+	return server
 }
 
 func routes() *chi.Mux {

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -33,7 +33,7 @@ func Server() (*service.Server) {
 func routes() *chi.Mux {
 	router := chi.NewRouter()
 	router.Use(service.NewAPILogger(), service.ConnectionClose)
-	router.Get("/token", token)
+	router.Post("/token", token)
 	router.Post("/authn", VerifyPassword)
 	router.With(parseToken, requireMFATokenAuth).Post("/authn/challenge", RequestMultifactorChallenge)
 	router.With(parseToken, requireMFATokenAuth).Post("/authn/verify", VerifyMultifactorResponse)

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -34,6 +34,7 @@ func routes() *chi.Mux {
 	router := chi.NewRouter()
 	router.Use(service.NewAPILogger(), service.ConnectionClose)
 	router.Post("/token", token)
+	router.Post("/introspect", introspect)
 	router.Post("/authn", VerifyPassword)
 	router.With(parseToken, requireMFATokenAuth).Post("/authn/challenge", RequestMultifactorChallenge)
 	router.With(parseToken, requireMFATokenAuth).Post("/authn/verify", VerifyMultifactorResponse)

--- a/ssas/service/public/router_test.go
+++ b/ssas/service/public/router_test.go
@@ -65,7 +65,7 @@ func (s *PublicRouterTestSuite) reqPublicRoute(verb string, route string, body i
 }
 
 func (s *PublicRouterTestSuite) TestTokenRoute() {
-	res := s.reqPublicRoute("GET", "/token", nil, "")
+	res := s.reqPublicRoute("POST", "/token", nil, "")
 	assert.Equal(s.T(), http.StatusBadRequest, res.StatusCode)
 }
 

--- a/ssas/service/public/tokens_test.go
+++ b/ssas/service/public/tokens_test.go
@@ -1,12 +1,13 @@
 package public
 
 import (
-	"github.com/CMSgov/bcda-app/ssas/service"
-	"github.com/go-chi/chi"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/CMSgov/bcda-app/ssas/service"
 )
 
 type PublicTokenTestSuite struct {
@@ -17,7 +18,7 @@ type PublicTokenTestSuite struct {
 func (s *PublicTokenTestSuite) SetupSuite() {
 	info := make(map[string][]string)
 	info["public"] = []string{"token", "register"}
-	s.server = service.NewServer("test-server", ":9999", "9.99.999", info, chi.NewRouter(), true)
+	s.server = Server()
 	err := os.Setenv("DEBUG", "true")
 	assert.Nil(s.T(), err)
 }

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -3,7 +3,6 @@ package service
 import (
 	"crypto/rsa"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -67,18 +66,6 @@ func NewServer(name, port, version string, info interface{}, routes *chi.Mux, no
 	}
 
 	return &s
-}
-
-// TODO remove after refactoring public side
-// SetSigningKey sets the RSA key to be used by this server for signing tokens
-func (s *Server) setSigningKey(privateKeyPath string) error {
-	var err error
-	if s.tokenSigningKey, err = getPrivateKey(privateKeyPath); err != nil {
-		msg := fmt.Sprintf("bad signing key; path %s; %v", privateKeyPath, err)
-		ssas.Logger.Info(msg)
-		return errors.New(msg)
-	}
-	return nil
 }
 
 func (s *Server) ListRoutes() ([]string, error) {
@@ -200,8 +187,6 @@ func ConnectionClose(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-var ttlScale = time.Minute
 
 // CommonClaims contains the superset of claims that may be found in the token
 type CommonClaims struct {

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -20,7 +19,7 @@ import (
 	"github.com/CMSgov/bcda-app/ssas/cfg"
 )
 
-// A Server defines the configuration of an SSAS server
+// Server configures and provisions an SSAS server
 type Server struct {
 	name string
 	// port server is running on; must have leading :, as in ":3000"
@@ -28,71 +27,90 @@ type Server struct {
 	// version of code running this server
 	version string
 	// info contains json metadata about server
-	info   interface{}
+	info interface{}
+	// router associates handlers to server endpoints
 	router chi.Router
-	// when true, not running in http mode   // TODO set this from HTTP_ONLY envv
-	notSecure         bool
-	srvr              http.Server
-	privateSigningKey *rsa.PrivateKey
-	tokenTTL          time.Duration
+	// notSecure flag; when true, not running in https mode   // TODO set this from HTTP_ONLY envv
+	notSecure       bool
+	tokenSigningKey *rsa.PrivateKey
+	tokenTTL        time.Duration
+	server          http.Server
 }
 
-// NewServer initializes an instance of the Server type. Subsequent to initialization, a signing key
-// must be assigned to the server.
-func NewServer(name, port, version string, info interface{}, routes *chi.Mux, notSecure bool) *Server {
+// NewServer correctly initializes an instance of the Server type.
+func NewServer(name, port, version string, info interface{}, routes *chi.Mux, notSecure bool, signingKeyPath string, ttl time.Duration) *Server {
+	sk, err := getPrivateKey(signingKeyPath);
+	if err != nil {
+		msg := fmt.Sprintf("bad signing key; path %s; %v", signingKeyPath, err)
+		ssas.Logger.Info(msg)
+		return nil
+	}
+
 	s := Server{}
 	s.name = name
 	s.port = port
 	s.version = version
 	s.info = info
 	s.router = s.newBaseRouter()
-	s.router.Mount("/", routes)
+	if routes != nil {
+		s.router.Mount("/", routes)
+	}
 	s.notSecure = notSecure
-	s.srvr = http.Server{
+	s.tokenSigningKey = sk
+	s.tokenTTL = ttl
+	s.server = http.Server{
 		Handler:      s.router,
 		Addr:         s.port,
 		ReadTimeout:  time.Duration(cfg.GetEnvInt("SSAS_READ_TIMEOUT", 10)) * time.Second,
 		WriteTimeout: time.Duration(cfg.GetEnvInt("SSAS_WRITE_TIMEOUT", 20)) * time.Second,
 		IdleTimeout:  time.Duration(cfg.GetEnvInt("SSAS_IDLE_TIMEOUT", 120)) * time.Second,
 	}
-	s.initTokenDuration()
+
 	return &s
 }
 
-// SetSigningKeys sets the RSA key pair to be used by this server for signing tokens
-func (s *Server) SetSigningKeys(privateKeyPath string) error {
+// TODO remove after refactoring public side
+// SetSigningKey sets the RSA key to be used by this server for signing tokens
+func (s *Server) setSigningKey(privateKeyPath string) error {
 	var err error
-	if s.privateSigningKey, err = getPrivateKey(privateKeyPath); err != nil {
-		msg := fmt.Sprintf("bad signing key;fpath %s; %v", privateKeyPath, err)
+	if s.tokenSigningKey, err = getPrivateKey(privateKeyPath); err != nil {
+		msg := fmt.Sprintf("bad signing key; path %s; %v", privateKeyPath, err)
 		ssas.Logger.Info(msg)
 		return errors.New(msg)
 	}
 	return nil
 }
 
+func (s *Server) ListRoutes() ([]string, error) {
+	var routes []string
+	walker := func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+		routes = append(routes, fmt.Sprintf("%s %s", method, route))
+		return nil
+	}
+	err := chi.Walk(s.router, walker)
+	return routes, err
+}
+
 // LogRoutes reports the routes supported by this server to the active log. Code is based on an example
 // from https://itnext.io/structuring-a-production-grade-rest-api-in-golang-c0229b3feedc
 func (s *Server) LogRoutes() {
-	routes := fmt.Sprintf("Routes for %s at port %s: ", s.name, s.port)
-	walker := func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
-		routes = fmt.Sprintf("%s %s %s, ", routes, method, route)
-		return nil
+	banner := fmt.Sprintf("Routes for %s at port %s: ", s.name, s.port)
+	routes, err := s.ListRoutes()
+	if err != nil {
+		ssas.Logger.Infof("%s routing error: %v", banner, err)
 	}
-	if err := chi.Walk(s.router, walker); err != nil {
-		ssas.Logger.Fatalf("bad route: %s", err.Error())
-	}
-	ssas.Logger.Infof(routes)
+	ssas.Logger.Infof("%s %v", banner, routes)
 }
 
 // Serve starts the server listening for and responding to requests.
 func (s *Server) Serve() {
 	if s.notSecure {
 		ssas.Logger.Infof("starting %s server running UNSAFE http only mode; do not do this in production environments", s.name)
-		go func() { log.Fatal(s.srvr.ListenAndServe()) }()
+		go func() { log.Fatal(s.server.ListenAndServe()) }()
 	} else {
-		tlsCertPath := os.Getenv("BCDA_TLS_CERT") // borrowing for now; we need to get our own
+		tlsCertPath := os.Getenv("BCDA_TLS_CERT") // borrowing for now; we need to get our own (for both servers?)
 		tlsKeyPath := os.Getenv("BCDA_TLS_KEY")
-		go func() { log.Fatal(s.srvr.ListenAndServeTLS(tlsCertPath, tlsKeyPath)) }()
+		go func() { log.Fatal(s.server.ListenAndServeTLS(tlsCertPath, tlsKeyPath)) }()
 	}
 }
 
@@ -131,7 +149,7 @@ func (s *Server) getHealthCheck(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, m)
 }
 
-// is this the right health check for this service? the db could be up but the service down
+// is this the right health check for a service? the db could be up but the service down
 // is there any condition under which the server could be running but become invalid?
 // is there any circumstance where the server could be partially disabled? (e.g., unable to sign tokens but still running)
 // could less than 3 servers be running?
@@ -139,6 +157,7 @@ func (s *Server) getHealthCheck(w http.ResponseWriter, r *http.Request) {
 func doHealthCheck() bool {
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
 	if err != nil {
+		// TODO health check failed event
 		ssas.Logger.Error("health check: database connection error: ", err.Error())
 		return false
 	}
@@ -158,7 +177,7 @@ func doHealthCheck() bool {
 }
 
 // This method gets the private key from the file system. Given that the server is completely unable to fulfill its
-// purpose without a signing key, it will panic and bubble up an error if the file is not present or not readable.
+// purpose without a signing key, a server should be considered invalid if it this function returns an error.
 func getPrivateKey(keyPath string) (*rsa.PrivateKey, error) {
 	keyData, err := ssas.ReadPEMFile(keyPath)
 	if err != nil {
@@ -167,14 +186,14 @@ func getPrivateKey(keyPath string) (*rsa.PrivateKey, error) {
 	return ssas.ReadPrivateKey(keyData)
 }
 
-// NYI provides a convenient handler for endpoints that are not yet implemented
+// NYI provides a convenience handler for endpoints that are not yet implemented
 func NYI(w http.ResponseWriter, r *http.Request) {
 	response := make(map[string]string)
 	response["msg"] = "Not Yet Implemented"
 	render.JSON(w, r, response)
 }
 
-// ConnectionClose provides a convenience function for closing http.Handlers
+// ConnectionClose provides a convenience handler for closing the http connection
 func ConnectionClose(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Connection", "close")
@@ -218,7 +237,7 @@ func (s *Server) mintToken(claims CommonClaims, issuedAt int64, expiresAt int64)
 	claims.IssuedAt = issuedAt
 	claims.ExpiresAt = expiresAt
 	token.Claims = claims
-	var signedString, err = token.SignedString(s.privateSigningKey)
+	var signedString, err = token.SignedString(s.tokenSigningKey)
 	if err != nil {
 		ssas.TokenMintingFailure(ssas.Event{TokenID: tokenID})
 		ssas.Logger.Errorf("token signing error %s", err)
@@ -232,30 +251,13 @@ func newTokenID() string {
 	return uuid.NewRandom().String()
 }
 
-// initTokenDuration sets (again) the tokenTTL from the JWT_EXPIRATION_DELTA environment variable. This function
-// should only be used for initialization or testing; we don't support changing the ttl during runtime
-func (s *Server) initTokenDuration() {
-	s.tokenTTL = time.Hour
-	if ttl := os.Getenv("SSAS_TOKEN_TTL_IN_MINUTES"); ttl != "" {
-		var (
-			n   int
-			err error
-		)
-		if n, err = strconv.Atoi(ttl); err == nil {
-			s.tokenTTL = ttlScale * time.Duration(n)
-			ssas.Logger.Infof("set token duration from env var value %s", ttl)
-		}
-	}
-	ssas.Logger.Infof("Token ttl is %d minutes", s.tokenTTL/ttlScale)
-}
-
 func (s *Server) VerifyToken(tokenString string) (*jwt.Token, error) {
 
 	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
-		return &s.privateSigningKey.PublicKey, nil
+		return &s.tokenSigningKey.PublicKey, nil
 	}
 
 	return jwt.ParseWithClaims(tokenString, &CommonClaims{}, keyFunc)
@@ -275,3 +277,4 @@ func (s *Server) CheckRequiredClaims(claims *CommonClaims, RequiredTokenType str
 
 	return nil
 }
+

--- a/ssas/service/server_test.go
+++ b/ssas/service/server_test.go
@@ -41,7 +41,7 @@ func (s *ServerTestSuite) TestNewServer() {
 
 	r := chi.NewRouter()
 	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("test"))
+		_, _ = w.Write([]byte("test"))
 	})
 	ts := NewServer("test-server", ":9999", "9.99.999", s.info, r, true, unitSigningKeyPath, 37 * time.Minute)
 	assert.NotEmpty(s.T(), ts.router)

--- a/ssas/service/server_test.go
+++ b/ssas/service/server_test.go
@@ -1,10 +1,11 @@
 package service
 
 import (
-	"os"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -14,29 +15,60 @@ const unitSigningKeyPath string = "../../shared_files/ssas/unit_test_private_key
 type ServerTestSuite struct {
 	suite.Suite
 	server *Server
+	info map[string][]string
 }
 
 func (s *ServerTestSuite) SetupSuite() {
-	info := make(map[string][]string)
-	info["public"] = []string{"token", "register"}
-	s.server = NewServer("test-server", ":9999", "9.99.999", info, s.server.newBaseRouter(), true)
+	s.info = make(map[string][]string)
+	s.info["public"] = []string{"token", "register"}
 }
 
-func (s *ServerTestSuite) TestSetSigningKeys() {
-	err := s.server.SetSigningKeys("")
-	assert.NotNil(s.T(), err)
-	assert.Contains(s.T(), err.Error(), "bad signing key", "testing bad key")
+func (s *ServerTestSuite) SetupTest() {
+	s.server = NewServer("test-server", ":9999", "9.99.999", s.info, nil, true, unitSigningKeyPath, 37 * time.Minute)
+}
 
-	err = s.server.SetSigningKeys(unitSigningKeyPath)
+func (s *ServerTestSuite) TestNewServer() {
+	assert.NotNil(s.T(), s.server)
+	assert.NotNil(s.T(), s.server.tokenSigningKey)
+	assert.NotEmpty(s.T(), s.server.name)
+	assert.NotEmpty(s.T(), s.server.port)
+	assert.NotEmpty(s.T(), s.server.version)
+	assert.NotEmpty(s.T(), s.server.info)
+	assert.NotEmpty(s.T(), s.server.router)
+	assert.True(s.T(), s.server.notSecure)
+	assert.NotNil(s.T(), s.server.tokenSigningKey)
+	assert.NotZero(s.T(), s.server.tokenTTL)
+
+	r := chi.NewRouter()
+	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test"))
+	})
+	ts := NewServer("test-server", ":9999", "9.99.999", s.info, r, true, unitSigningKeyPath, 37 * time.Minute)
+	assert.NotEmpty(s.T(), ts.router)
+	routes, err := ts.ListRoutes()
 	assert.Nil(s.T(), err)
-	assert.NotNil(s.T(), s.server.privateSigningKey)
+	assert.NotNil(s.T(), routes)
+	expected := []string{"GET /_health", "GET /_info", "GET /_version", "GET /*/test"}
+	assert.Equal(s.T(), expected, routes)
 }
 
-func (s *ServerTestSuite) TestTokenDurationDefault() {
-	assert.NotEmpty(s.T(), s.server.tokenTTL)
-	assert.Equal(s.T(), s.server.tokenTTL, time.Hour)
+// test Server() ? how????
+
+// test getInfo(), getVersion(), getHealthCheck()
+
+// test NYI()
+
+// test ConnectionClose()
+
+// MintToken(), MintTokenWithDuration(), mintToken()
+
+func (s *ServerTestSuite) TestNewServerWithBadSigningKey() {
+	ts := NewServer("test-server", ":9999", "9.99.999", s.info, nil, true, "", 37 * time.Minute)
+	assert.Nil(s.T(), ts)
 }
 
+// TODO belongs in public and admin server testing
+/*
 func (s *ServerTestSuite) TestTokenDurationOverride() {
 	originalValue := os.Getenv("SSAS_TOKEN_TTL_IN_MINUTES")
 	assert.NotEmpty(s.T(), s.server.tokenTTL)
@@ -54,23 +86,7 @@ func (s *ServerTestSuite) TestTokenDurationEmptyOverride() {
 	s.server.initTokenDuration()
 	assert.Equal(s.T(), time.Hour, s.server.tokenTTL)
 }
-
-func (s *ServerTestSuite) TestUnavailableSigner() {
-	acoUUID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
-	token, ts, err := s.server.MintToken(CommonClaims{ACOID: acoUUID})
-
-	assert.Nil(s.T(), err)
-	assert.NotNil(s.T(), token)
-	assert.NotNil(s.T(), ts)
-
-	s.server.privateSigningKey = nil
-	defer func() {
-		_ = s.server.SetSigningKeys(unitSigningKeyPath)
-	}()
-	assert.Panics(s.T(), func() {
-		_, _, _ = s.server.MintToken(CommonClaims{ACOID: acoUUID})
-	})
-}
+*/
 
 func TestServerTestSuite(t *testing.T) {
 	suite.Run(t, new(ServerTestSuite))

--- a/ssas/testutils.go
+++ b/ssas/testutils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 )
@@ -26,3 +27,29 @@ func GeneratePublicKey(bits int) (string, error) {
 
 	return string(publicKeyBytes), nil
 }
+
+func RandomHexID() string {
+	b, err := someRandomBytes(4)
+	if err != nil {
+		return "not_a_random_client_id"
+	}
+	return fmt.Sprintf("%x", b)
+}
+
+func RandomBase64(n int) string {
+	b, err := someRandomBytes(20)
+	if err != nil {
+		return "not_a_random_base_64_string"
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+func someRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+


### PR DESCRIPTION
### Fixes [BCDA-1535](https://jira.cms.gov/browse/BCDA-1535), [BCDA-1538](https://jira.cms.gov/browse/BCDA-1538)

Adds implementations of BCDA auth provider methods for MakeAccessToken() and VerifyToken().

### Proposed changes:

BCDA's auth process, when using the BCDA_AUTH_PROVIDER named 'ssas', makes calls to SSAS.
1) MakeAccessToken() calls /token on SSAS's public port, using the SSAS client. The token endpoint requires authorization.
2) VerifyToken() calls /introspect on SSAS's public port, using the SSAS client. The introspect endpoint requires authorization, and only returns a true / false response indicating whether the provided token is valid or not.

### Security Implications
This work is addressed in SIA's currently being drafted. The code is entirely protected by a feature flag in BCDA that must be set at compile time. Further, the SSAS server itself is not built or deployed anywhere except in local test docker containers.
When reviewing, please consider the following:
- Is token generation protected correctly?
- Is the BCDA client in bcda-app/bcda/auth/client/ssas.go secure and well-behaved?
- Is the introspect endpoint protected correctly?
- Should the introspect endpoint allow the token holder to use it? It currently does. The endpoint does not return any information about the token, only a true / false response indicating whether it is valid or not.

### Acceptance Validation

1) All current tests pass and additional tests pass.
2) If you enable the SSAS provider in BCDA, BCDA will successfully get and verify tokens.

<img width="1187" alt="Screen Shot 2019-08-07 at 5 39 44 AM" src="https://user-images.githubusercontent.com/14351382/62716595-a33bad00-b9bf-11e9-93b5-02f7d846c5ce.png">

If you want to run it end-to-end, follow these [painstaking] steps:

docker-compose up -d db
docker-compose up ssas

1) (SSAS) create group_id `bcda-admin`
2) (SSAS) register system for `bcda-admin`
3) set env vars: 
	BCDA_AUTH_PROVIDER=ssas
	SSAS_PUBLIC_URL=http://ssas:3003
	SSAS_URL=http://ssas:3004
	BCDA_SSAS_CLIENT_ID=(from 2)
	BCDA_SSAS_SECRET=(from 2)

docker-compose up

4) (SSAS) create group_id `0c527d2e-2e8a-4808-b11d-0fa06baf8254` (aco id for dev)
5) (SSAS) register system
6) (BCDA) using creds from 5), get token from bcda via postman
7) (BCDA) using token from 6), make request to EOB via postman

Step 7 will fail until BCDA-1537 is checked in.

### Feedback Requested
All welcome.