### PR TITLE
Increase deadline for linter from 1m (default) to 2m.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ package:
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
 lint:
-	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run 
+	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=2m
 	docker-compose -f docker-compose.test.yml run --rm tests gosec ./...
 
 lint-ssas:


### PR DESCRIPTION
Due to a likely combination of our growing codebase and enhancements made to the `golangci-lint` tool, the time it takes to lint our code now exceeds 1 minute.  The default deadline is set to 1 minute in the `golangci-lint` tool, so we will need to explicitly force it to be larger.

### Proposed Changes

Increase the deadline to 2 minutes on the command line invocation of `golangci-lint`.

### Change Details

Updated the `Makefile` to explicitly call `golangci-lint` with a deadline of 2 minutes, overriding the default of 1 minute.

### Security Implications

There are no security implications with this change.  This change simply tells our linting tool to wait 2 minutes (instead of 1 minute) to complete

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Build/Package is passing in Jenkins against this feature branch: https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/991/

### Feedback Requested

Please review.
