### PR TITLE
BCDA-1420: Refactor bcdaworker/main.go

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -142,7 +142,7 @@ func setUpApp() *cli.App {
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(app.Writer, fmt.Sprint(ssasID))
+				fmt.Fprint(app.Writer, fmt.Sprint(ssasID))
 				return nil
 			},
 		},

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -116,7 +116,7 @@ func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID string) (st
 	return bbc.getData(blueButtonBasePath+"/Coverage/", params, jobID, cmsID)
 }
 
-func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID string, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID string) (string, error) {
 	params := GetDefaultParams()
 	params.Set("patient", patientID)
 	params.Set("excludeSAMHSA", "true")

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -31,10 +31,10 @@ var logger *logrus.Logger
 const blueButtonBasePath = "/v1/fhir"
 
 type APIClient interface {
-	GetExplanationOfBenefitData(patientID, jobID, cmsID string) (string, error)
-	GetPatientData(patientID, jobID, cmsID string) (string, error)
-	GetCoverageData(beneficiaryID, jobID, cmsID string) (string, error)
-	GetBlueButtonIdentifier(hashedHICN string) (string, error)
+	GetExplanationOfBenefit(patientID, jobID, cmsID string) (string, error)
+	GetPatient(patientID, jobID, cmsID string) (string, error)
+	GetCoverage(beneficiaryID, jobID, cmsID string) (string, error)
+	GetPatientByHICNHash(hashedHICN string) (string, error)
 }
 
 type BlueButtonClient struct {
@@ -97,26 +97,26 @@ func NewBlueButtonClient() (*BlueButtonClient, error) {
 
 type BeneDataFunc func(string, string, string) (string, error)
 
-func (bbc *BlueButtonClient) GetPatientData(patientID, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetPatient(patientID, jobID, cmsID string) (string, error) {
 	params := GetDefaultParams()
 	params.Set("_id", patientID)
 	return bbc.getData(blueButtonBasePath+"/Patient/", params, jobID, cmsID)
 }
 
-func (bbc *BlueButtonClient) GetBlueButtonIdentifier(hashedHICN string) (string, error) {
+func (bbc *BlueButtonClient) GetPatientByHICNHash(hashedHICN string) (string, error) {
 	params := GetDefaultParams()
 	// FHIR spec requires a FULLY qualified namespace so this is in fact the argument, not a URL
 	params.Set("identifier", fmt.Sprintf("http://bluebutton.cms.hhs.gov/identifier#hicnHash|%v", hashedHICN))
 	return bbc.getData(blueButtonBasePath+"/Patient/", params, "", "")
 }
 
-func (bbc *BlueButtonClient) GetCoverageData(beneficiaryID, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID string) (string, error) {
 	params := GetDefaultParams()
 	params.Set("beneficiary", beneficiaryID)
 	return bbc.getData(blueButtonBasePath+"/Coverage/", params, jobID, cmsID)
 }
 
-func (bbc *BlueButtonClient) GetExplanationOfBenefitData(patientID string, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID string, jobID, cmsID string) (string, error) {
 	params := GetDefaultParams()
 	params.Set("patient", patientID)
 	params.Set("excludeSAMHSA", "true")

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -183,53 +183,53 @@ func (s *BBTestSuite) TestGetDefaultParams() {
 }
 
 /* Tests that make requests, using clients configured with the 200 response and 500 response httptest.Servers initialized in SetupSuite() */
-func (s *BBRequestTestSuite) TestGetBlueButtonPatientData() {
-	p, err := s.bbClient.GetPatientData("012345", "543210", "A0000")
+func (s *BBRequestTestSuite) TestGetPatient() {
+	p, err := s.bbClient.GetPatient("012345", "543210", "A0000")
 	assert.Nil(s.T(), err)
 	assert.Contains(s.T(), p, `{ "test": "ok"`)
 	assert.NotContains(s.T(), p, "excludeSAMHSA=true")
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonPatientData_500() {
-	p, err := s.bbClient.GetPatientData("012345", "543210", "A0000")
+func (s *BBRequestTestSuite) TestGetPatient_500() {
+	p, err := s.bbClient.GetPatient("012345", "543210", "A0000")
 	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
 	assert.Equal(s.T(), "", p)
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonCoverageData() {
-	c, err := s.bbClient.GetCoverageData("012345", "543210", "A0000")
+func (s *BBRequestTestSuite) TestGetCoverage() {
+	c, err := s.bbClient.GetCoverage("012345", "543210", "A0000")
 	assert.Nil(s.T(), err)
 	assert.Contains(s.T(), c, `{ "test": "ok"`)
 	assert.NotContains(s.T(), c, "excludeSAMHSA=true")
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonCoverageData_500() {
-	p, err := s.bbClient.GetCoverageData("012345", "543210", "A0000")
+func (s *BBRequestTestSuite) TestGetCoverage_500() {
+	p, err := s.bbClient.GetCoverage("012345", "543210", "A0000")
 	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
 	assert.Equal(s.T(), "", p)
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonExplanationOfBenefitData() {
-	e, err := s.bbClient.GetExplanationOfBenefitData("012345", "543210", "A0000")
+func (s *BBRequestTestSuite) TestGetExplanationOfBenefit() {
+	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000")
 	assert.Nil(s.T(), err)
 	assert.Contains(s.T(), e, `{ "test": "ok"`)
 	assert.Contains(s.T(), e, "excludeSAMHSA=true")
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonExplanationOfBenefitData_500() {
-	p, err := s.bbClient.GetExplanationOfBenefitData("012345", "543210", "A0000")
+func (s *BBRequestTestSuite) TestGetExplanationOfBenefit_500() {
+	p, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000")
 	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
 	assert.Equal(s.T(), "", p)
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonMetadata() {
+func (s *BBRequestTestSuite) TestGetMetadata() {
 	m, err := s.bbClient.GetMetadata()
 	assert.Nil(s.T(), err)
 	assert.Contains(s.T(), m, `{ "test": "ok"`)
 	assert.NotContains(s.T(), m, "excludeSAMHSA=true")
 }
 
-func (s *BBRequestTestSuite) TestGetBlueButtonMetadata_500() {
+func (s *BBRequestTestSuite) TestGetMetadata_500() {
 	p, err := s.bbClient.GetMetadata()
 	assert.Regexp(s.T(), `Blue Button request .+ failed \d+ time\(s\)`, err.Error())
 	assert.Equal(s.T(), "", p)

--- a/bcda/encryption/encryption.go
+++ b/bcda/encryption/encryption.go
@@ -72,6 +72,18 @@ func EncryptBytes(publicKey *rsa.PublicKey, plaintext []byte, label string) (cip
 	}
 }
 
+func EncryptFile(path, name string, key *rsa.PublicKey) ([]byte, []byte, error) {
+	// Open and read the file
+	/*#nosec*/
+	fileBytes, err := ioutil.ReadFile(path + "/" + name)
+	if err != nil {
+		log.Error(err)
+		return nil, nil, err
+	}
+
+	return EncryptBytes(key, fileBytes, name)
+}
+
 func EncryptAndMove(fromPath, toPath, fileName string, key *rsa.PublicKey, jobID uint) error {
 	// Open and read the file
 	/*#nosec*/

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -481,7 +481,7 @@ func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (bl
 
 	// didn't find a local value, need to ask BlueButton
 	hashedHICN := client.HashHICN(cclfBeneficiary.HICN)
-	jsonData, err := bb.GetBlueButtonIdentifier(hashedHICN)
+	jsonData, err := bb.GetPatientByHICNHash(hashedHICN)
 	if err != nil {
 		return "", err
 	}

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -910,7 +910,7 @@ func (s *ModelsTestSuite) TestGetBlueButtonID() {
 	cclfBeneficiary := CCLFBeneficiary{HICN: "HASH_ME", MBI: "NOTHING"}
 	bbc := testUtils.BlueButtonClient{}
 	bbc.HICN = &cclfBeneficiary.HICN
-	bbc.On("GetBlueButtonIdentifier", client.HashHICN(cclfBeneficiary.HICN)).Return(bbc.GetData("Patient", "BB_VALUE"))
+	bbc.On("GetPatientByHICNHash", client.HashHICN(cclfBeneficiary.HICN)).Return(bbc.GetData("Patient", "BB_VALUE"))
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 
@@ -952,5 +952,5 @@ func (s *ModelsTestSuite) TestGetBlueButtonID() {
 	assert.Nil(err)
 	assert.Equal("DB_VALUE", newBBID)
 	// Should be making only a single call to BB for all 3 attempts.
-	bbc.AssertNumberOfCalls(s.T(), "GetBlueButtonIdentifier", 1)
+	bbc.AssertNumberOfCalls(s.T(), "GetPatientByHICNHash", 1)
 }

--- a/bcda/servicemux/servicemux_test.go
+++ b/bcda/servicemux/servicemux_test.go
@@ -20,7 +20,7 @@ type ServiceMuxTestSuite struct {
 }
 
 func (s *ServiceMuxTestSuite) TestNew() {
-	addr := getConfig().testAddress
+	addr := getConfig().TestAddress
 	sm := New(addr)
 	go func() {
 		defer sm.Close()
@@ -34,7 +34,7 @@ func (s *ServiceMuxTestSuite) TestNew() {
 }
 
 func (s *ServiceMuxTestSuite) TestAddServer() {
-	sm := New(getConfig().testAddress)
+	sm := New(getConfig().TestAddress)
 	go func() {
 		defer sm.Close()
 	}()
@@ -90,7 +90,7 @@ func (s *ServiceMuxTestSuite) TestServeHTTPS() {
 		Handler: testHandler,
 	}
 
-	sm := New(getConfig().testAddress)
+	sm := New(getConfig().TestAddress)
 	addr := sm.Listener.Addr().String()
 
 	sm.AddServer(srv, "/test")
@@ -134,7 +134,7 @@ func (s *ServiceMuxTestSuite) TestServeHTTPSBadKeypair() {
 		Handler: testHandler,
 	}
 
-	sm := New(getConfig().testAddress)
+	sm := New(getConfig().TestAddress)
 	sm.AddServer(srv, "/test")
 
 	defer sm.Close()
@@ -155,7 +155,7 @@ func (s *ServiceMuxTestSuite) TestServeHTTP() {
 		Handler: testHandler,
 	}
 
-	sm := New(getConfig().testAddress)
+	sm := New(getConfig().TestAddress)
 	addr := sm.Listener.Addr().String()
 
 	sm.AddServer(&srv, "/test")
@@ -193,7 +193,7 @@ func (s *ServiceMuxTestSuite) TestServeHTTPEmptyPath() {
 		Handler: testHandler,
 	}
 
-	sm := New(getConfig().testAddress)
+	sm := New(getConfig().TestAddress)
 	addr := sm.Listener.Addr().String()
 
 	sm.AddServer(&srv, "")
@@ -246,7 +246,7 @@ func resetOrigVars(origTLSCert, origTLSKey, origHTTPOnly string) {
 }
 
 type config struct {
-	testAddress string
+	TestAddress string `json:"testAddress"`
 }
 
 func getConfig() config {

--- a/bcda/testUtils/client.go
+++ b/bcda/testUtils/client.go
@@ -15,22 +15,22 @@ type BlueButtonClient struct {
 	HICN *string
 }
 
-func (bbc *BlueButtonClient) GetExplanationOfBenefitData(patientID, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID string) (string, error) {
 	args := bbc.Called(patientID)
 	return args.String(0), args.Error(1)
 }
 
-func (bbc *BlueButtonClient) GetBlueButtonIdentifier(hashedHICN string) (string, error) {
+func (bbc *BlueButtonClient) GetPatientByHICNHash(hashedHICN string) (string, error) {
 	args := bbc.Called(hashedHICN)
 	return args.String(0), args.Error(1)
 }
 
-func (bbc *BlueButtonClient) GetPatientData(patientID, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetPatient(patientID, jobID, cmsID string) (string, error) {
 	args := bbc.Called(patientID, jobID, cmsID)
 	return args.String(0), args.Error(1)
 }
 
-func (bbc *BlueButtonClient) GetCoverageData(beneficiaryID, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID string) (string, error) {
 	args := bbc.Called(beneficiaryID, jobID, cmsID)
 	return args.String(0), args.Error(1)
 }

--- a/bcda/utils/common.go
+++ b/bcda/utils/common.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -53,4 +54,10 @@ func ContainsString(sa []string, os string) bool {
 		}
 	}
 	return false
+}
+
+// IsUUID returns true if `s` is a UUID.
+func IsUUID(s string) bool {
+	re := regexp.MustCompile("^[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$")
+	return re.MatchString(s)
 }

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -170,11 +170,11 @@ func writeBBDataToFile(bb client.APIClient, acoID string, acoCMSID string, cclfB
 	var bbFunc client.BeneDataFunc
 	switch t {
 	case "ExplanationOfBenefit":
-		bbFunc = bb.GetExplanationOfBenefitData
+		bbFunc = bb.GetExplanationOfBenefit
 	case "Patient":
-		bbFunc = bb.GetPatientData
+		bbFunc = bb.GetPatient
 	case "Coverage":
-		bbFunc = bb.GetCoverageData
+		bbFunc = bb.GetCoverage
 	default:
 		err := fmt.Errorf("Invalid resource type requested: %s", t)
 		log.Error(err)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/mock"
 	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/bgentry/que-go"
 	"github.com/pborman/uuid"
@@ -77,7 +78,7 @@ func TestWriteEOBDataToFile(t *testing.T) {
 		db.Create(&cclfBeneficiary)
 		defer db.Delete(&cclfBeneficiary)
 		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
-		bbc.On("GetExplanationOfBenefitData", beneficiaryIDs[i]).Return(bbc.GetData("ExplanationOfBenefit", beneficiaryID))
+		bbc.On("GetExplanationOfBenefit", beneficiaryIDs[i]).Return(bbc.GetData("ExplanationOfBenefit", beneficiaryID))
 	}
 
 	_, err := writeBBDataToFile(&bbc, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit")
@@ -138,9 +139,9 @@ func TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(t *testing.T) {
 
 	bbc := testUtils.BlueButtonClient{}
 	// Set up the mock function to return the expected values
-	bbc.On("GetExplanationOfBenefitData", "10000").Return("", errors.New("error"))
-	bbc.On("GetExplanationOfBenefitData", "11000").Return("", errors.New("error"))
-	bbc.On("GetExplanationOfBenefitData", "12000").Return(bbc.GetData("ExplanationOfBenefit", "12000"))
+	bbc.On("GetExplanationOfBenefit", "10000").Return("", errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", "11000").Return("", errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", "12000").Return(bbc.GetData("ExplanationOfBenefit", "12000"))
 	acoID := "387c3a62-96fa-4d93-a5d0-fd8725509dd9"
 	cmsID := "A00234"
 	beneficiaryIDs := []string{"10000", "11000", "12000"}
@@ -191,8 +192,8 @@ func TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(t *testing.T) {
 
 	bbc := testUtils.BlueButtonClient{}
 	// Set up the mock function to return the expected values
-	bbc.On("GetExplanationOfBenefitData", "1000089833").Return("", errors.New("error"))
-	bbc.On("GetExplanationOfBenefitData", "1000065301").Return("", errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", "1000089833").Return("", errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", "1000065301").Return("", errors.New("error"))
 	acoID := "387c3a62-96fa-4d93-a5d0-fd8725509dd9"
 	cmsID := "A00234"
 	beneficiaryIDs := []string{"1000089833", "1000065301", "1000012463"}
@@ -233,7 +234,7 @@ func TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(t *testing.T) {
 	assert.Equal(t, ooResp+"\n", string(fData))
 	bbc.AssertExpectations(t)
 	// should not have requested third beneficiary EOB because failure threshold was reached after second
-	bbc.AssertNotCalled(t, "GetExplanationOfBenefitData", "1000012463")
+	bbc.AssertNotCalled(t, "GetExplanationOfBenefit", "1000012463")
 
 	os.Remove(fmt.Sprintf("%s/%s/%s.ndjson", os.Getenv("FHIR_STAGING_DIR"), jobID, acoID))
 	os.Remove(errorFilePath)
@@ -255,7 +256,7 @@ func TestWriteEOBDataToFile_BlueButtonIDNotFound(t *testing.T) {
 	defer db.Delete(&cclfFile)
 
 	bbc := testUtils.BlueButtonClient{}
-	bbc.On("GetBlueButtonIdentifier", mock.AnythingOfType("string")).Return("", errors.New("No beneficiary found for HICN"))
+	bbc.On("GetPatientByHICNHash", mock.AnythingOfType("string")).Return("", errors.New("No beneficiary found for HICN"))
 
 	// clean out the data dir before beginning this test
 	os.RemoveAll(stagingDir)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -88,7 +88,7 @@ func TestWriteEOBDataToFile(t *testing.T) {
 
 	files, err := ioutil.ReadDir(stagingDir)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(files))
+	assert.Len(t, files, 1)
 
 	for _, f := range files {
 		filePath := fmt.Sprintf("%s/%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID, f.Name())

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -400,3 +400,21 @@ func (s *MainTestSuite) TestSetupQueue() {
 	os.Setenv("WORKER_POOL_SIZE", "7")
 	setupQueue()
 }
+
+func (s *MainTestSuite) TestUpdateJobStats() {
+	db := database.GetGORMDbConnection()
+	defer database.Close(db)
+
+	j := models.Job{
+		ACOID:             uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		UserID:            uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
+		RequestURL:        "",
+		Status:            "",
+		JobCount:          4,
+		CompletedJobCount: 1,
+	}
+	db.Create(&j)
+	updateJobStats(j.ID)
+	db.First(&j, j.ID)
+	assert.Equal(s.T(), 2, j.CompletedJobCount)
+}


### PR DESCRIPTION
### Fixes [BCDA-1420](https://jira.cms.gov/browse/BCDA-1420)
Some functions in bcdaworker/main.go are difficult to test and maintain because they do a lot of different things.

### Proposed Changes
Simplify `processJob()` and `writeBBDataToFile()`, and related functions.

### Change Details
* Moves parts of `processJob()` and `writeBBDataFile()` into new functions so the parent functions are more readable
* Shortens and/or clarifies BlueButtonClient function names. `Get{ResourceType}Data()` functions have been renamed to `Get{ResourceType}()` and `GetBlueButtonIdentifier()` is now called `GetPatientByHICNHash()` (it returns patient data, not only a BB ID)
* Replaces `EncryptAndMove()` with `EncryptFile()` so moving the output is decoupled from the encryption step. Both steps happen in the new `encryptData()` function in bcdaworker/main.go
* Cleans up linter issues that were causing failed builds in Travis

### Security Implications
No security impact. Encryption logic is relocated but unchanged.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

### Acceptance Validation
Existing tests continue to pass. New tests added for some new functions.

### Feedback Requested
Any
