### PR TITLE
BCDA-2327 Feature: Fixed description bug for successful responses

### DIFF
--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -105,12 +105,11 @@ type MetadataResponse struct {
 	Body fhirmodels.CapabilityStatement `json:"body,omitempty"`
 }
 
-// File of newline-delimited JSON FHIR ExplanationOfBenefit objects
-// swagger:response ExplanationOfBenefitNDJSON
-type ExplanationOfBenefitNDJSON struct {
+// File of newline-delimited JSON FHIR objects
+// swagger:response FileNDJSON
+type FileNDJSON struct {
 	// in: body
-	// minimum items: 1
-	Body *[]fhirmodels.ExplanationOfBenefit
+	Body string `json:"ndjson"`
 }
 
 // A JobStatus parameter model.

--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -366,7 +366,7 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 		bearer_token:
 
 	Responses:
-		200: ExplanationOfBenefitNDJSON
+		200: FileNDJSON
 		400: badRequestResponse
 		401: invalidCredentials
         404: notFoundResponse


### PR DESCRIPTION
Fixes [BCDA-2327](https://jira.cms.gov/browse/BCDA-2327)

Problem:
An incorrect description was given for one of our successful responses to the data retrieval endpoint. It described all responses as EOB which is incorrect. This has been changed to a more generic description to fit all bulk resource requests.

Proposed Details:
bcda/models/SwaggerStructs.go - changed to a more generic descriptor
bcda/web/api.go - uses the new response description

Security Implications:
This change does **not** deal with PII/PHI at all.

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation:
Yes, locally running swagger.

Screenshot:
![image](https://user-images.githubusercontent.com/42976557/68138031-e68db500-fef5-11e9-9eaf-a463a4b8aa5f.png)


Feedback Requested:
Any and all