### PR TITLE
Update CI to remove redundant linting of SSAS code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,4 @@ before_script:
 script:
   - make docker-bootstrap
   - make test
+  - make test-ssas

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ package:
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
 lint:
-	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=2m
-	docker-compose -f docker-compose.test.yml run --rm tests gosec ./...
+	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=2m --skip-dirs=./ssas
+	docker-compose -f docker-compose.test.yml run --rm tests gosec -exclude-dir=./ssas ./...
 
 lint-ssas:
 	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run ./ssas/...

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,7 @@ test:
 	$(MAKE) lint
 	$(MAKE) unit-test
 	$(MAKE) postman env=local
-	$(MAKE) postman-ssas
 	$(MAKE) smoke-test
-	$(MAKE) smoke-test-ssas
 
 test-ssas:
 	$(MAKE) lint-ssas

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ package:
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
 lint:
-	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=2m --skip-dirs=./ssas
-	docker-compose -f docker-compose.test.yml run --rm tests gosec -exclude-dir=./ssas ./...
+	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=2m --skip-dirs=ssas
+	docker-compose -f docker-compose.test.yml run --rm tests gosec -exclude-dir=ssas ./...
 
 lint-ssas:
 	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run ./ssas/...


### PR DESCRIPTION
We are redundantly linting the SSAS code: once as part of API build and once as part of SSAS build.  The SSAS code should only be linted as part of the SSAS build.

### Proposed Changes

Exclude linting of SSAS code from both `gosec` and `golangci-lint`.

### Change Details

Updated the `Makefile` to explicitly skip the SSAS code when executing `gosec` and `golangci-lint` as part of the API lint target.
Updated the `test` and `test-ssas` targets so that `test` is API-specific and `test-ssas` is SSAS-specific.

### Security Implications

There are no security implications with this change.  This change simply tells our linting tool which directories to lint.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Build/Package is passing in Jenkins against this feature branch: https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1012/

### Feedback Requested

Please review.
