### PR TITLE
BCDA-1541: add fixture data for local testing

### DIFF
--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -237,7 +237,12 @@ func (c *SSASClient) VerifyPublicToken(tokenString string) ([]byte, error) {
 	}
 
 	// TODO assuming auth is by self-management
-	req.SetBasicAuth(os.Getenv("BCDA_SSAS_CLIENT_ID"), os.Getenv("BCDA_SSAS_SECRET"))
+	clientID := os.Getenv("BCDA_SSAS_CLIENT_ID")
+	secret := os.Getenv("BCDA_SSAS_SECRET")
+	if clientID == "" || secret == "" {
+		return nil, errors.New("missing clientID or secret")
+	}
+	req.SetBasicAuth(clientID, secret)
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := c.Do(req)

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -23,6 +23,8 @@ var (
 	origSSASUseTLS         string
 	origSSASClientKeyFile  string
 	origSSASClientCertFile string
+	origSSASClientID       string
+	origSSASSecret         string
 )
 
 type SSASClientTestSuite struct {
@@ -35,6 +37,8 @@ func (s *SSASClientTestSuite) BeforeTest() {
 	origPublicURL = os.Getenv("SSAS_PUBLIC_URL")
 	origSSASClientKeyFile = os.Getenv("SSAS_CLIENT_KEY_FILE")
 	origSSASClientCertFile = os.Getenv("SSAS_CLIENT_CERT_FILE")
+	origSSASClientID = os.Getenv("BCDA_SSAS_CLIENT_ID")
+	origSSASSecret = os.Getenv("BCDA_SSAS_SECRET")
 }
 
 func (s *SSASClientTestSuite) AfterTest() {
@@ -43,6 +47,8 @@ func (s *SSASClientTestSuite) AfterTest() {
 	os.Setenv("SSAS_PUBLIC_URL", origPublicURL)
 	os.Setenv("SSAS_CLIENT_KEY_FILE", origSSASClientKeyFile)
 	os.Setenv("SSAS_CLIENT_CERT_FILE", origSSASClientCertFile)
+	os.Setenv("BCDA_SSAS_CLIENT_ID", origSSASClientID)
+	os.Setenv("BCDA_SSAS_SECRET", origSSASSecret)
 }
 
 func (s *SSASClientTestSuite) TestNewSSASClient_TLSFalse() {
@@ -255,6 +261,8 @@ func (s *SSASClientTestSuite) TestVerifyPublicToken() {
 	os.Setenv("SSAS_URL", server.URL)
 	os.Setenv("SSAS_PUBLIC_URL", server.URL)
 	os.Setenv("SSAS_USE_TLS", "false")
+	os.Setenv("BCDA_SSAS_CLIENT_ID", "happy")
+	os.Setenv("BCDA_SSAS_SECRET", "customer")
 
 	client, err := authclient.NewSSASClient()
 	if err != nil {

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -88,7 +88,7 @@ func (s *SuppressionTestSuite) TestImportSuppression() {
 	assert.Equal(fileTime.Format("010203040506"), suppressionFile.Timestamp.Format("010203040506"))
 
 	suppressions = []models.Suppression{}
-	db.Find(&suppressions, "file_id = ?", suppressionFile.ID)
+	db.Find(&suppressions, "file_id = ?", suppressionFile.ID).Order("created_at")
 	assert.Len(suppressions, 250)
 	assert.Equal("1000000019", suppressions[0].HICN)
 	assert.Equal("N", suppressions[0].PrefIndicator)

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -22,7 +22,8 @@ func init() {
 
 // Server creates an SSAS admin server
 func Server() *service.Server {
-	server = service.NewServer("admin", ":3004", version, infoMap, routes(), true, adminSigningKeyPath, 20*time.Minute)
+	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
+	server = service.NewServer("admin", ":3004", version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute)
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "admin", ":3004")}
@@ -33,6 +34,7 @@ func Server() *service.Server {
 
 func routes() *chi.Mux {
 	r := chi.NewRouter()
+	r.Use(service.NewAPILogger(), service.ConnectionClose)
 	r.Post("/group", createGroup)
 	r.Get("/group", listGroups)
 	r.Put("/group/{id}", updateGroup)

--- a/ssas/service/logging.go
+++ b/ssas/service/logging.go
@@ -1,4 +1,4 @@
-	package service
+package service
 
 import (
 	"fmt"

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -93,7 +93,7 @@ func addFixtureData() {
 	if err := db.Save(&ssas.Group{GroupID: "admin"}).Error; err != nil {
 		fmt.Println(err)
 	}
-	// group for cms_id A9994; aco_id 0c527d2e-2e8a-4808-b11d-0fa06baf8254
+	// group for cms_id A9994; client_id 0c527d2e-2e8a-4808-b11d-0fa06baf8254
 	if err := db.Save(&ssas.Group{GroupID: "0c527d2e-2e8a-4808-b11d-0fa06baf8254"}).Error; err != nil {
 		fmt.Println(err)
 	}

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -131,8 +131,7 @@ func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash string) 
 		Hash:     hash,
 		SystemID: system.ID,
 	}
-	err := db.Save(&secret).Error
-	if err != nil {
+	if err := db.Save(&secret).Error; err != nil {
 		ssas.Logger.Warn(err)
 	}
 }

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -2,20 +2,22 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/go-chi/chi"
+	"github.com/jinzhu/gorm"
 
 	"github.com/CMSgov/bcda-app/ssas"
+	"github.com/CMSgov/bcda-app/ssas/service"
 	"github.com/CMSgov/bcda-app/ssas/service/admin"
 	"github.com/CMSgov/bcda-app/ssas/service/public"
 )
 
 var startMeUp bool
 var migrateAndStart bool
-var unsafeMode bool
 
 func init() {
 	const usageStart = "start the service"
@@ -24,7 +26,6 @@ func init() {
 	const usageMigrate = "migrate the db and start the service"
 	flag.BoolVar(&migrateAndStart, "migrate", false, usageMigrate)
 	flag.BoolVar(&migrateAndStart, "m", false, usageMigrate+" (shorthand)")
-	unsafeMode = os.Getenv("HTTP_ONLY") == "true"
 }
 
 func main() {
@@ -35,6 +36,7 @@ func main() {
 			ssas.InitializeGroupModels()
 			ssas.InitializeSystemModels()
 			ssas.InitializeBlacklistModels()
+			addFixtureData()
 		}
 		start()
 	}
@@ -74,7 +76,7 @@ func start() {
 
 func newForwardingRouter() http.Handler {
 	r := chi.NewRouter()
-	// todo middleware logging
+	r.Use(service.NewAPILogger(), service.ConnectionClose)
 	r.Get("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// TODO only forward requests for paths in our own host or resource server
 		url := "https://" + req.Host + req.URL.String()
@@ -82,4 +84,55 @@ func newForwardingRouter() http.Handler {
 		http.Redirect(w, req, url, http.StatusMovedPermanently)
 	}))
 	return r
+}
+
+func addFixtureData() {
+	db := ssas.GetGORMDbConnection()
+	defer ssas.Close(db)
+
+	if err := db.Save(&ssas.Group{GroupID: "admin"}).Error; err != nil {
+		fmt.Println(err)
+	}
+	// group for cms_id A9994; aco_id 0c527d2e-2e8a-4808-b11d-0fa06baf8254
+	if err := db.Save(&ssas.Group{GroupID: "0c527d2e-2e8a-4808-b11d-0fa06baf8254"}).Error; err != nil {
+		fmt.Println(err)
+	}
+	makeSystem(db, "admin", "31e029ef-0e97-47f8-873c-0e8b7e7f99bf",
+		"BCDA API Admin", "bcda-admin",
+		"nbZ5oAnTlzyzeep46bL4qDGGuidXuYxs3xknVWBKjTI=:9s/Tnqvs8M7GN6VjGkLhCgjmS59r6TaVguos8dKV9lGqC1gVG8ywZVEpDMkdwOaj8GoNe4TU3jS+OZsK3kTfEQ==",
+	)
+	makeSystem(db, "0c527d2e-2e8a-4808-b11d-0fa06baf8254",
+		"0c527d2e-2e8a-4808-b11d-0fa06baf8254", "ACO Dev", "bcda-api",
+		"h5hF9cm0Wmm+ClnoF0+Dq5JCQFmDVtzAsaquigoYcTk=:mptcWsBLNYFylRT1q95brbfKiaQkUt8oZXml0EMXobghbVVewZeG40EfNqe10u1+RftftEMvzSCB/oG17MRpVA==")
+}
+
+func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash string) {
+	pem := `-----BEGIN PUBLIC KEY-----
+	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L
+	I8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK
+	/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL
+	cN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ
+	lT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI
+	XK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2
+	HwIDAQAB
+	-----END PUBLIC KEY-----`
+	system := ssas.System{GroupID: groupID, ClientID: clientID, ClientName: clientName, APIScope: scope}
+	if err := db.Save(&system).Error; err != nil {
+		ssas.Logger.Warn(err)
+	}
+	encryptionKey := ssas.EncryptionKey{
+		Body:     pem,
+		SystemID: system.ID,
+	}
+	if err := db.Save(&encryptionKey).Error; err != nil {
+		ssas.Logger.Warn(err)
+	}
+	secret := ssas.Secret{
+		Hash:     hash,
+		SystemID: system.ID,
+	}
+	err := db.Save(&secret).Error
+	if err != nil {
+		ssas.Logger.Warn(err)
+	}
 }

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -21,7 +21,8 @@ func init() {
 }
 
 func Server() (*service.Server) {
-	server = service.NewServer("public", ":3003", version, infoMap, routes(), true, publicSigningKeyPath, 20 * time.Minute)
+	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
+	server = service.NewServer("public", ":3003", version, infoMap, routes(), unsafeMode, publicSigningKeyPath, 20 * time.Minute)
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "public", ":3003")}

--- a/test/postman_test/1535-SSAS.postman_collection.json
+++ b/test/postman_test/1535-SSAS.postman_collection.json
@@ -1,0 +1,420 @@
+{
+	"info": {
+		"_postman_id": "46602b35-6ed4-4ebd-bbca-c426572f5c92",
+		"name": "SSAS",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "admin info",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3004/_info",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"_info"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "admin health",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3004/_health",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"_health"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "admin _version",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3004/_version",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"_version"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "admin create group",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{  \n\t\"id\":\"T0000\",\n\t\"name\":\"ACO Small\",\n\t\"users\":[  \n\t\t\"00uiqolo7fEFSfif70h7\",\n\t\t\"l0vckYyfyow4TZ0zOKek\",\n\t\t\"HqtEi2khroEZkH4sdIzj\"\n\t],\n\t\"resources\":[  \n\t\t{  \n\t\t\t\"id\":\"BCDA\",\n\t\t\t\"name\":\"BCDA API\",\n\t\t\t\"scopes\":[  \n\t\t\t\t\"bcda-api\"\n\t\t\t]\n\t\t}\n\t]\n}"
+				},
+				"url": {
+					"raw": "http://localhost:3004/group",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"group"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "admin create bcda-admin group",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{  \n\t\"id\":\"bcda-admin\",\n\t\"name\":\"BCDA Admin\",\n\t\"users\":[  \n\t\t\"00uiqolo7fEFSfif70h7\",\n\t\t\"l0vckYyfyow4TZ0zOKek\",\n\t\t\"HqtEi2khroEZkH4sdIzj\"\n\t],\n\t\"resources\":[  \n\t\t{  \n\t\t\t\"id\":\"BCDA\",\n\t\t\t\"name\":\"BCDA API\",\n\t\t\t\"scopes\":[  \n\t\t\t\t\"bcda-api\"\n\t\t\t]\n\t\t}\n\t]\n}"
+				},
+				"url": {
+					"raw": "http://localhost:3004/group",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"group"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "admin register",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"group_id\": \"T0000\",\n    \"client_name\": \"my sister's evil twin\",\n    \"scope\": \"bcda-api\",\n    \"public_key\": {\n        \"e\": \"AAEAAQ\",\n        \"n\": \"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw\",\n        \"kty\": \"RSA\"\n    },\n    \"tracking_id\": \"777\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:3004/system",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"system"
+					]
+				},
+				"description": "register a new system via POST /system"
+			},
+			"response": []
+		},
+		{
+			"name": "admin register bcda system",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"group_id\": \"T0000\",\n    \"client_name\": \"my sister's evil twin\",\n    \"scope\": \"bcda-api\",\n    \"public_key\": {\n        \"e\": \"AAEAAQ\",\n        \"n\": \"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw\",\n        \"kty\": \"RSA\"\n    },\n    \"tracking_id\": \"777\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:3004/system",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3004",
+					"path": [
+						"system"
+					]
+				},
+				"description": "register a new system via POST /system"
+			},
+			"response": []
+		},
+		{
+			"name": "public info",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3003/_info",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"_info"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "public health",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3003/_health",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"_health"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "public _version",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:3003/_version",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"_version"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "public authn",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"login_id\":\"{{login_id}}\",\"password\":\"{{password}}\"}"
+				},
+				"url": {
+					"raw": "http://localhost:3003/authn",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"authn"
+					]
+				},
+				"description": "Verify a username and password"
+			},
+			"response": []
+		},
+		{
+			"name": "public authn/challenge",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"login_id\":\"{{login_id}}\",\"factor_type\":\"{{factor_type}}\"}"
+				},
+				"url": {
+					"raw": "http://localhost:3003/authn/challenge",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"authn",
+						"challenge"
+					]
+				},
+				"description": "Request that an MFA challenge passcode be sent, for example, via SMS"
+			},
+			"response": []
+		},
+		{
+			"name": "public authn/verify",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"login_id\":\"{{login_id}}\",\"factor_type\":\"{{factor_type}}\",\"passcode\":\"{{passcode}}\"}"
+				},
+				"url": {
+					"raw": "http://localhost:3003/authn/verify",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"authn",
+						"verify"
+					]
+				},
+				"description": "Verify an MFA passcode"
+			},
+			"response": []
+		},
+		{
+			"name": "public register",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "x-group-id",
+						"value": "{{group_id}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"client_name\": \"My favorite name in all the world\",\n    \"scope\": \"bcda-api\",\n    \"jwks\": {\n        \"keys\": [\n            {\n                \"e\": \"AAEAAQ\",\n                \"n\": \"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw\",\n                \"kty\": \"RSA\"\n            }\n        ]\n    }\n}"
+				},
+				"url": {
+					"raw": "http://localhost:3003/register",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"register"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "public reset",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "x-group-id",
+						"type": "text",
+						"value": "T0001"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"client_id\":\"{{client_id}}\"}"
+				},
+				"url": {
+					"raw": "http://localhost:3003/reset",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3003",
+					"path": [
+						"reset"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "public token ",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": ""
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/postman_test/SSAS.postman_collection.json
+++ b/test/postman_test/SSAS.postman_collection.json
@@ -352,16 +352,19 @@
 			"response": []
 		},
 		{
-			"name": "admin get group, no groups",
+			"name": "admin get group, only fixture groups",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"id": "fc625fc2-e25e-4fd2-a110-fc1528839ca7",
 						"exec": [
-							"pm.test(\"response is 200 and no groups in response\", function () {",
+							"pm.test(\"response is 200 and only fixture groups in response\", function () {",
 							"    pm.response.to.have.status(200);",
-							"    pm.response.to.have.body(\"[]\");",
+							"    var jsonData = pm.response.json();",
+							"    pm.expect(jsonData.length).to.eql(2);",
+							"    pm.expect(jsonData[0].group_id).to.eql(\"admin\");",
+							"    pm.expect(jsonData[1].group_id).to.eql(\"0c527d2e-2e8a-4808-b11d-0fa06baf8254\");",
 							"});"
 						],
 						"type": "text/javascript"


### PR DESCRIPTION
### Fixes [BCDA-1541](https://jira.cms.gov/browse/BCDA-1541)

It's difficult to test end-to-end with SSAS because we don't have fixture data. This PR adds a tiny amount of fixture data to SSAS that matches the fixture data in BCDA for the A9994 ACO, which is used in integration testing.

### Proposed Changes

Adds two groups and two systems to support a bcda admin client and an API consumer client.

Because our tables are entirely built by GORM at the moment, I've added the fixtures via code in main.go. They are direct SQL updates because we need to retain fixed values in order to test with BCDA.

### Security Implications

This adds very minimal test-only data. There is no PII in the data; it's all fake. Its intended purpose is to support hand-testing while working on integration with BCDA, and possibly incorporated into postman or smoke tests.

- no new software dependencies
- no security controls or supporting software altered
- no new data stored or transmitted (this is not a new type of data)
- no security checklist is completed for this change

Included in the data are the client credentials for the two systems. The client secret is loaded as a hashed value. To use the credentials, reset the secret to something you know by posting to the admin system/{id}/credentials endpoint.

### Acceptance Validation

1. Nothing about BCDA is broken
2. When properly setup, you can do an end-to-end test of getting and verifying a token. That is, you can go from postman request -> bcda -> ssas -> bcda -> postman result.

### Feedback Requested

Any welcome.