### PR TITLE
BCDA-2373: Improve Performance of Blue Button ID Acquisition

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -480,8 +480,6 @@ func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (bl
 	if cclfBeneficiary.BlueButtonID != "" {
 		return cclfBeneficiary.BlueButtonID, nil
 	}
-	db := database.GetGORMDbConnection()
-	defer db.Close()
 
 	// didn't find a local value, need to ask BlueButton
 	hashedHICN := client.HashHICN(cclfBeneficiary.HICN)

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -480,7 +480,6 @@ func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (bl
 	if cclfBeneficiary.BlueButtonID != "" {
 		return cclfBeneficiary.BlueButtonID, nil
 	}
-	var oldRecord CCLFBeneficiary
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -484,13 +484,6 @@ func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (bl
 	db := database.GetGORMDbConnection()
 	defer db.Close()
 
-	// find another record with this HICN.  If it has a value use it.
-	// Find the first record with a matching HICN and an non empty BlueButtonID
-	db.Where("hicn = ? and blue_button_id <> ''", cclfBeneficiary.HICN).First(&oldRecord)
-	if oldRecord.BlueButtonID != "" {
-		return oldRecord.BlueButtonID, nil
-	}
-
 	// didn't find a local value, need to ask BlueButton
 	hashedHICN := client.HashHICN(cclfBeneficiary.HICN)
 	jsonData, err := bb.GetPatientByHICNHash(hashedHICN)

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -925,32 +925,6 @@ func (s *ModelsTestSuite) TestGetBlueButtonID() {
 	assert.Nil(err)
 	assert.Equal("LOCAL_VAL", blueButtonID)
 
-	// A record with the same HICN value exists.  Grab that value.
-	cclfFile := CCLFFile{
-		Name:            "HASHTEST",
-		CCLFNum:         8,
-		ACOCMSID:        "12345",
-		PerformanceYear: 2019,
-		Timestamp:       time.Now(),
-	}
-	db.Save(&cclfFile)
-	defer db.Unscoped().Delete(&cclfFile)
-	cclfBeneficiary.FileID = cclfFile.ID
-	// Save a blank one, this shouldn't affect pulling a val from the DB later
-	cclfBeneficiary.BlueButtonID = ""
-	err = db.Create(&cclfBeneficiary).Error
-	defer db.Unscoped().Delete(&cclfBeneficiary)
-	assert.Nil(err)
-	cclfBeneficiary.ID = 0
-	cclfBeneficiary.BlueButtonID = "DB_VALUE"
-	err = db.Create(&cclfBeneficiary).Error
-	defer db.Unscoped().Delete(&cclfBeneficiary)
-
-	assert.Nil(err)
-	newCCLFBeneficiary := CCLFBeneficiary{HICN: cclfBeneficiary.HICN, MBI: "NOT_AN_MBI"}
-	newBBID, err := newCCLFBeneficiary.GetBlueButtonID(&bbc)
-	assert.Nil(err)
-	assert.Equal("DB_VALUE", newBBID)
-	// Should be making only a single call to BB for all 3 attempts.
+	// Should be making only a single call to BB for all 2 attempts.
 	bbc.AssertNumberOfCalls(s.T(), "GetPatientByHICNHash", 1)
 }


### PR DESCRIPTION
### Fixes [BCDA-2373](https://jira.cms.gov/browse/BCDA-2373)

Queries to `cclf_beneficiaries` to find pre-existing Blue Button IDs are proving to be inefficient (3-4 second execution time).   Acquiring the Blue Button ID directly via lean `/Patient` call to Blue Button might speed up processing.

### Change Details

- Removed inefficient query.

### Security Implications

This is a performance optimization implemented by removing code.  No security implications are involved. 

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Only local testing has been performed, due to DB/data size differences between `prod` and lower environments.

Additionally, the straight query was executed on `prod` and proven to take ~4 seconds in most cases (note that in the query below, the [HICN is synthetic](https://github.com/CMSgov/bcda-app/blob/master/shared_files/cclf/files/synthetic/test/small/ZC8#L2) 

```
time psql <SECRET_DB_CONN_STRING> -c "select * from cclf_beneficiaries where hicn = '1000003701' and blue_button_id='' limit 1;"

real    0m4.120s
```


### Feedback Requested

Please review.
