### PR TITLE
BCDA-2035: SSAS: Update test for SonarQube

### DIFF
--- a/ssas/service/public/oktamfa_test.go
+++ b/ssas/service/public/oktamfa_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CMSgov/bcda-app/ssas/okta"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"net/http"
@@ -143,7 +144,8 @@ func (s *OTestSuite) TestPostFactorChallengeFactorNotFound() {
 func (s *OTestSuite) TestPostPasswordSuccess() {
 	trackingId := uuid.NewRandom().String()
 	userId := "abc123"
-	password := "not_a_password"
+	password, err := randomCharacters(16)
+	require.Nil(s.T(), err)
 	client := okta.NewTestClient(func(req *http.Request) *http.Response {
 		assert.Equal(s.T(), req.URL.String(), okta.OktaBaseUrl + "/api/v1/authn")
 		b, err := ioutil.ReadAll(req.Body)
@@ -163,7 +165,8 @@ func (s *OTestSuite) TestPostPasswordSuccess() {
 func (s *OTestSuite) TestPostPasswordFailure() {
 	trackingId := uuid.NewRandom().String()
 	userId := "abc123"
-	password := "not_a_password"
+	password, err := randomCharacters(16)
+	require.Nil(s.T(), err)
 	client := okta.NewTestClient(func(req *http.Request) *http.Response {
 		assert.Equal(s.T(), req.URL.String(), okta.OktaBaseUrl + "/api/v1/authn")
 		b, err := ioutil.ReadAll(req.Body)


### PR DESCRIPTION
### Fixes [BCDA-2035](https://jira.cms.gov/browse/BCDA-2035)
SonarQube has alerted that two of our unit tests hard-code a string as a mock password.  This PR assigns a random value to those strings as a better password pattern.

### Proposed Changes
- 16 random characters are assigned to each string

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No net change to security is introduced, though arguably the net result is an appreciation of the kind of issue SonarQube can catch.

### Acceptance Validation
Final validation will occur after merging with `master`, when SonarQube runs its tests.

### Feedback Requested
Please point out anything I've missed.