### PR TITLE
BCDA-1945 Feature: changed synthetic creds for sandbox userguide

### DIFF
--- a/bcda-site-static/user_guide.md
+++ b/bcda-site-static/user_guide.md
@@ -80,7 +80,7 @@ Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOmY5NzgwZDMyMzU4OGYxY2RmYz
 
 ###### cURL command
 ``` sh
-curl -X POST "http://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+curl -X POST "https://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
 Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
 ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 ```

--- a/bcda-site-static/user_guide.md
+++ b/bcda-site-static/user_guide.md
@@ -50,21 +50,21 @@ To get a token that can be used with protected endpoints, `POST` the following c
 
 Client ID: 
 {%- capture client_id -%}
-09869a7f-46ce-4908-a914-6129d080a2ae
+3841c594-a8c0-41e5-98cc-38bb45360d3c
 {%- endcapture -%}
 
 {% include copy_snippet.md code=client_id %}
 
 Client Secret: 
 {%- capture client_secret -%}
-64916fe96f71adc79c5735e49f4e72f18ff941d0dd62cf43ee1ae0857e204f173ba10e4250c12c48
+f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
 {%- endcapture -%}
 
 {% include copy_snippet.md code=client_secret %}
 
 Encoded Basic authentication:
 {%- capture auth_header -%}
-Basic MDk4NjlhN2YtNDZjZS00OTA4LWE5MTQtNjEyOWQwODBhMmFlOjY0OTE2ZmU5NmY3MWFkYzc5YzU3MzVlNDlmNGU3MmYxOGZmOTQxZDBkZDYyY2Y0M2VlMWFlMDg1N2UyMDRmMTczYmExMGU0MjUwYzEyYzQ4
+Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOmY5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAyZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh
 {%- endcapture -%}
 
 {% include copy_snippet.md code=auth_header %}
@@ -80,9 +80,9 @@ Basic MDk4NjlhN2YtNDZjZS00OTA4LWE5MTQtNjEyOWQwODBhMmFlOjY0OTE2ZmU5NmY3MWFkYzc5Yz
 
 ###### cURL command
 ``` sh
-curl -X POST "http://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic MDk4NjlhN2YtNDZjZS00OTA4LWE5MTQtNjEyOWQwODBhMmFlOj\
-Y0OTE2ZmU5NmY3MWFkYzc5YzU3MzVlNDlmNGU3MmYxOGZmOTQx\
-ZDBkZDYyY2Y0M2VlMWFlMDg1N2UyMDRmMTczYmExMGU0MjUwYzEyYzQ4"
+curl -X POST "http://sandbox.bcda.cms.gov/auth/token" -H "accept: application/json" -H "authorization: Basic Mzg0MWM1OTQtYThjMC00MWU1LTk4Y2MtMzhiYjQ1MzYwZDNjOm\
+Y5NzgwZDMyMzU4OGYxY2RmYzNlNjNlOTVhOGNiZGNkZDQ3NjAy\
+ZmY0OGE1MzdiNTFkYzVkNzgzNGJmNDY2NDE2YTcxNmJkNDUwOGU5MDRh"
 ```
 
 ##### Response


### PR DESCRIPTION
Fixes [BCDA-1945](https://jira.cms.gov/browse/BCDA-1945)

Problem:
After deploying a new release we have to update our synthetic credentials for our sandbox users. This change will display the new **synthetic** client id and client secret credentials on our sandbox UG.

Proposed Changes:
Update to user guide sections involving synthetic credentials.

Change Details:
bcda-site-static/user_guide.md - changed synthetic credentials.

Security Implications:
No, this change does not deal with any PII/PHI. This is only a visual update to our user guide to match our synthetic system credentials.

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation
Yes, tested new creds and they work. Smoke test also passed using the same credentials.

Feedback Requested:
Any and all

Screenshot:
<img width="1419" alt="Screen Shot 2019-09-10 at 3 06 28 PM" src="https://user-images.githubusercontent.com/42976557/64642672-e2a15300-d3dc-11e9-9e3a-352ddc56aeba.png">

