### PR TITLE
BCDA-1877: SSAS: Add helpful CLI commands to simplify deployment

### DIFF
--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -18,4 +18,4 @@ RUN go install ./vendor/github.com/pressly/fresh
 RUN dep ensure
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app/ssas
-CMD ["fresh", "-o", "ssas-service", "-p", "./service/main", "-r", "--migrate"]
+CMD ["fresh", "-o", "ssas-service", "-p", "./service/main", "-r", "--migrate-and-start"]

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ smoke-test:
 
 # The following vars are available to tests needing SSAS admin credentials; currently they are used in smoke-test-ssas.
 SSAS_ADMIN_CLIENT_ID ?= 31e029ef-0e97-47f8-873c-0e8b7e7f99bf
-SSAS_ADMIN_CLIENT_SECRET := $(shell docker-compose run --rm ssas sh -c 'tmp/ssas-service --reset-credentials --client-id=$(SSAS_ADMIN_CLIENT_ID)'|tail -n1)
+SSAS_ADMIN_CLIENT_SECRET := $(shell docker-compose run --rm ssas sh -c 'tmp/ssas-service --reset-secret --client-id=$(SSAS_ADMIN_CLIENT_ID)'|tail -n1)
 smoke-test-ssas:
 	docker-compose -f docker-compose.test.yml run --rm postman_test test/postman_test/SSAS_Smoke_Test.postman_collection.json -e test/postman_test/ssas-local.postman_environment.json --global-var "token=$(token)" --global-var adminClientId=$(SSAS_ADMIN_CLIENT_ID) --global-var adminClientSecret=$(SSAS_ADMIN_CLIENT_SECRET)
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -61,6 +61,7 @@ func (s *APITestSuite) SetupSuite() {
 	ssas.InitializeGroupModels()
 	ssas.InitializeSystemModels()
 	s.db = ssas.GetGORMDbConnection()
+	service.StartBlacklist()
 }
 
 func (s *APITestSuite) TearDownSuite() {

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
-	"github.com/CMSgov/bcda-app/ssas"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/CMSgov/bcda-app/ssas"
 )
 
 type MainTestSuite struct {
@@ -16,12 +19,17 @@ type MainTestSuite struct {
 func (s *MainTestSuite) SetupSuite() {
 	ssas.InitializeGroupModels()
 	ssas.InitializeSystemModels()
+	addFixtureData()
 }
 
-func (s *MainTestSuite) TestResetCredentials() {
-	addFixtureData()
+func (s *MainTestSuite) TestResetSecret() {
 	fixtureClientID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
-	output := captureOutput(func() {resetCredentials(fixtureClientID)})
+	output := captureOutput(func() { resetSecret(fixtureClientID) })
+	assert.NotEqual(s.T(), "", output)
+}
+
+func (s *MainTestSuite) TestNewAdminSystem() {
+	output := captureOutput(func() { newAdminSystem("Main Test System") })
 	assert.NotEqual(s.T(), "", output)
 }
 
@@ -30,7 +38,53 @@ func (s *MainTestSuite) TestMainLog() {
 	ssas.Logger.SetOutput(&str)
 	main()
 	output := str.String()
-	assert.Contains(s.T(), output, "Future home of")
+	assert.Contains(s.T(), output, "Home of")
+}
+
+func (s *MainTestSuite) TestAddFixtureData() {
+	q := `select distinct g.id as gid, g.group_id, s.id as sid, s.client_name, ek.id as ekid, s.id as scrtid
+	from groups g
+	join systems s on g.group_id = s.group_id
+	join encryption_keys ek on ek.system_id = s.id
+	join secrets sc on sc.system_id = s.id
+	where g.group_id in ('admin', '0c527d2e-2e8a-4808-b11d-0fa06baf8254');`
+	// if you run the query above against the db, you will see a result like this:
+	// gid |               group_id               | sid |  client_name   | ekid | scrtid
+	// -----+--------------------------------------+-----+----------------+------+--------
+	// 15 | admin                                |  13 | BCDA API Admin |   13 |     13
+	// 16 | 0c527d2e-2e8a-4808-b11d-0fa06baf8254 |  14 | ACO Dev        |   14 |     14
+	// (2 rows)
+	//
+	// only complete fixture data will be included in the result
+
+	type result struct {
+		GID        uint		`json:"gid"`
+		GroupID    string	`json:"group_id"`
+		SID        uint		`json:"sid"`
+		ClientName string	`json:"client_name"`
+		EKID       uint		`json:"ekid"`
+		ScrtID     uint		`json:"scrtid"`
+	}
+	rows, err := ssas.GetGORMDbConnection().Raw(q).Rows()
+	require.Nil(s.T(), err, "error checking fixture data")
+	defer rows.Close()
+
+	foundAdmin := false
+	foundConsumer := false
+	for rows.Next() {
+		var r result
+		err := rows.Scan(&r.GID, &r.GroupID, &r.SID, &r.ClientName, &r.EKID, &r.ScrtID)
+		require.Nil(s.T(), err, "error scanning data")
+		switch r.GroupID {
+		case "admin":
+			foundAdmin = true
+		case "0c527d2e-2e8a-4808-b11d-0fa06baf8254":
+			foundConsumer = true
+		}
+	}
+
+	assert.True(s.T(), foundAdmin)
+	assert.True(s.T(), foundConsumer)
 }
 
 func TestMainTestSuite(t *testing.T) {
@@ -39,7 +93,7 @@ func TestMainTestSuite(t *testing.T) {
 
 func captureOutput(f func()) string {
 	var (
-		buf bytes.Buffer
+		buf     bytes.Buffer
 		outOrig io.Writer
 	)
 

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/CMSgov/bcda-app/ssas"
+	"github.com/CMSgov/bcda-app/ssas/service"
 
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ func (s *APITestSuite) SetupSuite() {
 	ssas.InitializeSystemModels()
 	s.db = ssas.GetGORMDbConnection()
 	_ = Server()
+	service.StartBlacklist()
 }
 
 func (s *APITestSuite) SetupTest() {

--- a/ssas/service/tokenblacklist.go
+++ b/ssas/service/tokenblacklist.go
@@ -23,11 +23,15 @@ func init() {
 	cacheCleanupInterval = time.Duration(cfg.GetEnvInt("SSAS_TOKEN_BLACKLIST_CACHE_CLEANUP_MINUTES", 15)) * time.Minute
 	TokenCacheLifetime	 = time.Duration(cfg.GetEnvInt("SSAS_TOKEN_BLACKLIST_CACHE_TIMEOUT_MINUTES", 60*24)) * time.Minute
 	cacheRefreshFreq	 = time.Duration(cfg.GetEnvInt("SSAS_TOKEN_BLACKLIST_CACHE_REFRESH_MINUTES", 5)) * time.Minute
+}
+
+// This function should only be called by main
+func StartBlacklist() {
 	NewBlacklist(defaultCacheTimeout, cacheCleanupInterval)
 }
 
-//	NewBlacklist allows for easy Blacklist{} creation and manipulation during testing, and should not be called
-//		outside a test suite
+//	NewBlacklist allows for easy Blacklist{} creation and manipulation during testing, and, outside a test suite,
+//	should not be called
 func NewBlacklist(cacheTimeout time.Duration, cleanupInterval time.Duration) *Blacklist {
 	// In case a Blacklist timer has already been started:
 	stopCacheRefreshTicker()


### PR DESCRIPTION
### Fixes [BCDA-1877](https://jira.cms.gov/browse/BCDA-1877)

Our current means of bootstrapping SSAS into docker does not work very for the AWS environments where the database is persistent. It also adds to the chicken and egg challenges of deploying a new system with dependencies for the first time. This PR adds commands to make it easier.

### Proposed Changes

Separate commands now exist to migrate the database, add fixture data, add new admin clients, reset secrets and start the service.

Also see the CLI section added to the ssas README.

### Security Implications

- No new software dependencies
- No security controls or supporting software altered
- No new data stored or transmitted
- No security checklist (other than this informal one)  is needed for this change
- Does not require more information or team discussion to evaluate security implications

### Acceptance Validation

All tests pass.
New test added for validating fixture data.
New tests added to test new commands.

### Feedback Requested

All feedback welcome.