### PR TITLE
BCDA-1857: Document 401 responses in Swagger

### DIFF
--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -156,7 +156,7 @@ type TokenResponse struct {
 // swagger:response missingCredentials
 type MissingCredentials struct{}
 
-// Invalid credentials
+// Unauthorized. The provided credentials are invalid for the requested resource.
 // swagger:response invalidCredentials
 type InvalidCredentials struct{}
 

--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/CMSgov/bcda-app/bcda/constants"
 	"strconv"
+
+	"github.com/CMSgov/bcda-app/bcda/constants"
 
 	"net/http"
 	"os"
@@ -48,6 +49,7 @@ var qc *que.Client
 	Responses:
 		202: BulkRequestResponse
 		400: badRequestResponse
+		401: invalidCredentials
 		429: tooManyRequestsResponse
 		500: errorResponse
 */
@@ -72,6 +74,7 @@ func bulkEOBRequest(w http.ResponseWriter, r *http.Request) {
 	Responses:
 		202: BulkRequestResponse
 		400: badRequestResponse
+		401: invalidCredentials
 		429: tooManyRequestsResponse
 		500: errorResponse
 */
@@ -95,6 +98,7 @@ func bulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 	Responses:
 		202: BulkRequestResponse
 		400: badRequestResponse
+		401: invalidCredentials
 		429: tooManyRequestsResponse
 		500: errorResponse
 */
@@ -219,6 +223,7 @@ func bulkRequest(t string, w http.ResponseWriter, r *http.Request) {
 		202: jobStatusResponse
 		200: completedJobResponse
 		400: badRequestResponse
+		401: invalidCredentials
 		404: notFoundResponse
 		410: goneResponse
 		500: errorResponse
@@ -352,6 +357,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 	Responses:
 		200: ExplanationOfBenefitNDJSON
 		400: badRequestResponse
+		401: invalidCredentials
         404: notFoundResponse
 		500: errorResponse
 */


### PR DESCRIPTION
### Fixes [BCDA-1857](https://jira.cms.gov/browse/BCDA-1851)
BCDA Swagger describes a 401 response as "Undocumented" for some endpoints.

### Proposed Changes
Indicate the reason for a 401.

### Change Details
This adds a description of 
>Unauthorized. The provided credentials are invalid for the requested resource.

to 401 responses on job status, data, and export endpoints (all resource types).

### Security Implications
No security implications. This is an improvement to documentation.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation
Can be seen in Swagger.
![Screen Shot 2019-09-26 at 9 29 26 AM](https://user-images.githubusercontent.com/1923441/65692232-2ed8ce00-e040-11e9-85e0-8e0640a966df.png)


### Feedback Requested
Any
