### PR TITLE
BCDA-1650 Feature: Align deletion threshold with env var

### DIFF
--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -60,8 +60,6 @@ type cclfFileValidator struct {
 	maxRecordLength  int
 }
 
-const deleteThresholdHr = 8
-
 func importCCLF0(fileMetadata *cclfFileMetadata) (map[string]cclfFileValidator, error) {
 	if fileMetadata == nil {
 		fmt.Println("File CCLF0 not found.")
@@ -568,7 +566,8 @@ func cleanupCCLF(cclfmap map[string][]*cclfFileMetadata) error {
 			if !cclf.imported {
 				// check the timestamp on the failed files
 				elapsed := time.Since(cclf.deliveryDate).Hours()
-				if int(elapsed) > deleteThresholdHr {
+				deleteThreshold := utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24)
+				if int(elapsed) > deleteThreshold {
 					err := os.Rename(cclf.filePath, newpath)
 					if err != nil {
 						errCount++

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -31,7 +31,6 @@ type suppressionFileMetadata struct {
 const (
 	headerCode        = "HDR_BENEDATASHR"
 	trailerCode       = "TRL_BENEDATASHR"
-	deleteThresholdHr = 8
 )
 
 func ImportSuppressionDirectory(filePath string) (success, failure, skipped int, err error) {
@@ -351,7 +350,8 @@ func cleanupSuppression(suppresslist []suppressionFileMetadata) error {
 		if !suppressionFile.imported {
 			// check the timestamp on the failed files
 			elapsed := time.Since(suppressionFile.deliveryDate).Hours()
-			if int(elapsed) > deleteThresholdHr {
+			deleteThreshold := utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24)
+			if int(elapsed) > deleteThreshold {
 				err := os.Rename(suppressionFile.filePath, newpath)
 				if err != nil {
 					errCount++


### PR DESCRIPTION
Fixes [BCDA-1650](https://jira.cms.gov/browse/BCDA-1650)

Problem:
Before this change, files were being deleted at a different time from our set ARCHIVE_THRESHOLD_HR env variable. This change makes our code more consistent and also stays inline with our security posture.

Proposed changes:
Changed the deletion threshold to match our env var ARCHIVE_THRESHOLD_HR.

Change Details:
bcda/cclf/cclf.go - changed to align with env variable
bcda/suppression/suppression.go  - changed to align with env variable

Security Implications:
This change does deal with PII/PHI directly. -This code will be responsible for deleting all cclf and suppression files from our system.
This change does **not** add new software dependencies
This change does **not** alter security controls or supporting software
This change does **not** introduce storage of new data
A security checklist has been completed for this change: https://confluence.cms.gov/pages/viewpage.action?spaceKey=BCDA&title=Sprint+4.4+ACO+API+-+Security+Checklist

Acceptance Validation:
Yes, all tests pass


Feedback Requested:
Any and all