### PR TITLE
BCDA-1360 add prod config for postman tests

### DIFF
--- a/test/postman_test/prod.postman_environment.json
+++ b/test/postman_test/prod.postman_environment.json
@@ -1,0 +1,27 @@
+{
+        "id": "13a8c794-c1a8-4c1c-9601-d93c66be068a",
+	"name": "bcda-prod",
+	"values": [
+		{
+			"key": "scheme",
+			"value": "https",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "host",
+			"value": "api.bcda.cms.gov",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "env",
+			"value": "prod",
+			"description": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2019-09-26T12:31:15.933Z",
+	"_postman_exported_using": "Postman/6.6.1"
+}


### PR DESCRIPTION
### Partially Fixes [BCDA-1360](https://jira.cms.gov/browse/BCDA-1360)
We currently have no smoke tests running on the production environment.

### Proposed Changes
We are updating the smoke test job in jenkins to run on prod in https://github.com/CMSgov/bcda-ops/pull/307 but we need an app code change for postman tests to pass.

### Change Details
Add a prod config for postman tests.

### Security Implications
No security implications. This is not a new test, just an additional config file.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation
https://bcda-ci.adhocteam.us/job/MMurphy%20-%20BCDA-1360/4/

### Feedback Requested
Please review 