### PR TITLE
BCDA-1490-b Feature: removed non-nullable constraint on import status field

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -391,7 +391,7 @@ type CCLFFile struct {
 	ACOCMSID        string    `gorm:"column:aco_cms_id"`
 	Timestamp       time.Time `gorm:"not null"`
 	PerformanceYear int       `gorm:"not null"`
-	ImportStatus    string    `gorm:"column:import_status;not null"`
+	ImportStatus    string    `gorm:"column:import_status"`
 }
 
 func (cclfFile *CCLFFile) Delete() error {
@@ -419,7 +419,7 @@ type SuppressionFile struct {
 	gorm.Model
 	Name         string    `gorm:"not null;unique"`
 	Timestamp    time.Time `gorm:"not null"`
-	ImportStatus string    `gorm:"column:import_status;not null"`
+	ImportStatus string    `gorm:"column:import_status"`
 }
 
 func (suppressionFile *SuppressionFile) Delete() error {

--- a/db/api.sql
+++ b/db/api.sql
@@ -41,7 +41,7 @@ create table cclf_files (
     aco_cms_id char(5),
     "timestamp" timestamp with time zone not null,
     performance_year integer not null,
-    import_status varchar not null,
+    import_status varchar,
     created_at timestamp with time zone not null default now(),
     updated_at timestamp with time zone not null default now(),
     deleted_at timestamp with time zone
@@ -75,7 +75,7 @@ create table suppression_files (
     id serial primary key,
     name varchar not null,
     "timestamp" timestamp with time zone not null,
-    import_status varchar not null,
+    import_status varchar,
     created_at timestamp with time zone not null default now(),
     updated_at timestamp with time zone not null default now(),
     deleted_at timestamp with time zone


### PR DESCRIPTION
Fixes [BCDA-1490](https://jira.cms.gov/browse/BCDA-1490)

Problem:
The additional import status field was originally non-nullable, but that presented complications for db migrations on existing rows. A default could have been used that set import statuses as a non-complete string but this is cleaner better solution.

Proposed changes:
Modified the import status field to nullable.

Change Details:
bcda/models/models.go - removed non-nullable constraint 
db/api.sql - removed non-nullable constraint


Security Implications:
This change will deal with PII/PHI directly. This code will set an import status for incoming cclf and suppression files.
This change does **not** add new software dependencies
This change does **not** alter security controls or supporting software
This change does **not** introduce storage of new data

A security checklist has been completed for this change:
https://confluence.cms.gov/pages/viewpage.action?spaceKey=BCDA&title=Sprint+4.4+ACO+API+-+Security+Checklist


Acceptance Validation:
Yes, all tests pass

Feedback Requested:
Any and all