### PR TITLE
BCDA-1994: Increase Retention Threshold for Data Files on NFS

### DIFF
--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -419,7 +419,7 @@ func sortCCLFArchives(cclfMap *map[string]map[int][]*cclfFileMetadata, skipped *
 			log.Errorf("Unknown file found: %s", metadata)
 			*skipped = *skipped + 1
 
-			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24))
+			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("CCLF_ARCHIVE_THRESHOLD_HR", 72))
 			if metadata.deliveryDate.Add(deleteThreshold).Before(time.Now()) {
 				newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), info.Name())
 				err = os.Rename(metadata.filePath, newpath)
@@ -587,7 +587,7 @@ func cleanUpCCLF(cclfMap map[string]map[int][]*cclfFileMetadata) error {
 				if !cclf.imported {
 					// check the timestamp on the failed files
 					elapsed := time.Since(cclf.deliveryDate).Hours()
-					deleteThreshold := utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24)
+					deleteThreshold := utils.GetEnvInt("CCLF_ARCHIVE_THRESHOLD_HR", 72)
 					if int(elapsed) > deleteThreshold {
 						err := os.Rename(cclf.filePath, newpath)
 						if err != nil {

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -419,7 +419,7 @@ func sortCCLFArchives(cclfMap *map[string]map[int][]*cclfFileMetadata, skipped *
 			log.Errorf("Unknown file found: %s", metadata)
 			*skipped = *skipped + 1
 
-			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("CCLF_ARCHIVE_THRESHOLD_HR", 72))
+			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("BCDA_ETL_FILE_ARCHIVE_THRESHOLD_HR", 72))
 			if metadata.deliveryDate.Add(deleteThreshold).Before(time.Now()) {
 				newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), info.Name())
 				err = os.Rename(metadata.filePath, newpath)
@@ -587,7 +587,7 @@ func cleanUpCCLF(cclfMap map[string]map[int][]*cclfFileMetadata) error {
 				if !cclf.imported {
 					// check the timestamp on the failed files
 					elapsed := time.Since(cclf.deliveryDate).Hours()
-					deleteThreshold := utils.GetEnvInt("CCLF_ARCHIVE_THRESHOLD_HR", 72)
+					deleteThreshold := utils.GetEnvInt("BCDA_ETL_FILE_ARCHIVE_THRESHOLD_HR", 72)
 					if int(elapsed) > deleteThreshold {
 						err := os.Rename(cclf.filePath, newpath)
 						if err != nil {

--- a/bcda/cclf/cclf_test.go
+++ b/bcda/cclf/cclf_test.go
@@ -484,7 +484,7 @@ func (s *CCLFTestSuite) TestSortCCLFArchives_TimeChange() {
 
 	testUtils.ResetFiles(s.Suite, BASE_FILE_PATH+"cclf/mixed/with_invalid_filenames/")
 
-	timeChange := origTime.Add(-(time.Hour * 25)).Truncate(time.Second)
+	timeChange := origTime.Add(-(time.Hour * 73)).Truncate(time.Second)
 	err = os.Chtimes(filePath, timeChange, timeChange)
 	if err != nil {
 		s.FailNow("Failed to change modified time for file", err)

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -105,7 +105,7 @@ func getSuppressionFileMetadata(suppresslist *[]*suppressionFileMetadata, skippe
 			log.Errorf("Unknown file found: %s", metadata)
 			*skipped = *skipped + 1
 
-			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24))
+			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("BCDA_ETL_FILE_ARCHIVE_THRESHOLD_HR", 72))
 			if metadata.deliveryDate.Add(deleteThreshold).Before(time.Now()) {
 				newpath := fmt.Sprintf("%s/%s", os.Getenv("PENDING_DELETION_DIR"), info.Name())
 				err = os.Rename(metadata.filePath, newpath)
@@ -356,7 +356,7 @@ func cleanupSuppression(suppresslist []*suppressionFileMetadata) error {
 		if !suppressionFile.imported {
 			// check the timestamp on the failed files
 			elapsed := time.Since(suppressionFile.deliveryDate).Hours()
-			deleteThreshold := utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24)
+			deleteThreshold := utils.GetEnvInt("BCDA_ETL_FILE_ARCHIVE_THRESHOLD_HR", 72)
 			if int(elapsed) > deleteThreshold {
 				err := os.Rename(suppressionFile.filePath, newpath)
 				if err != nil {

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -319,7 +319,7 @@ func (s *SuppressionTestSuite) TestGetSuppressionFileMetadata_TimeChange() {
 	assert.Nil(err)
 	testUtils.ResetFiles(s.Suite, folderPath)
 
-	timeChange := origTime.Add(-(time.Hour * 25)).Truncate(time.Second)
+	timeChange := origTime.Add(-(time.Hour * 73)).Truncate(time.Second)
 	err = os.Chtimes(filePath, timeChange, timeChange)
 	if err != nil {
 		s.FailNow("Failed to change modified time for file", err)


### PR DESCRIPTION
### Fixes [BCDA-1994](https://jira.cms.gov/browse/BCDA-1994)

The most recent CCLF ETL process was the first execution of that process in which our software was required to accommodate all >500 ACOs (up until that point, we were only ingesting CCLF data for 4 ACOs).  We learned that with >500 ACOs, the ETL process takes >24 hours and the estimation is that it should take ~48 hours.  As a result, our file retention period (for CCLF files and 1-800-Medicare suppression files which enter the BCDA NFS via CMS EFT) must be increased from 24 to 72 hours.

### Change Details

- Updated the ETL code to remove files which are older than 72 hours instead of 24 hours.
- Updated the unit test code to accommodate the new time threshold.
- Modified several security documents (specific documents identified in the `Security Implications` section)

### Security Implications

This change means that CCLF files and 1-800-Medicare files (which contain sensitive information) will remain on the BCDA NFS for a longer period of time.  The files will be purged from the BCDA NFS after 72 hours (previously 24 hours).  Note that the BCDA NFS is within the data tier of the BCDA system architecture.

- [ ] new software dependencies
- [x] security controls or supporting software altered
>Due to the security control modification, the following documents have been updated to indicate the 72-hour threshold:
(1) NFS/EFT SIA
(2) XLC Megadeck slides
(3) System Design Document 
(4) Privacy Impact Assessment

- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

- Unit tests were modified to accommodate the new scenario, and those tests are passing.

### Feedback Requested

Please review.