### PR TITLE
BCDA-2359: Do not send BB-specific headers with blank values

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -172,18 +172,20 @@ func AddRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) 
 	req.Header.Add("BlueButton-OriginalQueryTimestamp", time.Now().String())
 	req.Header.Add("BlueButton-OriginalQueryId", reqID.String())
 	req.Header.Add("BlueButton-OriginalQueryCounter", "1")
-	req.Header.Add("BlueButton-BeneficiaryId", "")
-	req.Header.Add("BlueButton-OriginatingIpAddress", "")
-
 	req.Header.Add("keep-alive", "")
 	req.Header.Add("X-Forwarded-Proto", "https")
 	req.Header.Add("X-Forwarded-Host", "")
-
 	req.Header.Add("BlueButton-OriginalUrl", req.URL.String())
 	req.Header.Add("BlueButton-OriginalQuery", req.URL.RawQuery)
-	req.Header.Add("BlueButton-BackendCall", "")
 	req.Header.Add("BCDA-JOBID", jobID)
 	req.Header.Add("BCDA-CMSID", cmsID)
+
+        // Do not set BB-specific headers with blank values
+        // Leaving them here, commented out, in case we want to set them to real values in future
+        //req.Header.Add("BlueButton-BeneficiaryId", "")
+        //req.Header.Add("BlueButton-OriginatingIpAddress", "")
+        //req.Header.Add("BlueButton-BackendCall", "")
+
 }
 
 func (bbc *BlueButtonClient) tryRequest(req *http.Request) (string, error) {

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -270,8 +270,6 @@ func (s *BBTestSuite) TestAddRequestHeaders() {
 
 	assert.Equal(s.T(), reqID.String(), req.Header.Get("BlueButton-OriginalQueryId"))
 	assert.Equal(s.T(), "1", req.Header.Get("BlueButton-OriginalQueryCounter"))
-	assert.Equal(s.T(), "", req.Header.Get("BlueButton-BeneficiaryId"))
-	assert.Equal(s.T(), "", req.Header.Get("BlueButton-OriginatingIpAddress"))
 
 	assert.Equal(s.T(), "", req.Header.Get("keep-alive"))
 	assert.Equal(s.T(), "https", req.Header.Get("X-Forwarded-Proto"))
@@ -279,7 +277,6 @@ func (s *BBTestSuite) TestAddRequestHeaders() {
 
 	assert.Equal(s.T(), req.URL.String(), req.Header.Get("BlueButton-OriginalUrl"))
 	assert.Equal(s.T(), req.URL.RawQuery, req.Header.Get("BlueButton-OriginalQuery"))
-	assert.Equal(s.T(), "", req.Header.Get("BlueButton-BackendCall"))
 
 	assert.Equal(s.T(), "543210", req.Header.Get("BCDA-JOBID"))
 	assert.Equal(s.T(), "A00234", req.Header.Get("BCDA-CMSID"))


### PR DESCRIPTION
### Fixes [BCDA-2359](https://jira.cms.gov/browse/BCDA-2359)

BB is unable to analyze BCDA request metrics because BCDA is sending BB-specific headers with blank values.

### Change Details

Stop sending the following BB-specific headers:

- `BlueButton-BeneficiaryId`
- `BlueButton-OriginatingIpAddress`
- `BlueButton-BackendCall`

### Security Implications

No PHI/PII is involved.  This change helps BFD track requests at a more granular level.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Local tests passed.  Confirmed with BFD team that access logs are correct when removing these headers from requests.  

### Feedback Requested

Please review.
