### PR TITLE
BCDA-1661 Feature: Fix for local suppression test failures

### DIFF
--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -821,7 +821,7 @@ func (s *CLITestSuite) TestImportSuppressionDirectory() {
 	buf := new(bytes.Buffer)
 	s.testApp.Writer = buf
 
-	path := "../../shared_files/synthetic1800MedicareFiles/"
+	path := "../../shared_files/synthetic1800MedicareFiles/test/"
 
 	args := []string{"bcda", "import-suppression-directory", "--directory", path}
 	err := s.testApp.Run(args)


### PR DESCRIPTION
Fixes [BCDA-1661](https://jira.cms.gov/browse/BCDA-1661)

Problem:
Tests were failing locally due to a file being moved that shouldn't. 

Proposed changes:
The wrong directory was being passed into the import-suppression-directory cli command. Later in the method a call to reset files used the same path location essentially placing the synthetic file in a wrong location...which caused local test failures. 


Change Details:
bcda/bcdacli/cli_test.go - changed directory to actual location of synthetic suppression file


Security Implications:
This change does **not** deal with PII/PHI directly.
This change does **not** add new software dependencies
This change does **not** alter security controls or supporting software
This change does **not** introduce storage of new data

Acceptance Validation
Yes, local tests pass.

Screenshot:
<img width="1186" alt="Screen Shot 2019-08-08 at 1 31 18 PM" src="https://user-images.githubusercontent.com/42976557/62724488-186baa00-b9e1-11e9-803e-a0efaa161b49.png">

Feedback Requested:
Any and all