### PR TITLE
BCDA-1723 Feature: SSAS CLI command reset-credentials

### DIFF
--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/pborman/uuid"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -21,8 +22,11 @@ var startMeUp bool
 var migrateAndStart bool
 var resetCreds bool
 var clientID string
+var output io.Writer
 
 func init() {
+	output = os.Stdout
+
 	const usageStart = "start the service"
 	flag.BoolVar(&startMeUp, "start", false, usageStart)
 	flag.BoolVar(&startMeUp, "s", false, usageStart+" (shorthand)")
@@ -159,6 +163,6 @@ func resetCredentials(clientID string) {
 	if c, err = s.ResetSecret(clientID); err != nil {
 		ssas.Logger.Warn(err)
 	} else {
-		fmt.Println(c.ClientSecret)
+		_, _ = fmt.Fprintf(output, "%s\n", c.ClientSecret)
 	}
 }

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -2,18 +2,45 @@ package main
 
 import (
 	"bytes"
-	"strings"
-	"testing"
-
 	"github.com/CMSgov/bcda-app/ssas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"io"
+	"testing"
 )
 
-func TestSSASMain(t *testing.T) {
+type MainTestSuite struct {
+	suite.Suite
+}
+
+func (s *MainTestSuite) TestResetCredentials() {
+	addFixtureData()
+	fixtureClientID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
+	output := captureOutput(func() {resetCredentials(fixtureClientID)})
+	assert.NotEqual(s.T(), "", output)
+}
+
+func (s *MainTestSuite) TestMainLog() {
 	var str bytes.Buffer
 	ssas.Logger.SetOutput(&str)
 	main()
-	s := str.String()
-	if !strings.Contains(s, "Future home of") {
-		t.Errorf("expected log containing 'Future home of'; got %s", s)
-	}
+	output := str.String()
+	assert.Contains(s.T(), output, "Future home of")
+}
+
+func TestMainTestSuite(t *testing.T) {
+	suite.Run(t, new(MainTestSuite))
+}
+
+func captureOutput(f func()) string {
+	var (
+		buf bytes.Buffer
+		outOrig io.Writer
+	)
+
+	outOrig = output
+	output = &buf
+	f()
+	output = outOrig
+	return buf.String()
 }


### PR DESCRIPTION
### Fixes [BCDA-1723](https://jira.cms.gov/browse/BCDA-1723)
During automated testing, the test suite(s) need to know administrative credentials for the BCDA system.  We don't want to publish these, even as part of fixture data.

Instead, following the pattern used in BCDA, we will reset these credentials from the `make` commands as needed during/before tests.  To do so, we need a `reset-credentials` CLI command in SSAS.  This PR provides that command.

### Proposed Changes
Add a SSAS CLI command `reset-credentials` that can be called as follows:
  `docker-compose run --rm ssas sh -c 'tmp/ssas-service --reset-credentials --client-id=[client_id]'`

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] No new software dependencies
- [ ] No security controls or supporting software altered
- [ ] No new data stored or transmitted
- [ ] No security checklist is completed for this change
- [X] Further discussion:
Risk: This new CLI command exercises a security feature: credential creation/rotation.  What if it got into the wrong hands?
Mitigation: It is accessible only at the command line, and therefore protected by all the OS, container, and AWS platform protections we already have in place.  Also, logs will show what clientID was used, and that it was called from the command line rather than one of our API endpoints).

### Acceptance Validation
(The last line of the screenshot below contains the new client secret)

<img width="1106" alt="Screen Shot 2019-08-23 at 3 32 18 PM" src="https://user-images.githubusercontent.com/2533561/63619121-cbc8c700-c5bb-11e9-8ee6-926f2e47963b.png">


### Feedback Requested
* This adds a minimal framework for a CLI with testable `stdout` output.  Is there anything else we _must_ add at the moment?
* All other suggestions welcome