### PR TITLE
BCDA-1967: Redirect sandbox.bcda.cms.gov to bcda.cms.gov

### DIFF
--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -27,7 +26,7 @@ func NewAPIRouter() http.Handler {
 
 	if os.Getenv("DEPLOYMENT_TARGET") != "prod" {
 		r.Get("/", userGuideRedirect)
-		r.Get(`/{p:(user_guide|encryption|decryption_walkthrough).html}`, userGuideRedirect)
+		r.Get(`/{:(user_guide|encryption|decryption_walkthrough).html}`, userGuideRedirect)
 	}
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/ExplanationOfBenefit/$export", bulkEOBRequest))
@@ -93,6 +92,5 @@ func FileServer(r chi.Router, path string, root http.FileSystem) {
 }
 
 func userGuideRedirect(w http.ResponseWriter, r *http.Request) {
-	url := fmt.Sprintf("%s/%s", utils.FromEnv("USER_GUIDE_LOC", "https://bcda.cms.gov"), chi.URLParam(r, "p"))
-	http.Redirect(w, r, url, http.StatusMovedPermanently)
+	http.Redirect(w, r, utils.FromEnv("USER_GUIDE_LOC", "https://bcda.cms.gov"), http.StatusMovedPermanently)
 }

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -41,10 +41,7 @@ func (s *RouterTestSuite) getDataRoute(route string) *http.Response {
 
 func (s *RouterTestSuite) TestDefaultRoute() {
 	res := s.getAPIRoute("/")
-	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
-	body, _ := ioutil.ReadAll(res.Body)
-	assert.NotContains(s.T(), string(body), "404 page not found", "Default route returned wrong body")
-	assert.Contains(s.T(), string(body), "Beneficiary Claims Data API")
+	assert.Equal(s.T(), http.StatusMovedPermanently, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestDefaultProdRoute() {

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -44,6 +44,11 @@ func (s *RouterTestSuite) TestDefaultRoute() {
 	assert.Equal(s.T(), http.StatusMovedPermanently, res.StatusCode)
 }
 
+func (s *RouterTestSuite) TestUGRoute() {
+	res := s.getAPIRoute("/user_guide.html")
+	assert.Equal(s.T(), http.StatusMovedPermanently, res.StatusCode)
+}
+
 func (s *RouterTestSuite) TestDefaultProdRoute() {
 	err := os.Setenv("DEPLOYMENT_TARGET", "prod")
 	if err != nil {


### PR DESCRIPTION
### Fixes [BCDA-1967](https://jira.cms.gov/browse/BCDA-1967)
The sandbox user guide URL should redirect to bcda.cms.gov.

### Proposed Changes
Remove user guide file server from bcda-app and redirect user guide paths to a URL set in an environment variable.

### Change Details
* Sets response code to `301 Moved Permanently` for `/`, `user_guide.html`, `encryption.html`, and `decryption_walkthrough.html`, redirecting to value of env var `USER_GUIDE_LOC` or default `https://bcda.cms.gov`

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [x] security checklist is completed for this change
_Static Site Security Checklist (Migrating User Guide to bcda.cms.gov)_ https://confluence.cms.gov/pages/viewpage.action?pageId=154444934

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation
Test updated for path `/` to confirm `301` response. Can be run locally to see the redirects in action.

### Feedback Requested
Any
