### PR TITLE
Improvements to 1-800-MEDICARE synthetic data script

### DIFF
--- a/test/datagenerator/1800medicare.go
+++ b/test/datagenerator/1800medicare.go
@@ -42,6 +42,8 @@ func main() {
 		panic(err)
 	}
 
+	recCount := 0
+
 	for _, acoID := range []string{"A9990", "A9991", "A9992", "A9993", "A9994"} {
 		inf, err := os.Open(fmt.Sprintf("%s-HICNs", acoID))
 		if err != nil {
@@ -71,6 +73,12 @@ func main() {
 					panic(err)
 				}
 			}
+			recCount += len(recs)
+		}
+
+		_, err = outf.WriteString(fmt.Sprintf("TRL_BENEDATASHR%s%-10d", now.Format("20060102"), recCount))
+		if err != nil {
+			panic(err)
 		}
 
 		err = inf.Close()
@@ -90,22 +98,22 @@ func profile(hicn string, acoID string) record {
 	dobMax := time.Now().Add(-65 * 365 * 24 * time.Hour)
 
 	p := record{
-		hicn:       field{l: 11, v: hicn},                       // HICN
-		blk:        field{l: 10},                                // Beneficiary link key
-		firstName:  field{l: 30, v: randWord(1, 30)},            // Beneficiary first name
-		middleName: field{l: 30},                                // Beneficiary middle name
-		lastName:   field{l: 40, v: randWord(1, 30)},            // Beneficiary last name
-		dob:        field{l: 8, v: ccyymmdd(dobMin, dobMax, 0)}, // Beneficiary date of birth
-		addr1:      field{l: 55, v: addr1()},                    // Beneficiary address line 1
-		addr2:      field{l: 55},                                // Beneficiary address line 2
-		addr3:      field{l: 55},                                // Beneficiary address line 3
-		city:       field{l: 40, v: randWord(1, 40)},            // Beneficiary city
-		state:      field{l: 2, v: "ST"},                        // Beneficiary state
-		zip5:       field{l: 5, v: "00000"},                     // Beneficiary first five digits of ZIP code
-		zip4:       field{l: 4},                                 // Beneficiary last four digits of ZIP code
-		gender:     field{l: 1, v: oneOfStr("M", "F", "U")},     // Beneficiary gender
-		acoID:      field{l: 5, v: acoID},                       // ACO identifier
-		acoName:    field{l: 70, v: randWord(1, 66) + " ACO"},   // ACO legal name
+		hicn:       field{l: 11, v: hicn},                     // HICN
+		blk:        field{l: 10},                              // Beneficiary link key
+		firstName:  field{l: 30, v: randWord(1, 30)},          // Beneficiary first name
+		middleName: field{l: 30},                              // Beneficiary middle name
+		lastName:   field{l: 40, v: randWord(1, 30)},          // Beneficiary last name
+		dob:        field{l: 8, v: ccyymmdd(dobMin, dobMax)},  // Beneficiary date of birth
+		addr1:      field{l: 55, v: addr1()},                  // Beneficiary address line 1
+		addr2:      field{l: 55},                              // Beneficiary address line 2
+		addr3:      field{l: 55},                              // Beneficiary address line 3
+		city:       field{l: 40, v: randWord(1, 40)},          // Beneficiary city
+		state:      field{l: 2, v: "ST"},                      // Beneficiary state
+		zip5:       field{l: 5, v: "00000"},                   // Beneficiary first five digits of ZIP code
+		zip4:       field{l: 4},                               // Beneficiary last four digits of ZIP code
+		gender:     field{l: 1, v: oneOfStr("M", "F", "U")},   // Beneficiary gender
+		acoID:      field{l: 5, v: acoID},                     // ACO identifier
+		acoName:    field{l: 70, v: randWord(1, 66) + " ACO"}, // ACO legal name
 	}
 
 	return p
@@ -120,15 +128,29 @@ func records(profile record) []record {
 
 	for i := 0; i < ct; i++ {
 		r := profile
-		r.encDate = field{l: 8, v: ccyymmdd(encDtMin, encDtMax, 0)}    // Encounter date
-		r.effDate = field{l: 8, v: ccyymmdd(effDtMin, effDtMax, 10)}   // Beneficiary data sharing effective date
-		r.srcCode = field{l: 5, v: oneOfStr("1800", "")}               // Beneficiary data sharing source code
-		r.mechCode = field{l: 1, v: oneOfStr("T", "")}                 // Beneficiary option data sharing decision mechanism code
-		r.prefInd = field{l: 1, v: oneOfStr("Y", "N", "")}             // Beneficiary data sharing preference indicator
-		r.saEffDate = field{l: 8, v: ccyymmdd(effDtMin, effDtMax, 10)} // Beneficiary substance abuse data sharing effective date
-		r.saSrcCode = field{l: 5, v: oneOfStr("1-800", "")}            // Beneficiary substance abuse data sharing source code
-		r.saMechCode = field{l: 1, v: oneOfStr("T", "")}               // Beneficiary option substance abuse decision mechanism code
-		r.saPrefInd = field{l: 1, v: oneOfStr("N", "")}                // Beneficiary substance abuse data sharing preference indicator
+		r.encDate = field{l: 8, v: ccyymmdd(encDtMin, encDtMax)} // Encounter date
+
+		r.effDate = field{l: 8, v: ""}                   // Beneficiary data sharing effective date
+		r.srcCode = field{l: 5, v: oneOfStr("1800", "")} // Beneficiary data sharing source code
+		r.mechCode = field{l: 1, v: ""}                  // Beneficiary option data sharing decision mechanism code
+		r.prefInd = field{l: 1, v: ""}                   // Beneficiary data sharing preference indicator
+		// If beneficiary data sharing source code is populated, also populate its associated fields (ICD v9.1 p.11)
+		if r.srcCode.v != "" {
+			r.effDate.v = ccyymmdd(effDtMin, effDtMax)
+			r.mechCode.v = "T"
+			r.prefInd.v = oneOfStr("Y", "N")
+		}
+
+		r.saEffDate = field{l: 8, v: ""}                    // Beneficiary substance abuse data sharing effective date
+		r.saSrcCode = field{l: 5, v: oneOfStr("1-800", "")} // Beneficiary substance abuse data sharing source code
+		r.saMechCode = field{l: 1, v: ""}                   // Beneficiary option substance abuse decision mechanism code
+		r.saPrefInd = field{l: 1, v: ""}                    // Beneficiary substance abuse data sharing preference indicator
+		// If beneficiary substance abuse data sharing source code is populated, also populate its associated fields (ICD v9.1 p.11)
+		if r.saSrcCode.v != "" {
+			r.saEffDate.v = ccyymmdd(effDtMin, effDtMax)
+			r.saMechCode.v = "T"
+			r.saPrefInd.v = "N"
+		}
 
 		records = append(records, r)
 	}
@@ -136,14 +158,10 @@ func records(profile record) []record {
 	return records
 }
 
-// blankPct indicates likelihood of blank result (0-100)
-func ccyymmdd(min, max time.Time, blankPct int) string {
-	if blankPct < rand.Intn(100)+1 {
-		diffHrs := max.Sub(min).Hours()
-		dt := min.Add(time.Duration(rand.Float64()*diffHrs) * time.Hour)
-		return dt.Format("20060102")
-	}
-	return ""
+func ccyymmdd(min, max time.Time) string {
+	diffHrs := max.Sub(min).Hours()
+	dt := min.Add(time.Duration(rand.Float64()*diffHrs) * time.Hour)
+	return dt.Format("20060102")
 }
 
 func oneOfStr(strs ...string) string {

--- a/test/datagenerator/1800medicare.go
+++ b/test/datagenerator/1800medicare.go
@@ -120,20 +120,27 @@ func profile(hicn string, acoID string) record {
 }
 
 func records(profile record) []record {
-	// Create 0-5 suppression records for this profile
-	ct := rand.Intn(6)
+	// Create 0-3 suppression records for this profile
+	ct := rand.Intn(4)
 	encDtMin, encDtMax := time.Now().Add(-7*24*time.Hour), time.Now()
 	effDtMin, effDtMax := time.Now().Add(-7*24*time.Hour), time.Now().Add(3*24*time.Hour)
 	records := []record{}
 
 	for i := 0; i < ct; i++ {
 		r := profile
+
+		r.srcCode = field{l: 5, v: oneOfStr("1800", "")}    // Beneficiary data sharing source code
+		r.saSrcCode = field{l: 5, v: oneOfStr("1-800", "")} // Beneficiary substance abuse data sharing source code
+		if r.srcCode.v == "" && r.saSrcCode.v == "" {
+			// One or both types of data sharing should have values
+			continue
+		}
+
 		r.encDate = field{l: 8, v: ccyymmdd(encDtMin, encDtMax)} // Encounter date
 
-		r.effDate = field{l: 8, v: ""}                   // Beneficiary data sharing effective date
-		r.srcCode = field{l: 5, v: oneOfStr("1800", "")} // Beneficiary data sharing source code
-		r.mechCode = field{l: 1, v: ""}                  // Beneficiary option data sharing decision mechanism code
-		r.prefInd = field{l: 1, v: ""}                   // Beneficiary data sharing preference indicator
+		r.effDate = field{l: 8, v: ""}  // Beneficiary data sharing effective date
+		r.mechCode = field{l: 1, v: ""} // Beneficiary option data sharing decision mechanism code
+		r.prefInd = field{l: 1, v: ""}  // Beneficiary data sharing preference indicator
 		// If beneficiary data sharing source code is populated, also populate its associated fields (ICD v9.1 p.11)
 		if r.srcCode.v != "" {
 			r.effDate.v = ccyymmdd(effDtMin, effDtMax)
@@ -141,10 +148,9 @@ func records(profile record) []record {
 			r.prefInd.v = oneOfStr("Y", "N")
 		}
 
-		r.saEffDate = field{l: 8, v: ""}                    // Beneficiary substance abuse data sharing effective date
-		r.saSrcCode = field{l: 5, v: oneOfStr("1-800", "")} // Beneficiary substance abuse data sharing source code
-		r.saMechCode = field{l: 1, v: ""}                   // Beneficiary option substance abuse decision mechanism code
-		r.saPrefInd = field{l: 1, v: ""}                    // Beneficiary substance abuse data sharing preference indicator
+		r.saEffDate = field{l: 8, v: ""}  // Beneficiary substance abuse data sharing effective date
+		r.saMechCode = field{l: 1, v: ""} // Beneficiary option substance abuse decision mechanism code
+		r.saPrefInd = field{l: 1, v: ""}  // Beneficiary substance abuse data sharing preference indicator
 		// If beneficiary substance abuse data sharing source code is populated, also populate its associated fields (ICD v9.1 p.11)
 		if r.saSrcCode.v != "" {
 			r.saEffDate.v = ccyymmdd(effDtMin, effDtMax)


### PR DESCRIPTION
This pull request contains improvements to the script for creating synthetic 1-800-MEDICARE files.

### Change Details
* Ensures that when a source code is set, its associated effective date, mechanism code, and preference indicator are also set, as indicated by the ICD
* Lowers max records per beneficiary to 3
* Adds trailer row with date and record count in file, per ICD

### Security Implications
No security implications. This is a synthetic data generator.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation
Can be tested by running `go run 1800medicare.go`

### Feedback Requested
Any
