### PR TITLE
BCDA-2372 Feature: Cleanup for removing old feature flags for coverage and patient

### DIFF
--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -113,45 +113,25 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 							Type:      "Endpoint",
 						},
 					},
+					{
+						Name: "export",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/Patient/$export",
+							Type:      "Endpoint",
+						},
+					},
+					{
+						Name: "export",
+						Definition: &fhirmodels.Reference{
+							Reference: baseurl + "/api/v1/Coverage/$export",
+							Type:      "Endpoint",
+						},
+					},
 				},
 			},
 		},
 	}
-	addPatientEndpointToStatement(statement, baseurl)
-	addCoverageEndpointToStatement(statement, baseurl)
 	return statement
-}
-
-func addPatientEndpointToStatement(statement *fhirmodels.CapabilityStatement, baseUrl string) {
-	if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
-		restComponent := statement.Rest[0].Operation
-
-		element := fhirmodels.CapabilityStatementRestOperationComponent{
-			Name: "export",
-			Definition: &fhirmodels.Reference{
-				Reference: baseUrl + "/api/v1/Patient/$export",
-				Type:      "Endpoint",
-			},
-		}
-		restComponent = append(restComponent, element)
-		statement.Rest[0].Operation = restComponent
-	}
-}
-
-func addCoverageEndpointToStatement(statement *fhirmodels.CapabilityStatement, baseUrl string) {
-	if os.Getenv("ENABLE_COVERAGE_EXPORT") == "true" {
-		restComponent := statement.Rest[0].Operation
-
-		element := fhirmodels.CapabilityStatementRestOperationComponent{
-			Name: "export",
-			Definition: &fhirmodels.Reference{
-				Reference: baseUrl + "/api/v1/Coverage/$export",
-				Type:      "Endpoint",
-			},
-		}
-		restComponent = append(restComponent, element)
-		statement.Rest[0].Operation = restComponent
-	}
 }
 
 func WriteCapabilityStatement(statement *fhirmodels.CapabilityStatement, w http.ResponseWriter) {

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -187,8 +187,6 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 func (s *APITestSuite) TestBulkPatientRequest() {
 	err := cclfUtils.ImportCCLFPackage("dev", "test")
 	assert.Nil(s.T(), err)
-	origPtExp := os.Getenv("ENABLE_PATIENT_EXPORT")
-	os.Setenv("ENABLE_PATIENT_EXPORT", "true")
 	acoID := constants.DevACOUUID
 	user, err := models.CreateUser("api.go Test User", "testbulkpatientrequest@example.com", uuid.Parse(acoID))
 	if err != nil {
@@ -196,7 +194,6 @@ func (s *APITestSuite) TestBulkPatientRequest() {
 	}
 
 	defer func() {
-		os.Setenv("ENABLE_PATIENT_EXPORT", origPtExp)
 		s.db.Where("user_id = ?", user.UUID).Delete(models.Job{})
 		s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 	}()
@@ -230,9 +227,6 @@ func (s *APITestSuite) TestBulkPatientRequest() {
 }
 
 func (s *APITestSuite) TestBulkCoverageRequest() {
-	origPtExp := os.Getenv("ENABLE_COVERAGE_EXPORT")
-	os.Setenv("ENABLE_COVERAGE_EXPORT", "true")
-
 	acoID := constants.DevACOUUID
 	user, err := models.CreateUser("api.go Test User", "testbulkcoveragerequest@example.com", uuid.Parse(acoID))
 	if err != nil {
@@ -240,7 +234,6 @@ func (s *APITestSuite) TestBulkCoverageRequest() {
 	}
 
 	defer func() {
-		os.Setenv("ENABLE_COVERAGE_EXPORT", origPtExp)
 		s.db.Where("user_id = ?", user.UUID).Delete(models.Job{})
 		s.db.Where("uuid = ?", user.UUID).Delete(models.User{})
 	}()

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -30,12 +30,8 @@ func NewAPIRouter() http.Handler {
 	}
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/ExplanationOfBenefit/$export", bulkEOBRequest))
-		if os.Getenv("ENABLE_PATIENT_EXPORT") == "true" {
-			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Patient/$export", bulkPatientRequest))
-		}
-		if os.Getenv("ENABLE_COVERAGE_EXPORT") == "true" {
-			r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Coverage/$export", bulkCoverageRequest))
-		}
+		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Patient/$export", bulkPatientRequest))
+		r.With(auth.RequireTokenAuth, ValidateBulkRequestHeaders).Get(m.WrapHandler("/Coverage/$export", bulkCoverageRequest))
 		r.With(auth.RequireTokenAuth, auth.RequireTokenJobMatch).Get(m.WrapHandler("/jobs/{jobID}", jobStatus))
 		r.Get(m.WrapHandler("/metadata", metadata))
 	})

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -110,23 +110,13 @@ func (s *RouterTestSuite) TestEOBExportRoute() {
 }
 
 func (s *RouterTestSuite) TestPatientExportRoute() {
-	origPtExp := os.Getenv("ENABLE_PATIENT_EXPORT")
-	defer os.Setenv("ENABLE_PATIENT_EXPORT", origPtExp)
-
-	os.Setenv("ENABLE_PATIENT_EXPORT", "true")
 	req := httptest.NewRequest("GET", "/api/v1/Patient/$export", nil)
 	rr := httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res := rr.Result()
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 
-	os.Setenv("ENABLE_PATIENT_EXPORT", "false")
-	rr = httptest.NewRecorder()
-	NewAPIRouter().ServeHTTP(rr, req)
-	res = rr.Result()
-	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
-
-	os.Unsetenv("ENABLE_PATIENT_EXPORT")
+	req = httptest.NewRequest("GET", "/api/v1/Patients/$export", nil)
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
@@ -134,27 +124,18 @@ func (s *RouterTestSuite) TestPatientExportRoute() {
 }
 
 func (s *RouterTestSuite) TestCoverageExportRoute() {
-	origCovExp := os.Getenv("ENABLE_COVERAGE_EXPORT")
-	defer os.Setenv("ENABLE_COVERAGE_EXPORT", origCovExp)
-
-	os.Setenv("ENABLE_COVERAGE_EXPORT", "true")
 	req := httptest.NewRequest("GET", "/api/v1/Coverage/$export", nil)
 	rr := httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res := rr.Result()
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 
-	os.Setenv("ENABLE_COVERAGE_EXPORT", "false")
+	req = httptest.NewRequest("GET", "/api/v1/Coverages/$export", nil)
 	rr = httptest.NewRecorder()
 	NewAPIRouter().ServeHTTP(rr, req)
 	res = rr.Result()
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 
-	os.Unsetenv("ENABLE_COVERAGE_EXPORT")
-	rr = httptest.NewRecorder()
-	NewAPIRouter().ServeHTTP(rr, req)
-	res = rr.Result()
-	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 }
 
 func (s *RouterTestSuite) TestJobStatusRoute() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
       - ATO_PUBLIC_KEY_FILE=../../shared_files/ATO_public.pem
       - ATO_PRIVATE_KEY_FILE=../../shared_files/ATO_private.pem
       - HTTP_ONLY=true
-      - ENABLE_PATIENT_EXPORT=true
-      - ENABLE_COVERAGE_EXPORT=true
       - BB_CLIENT_CERT_FILE=../shared_files/bb-dev-test-cert.pem
       - BB_CLIENT_KEY_FILE=../shared_files/bb-dev-test-key.pem
       - BB_SERVER_LOCATION=https://fhir.backend.bluebutton.hhsdevcloud.us


### PR DESCRIPTION
Fixes [BCDA-2372](https://jira.cms.gov/browse/BCDA-2372)

Problem:
We have progressed past the point of needing feature flags for 2 of our main bulk data requests. At first, both Coverage and Patient endpoints were only exposed via environment variables allowing a smooth rollout of features. At this point in time the env vars are no longer needed as both have been fully implemented.

Proposed Changes:
Removed old environment variables for both patient and coverage endpoint exposure.

Change Details:
bcda/responseutils/writer.go - maintained both endpoints but removed extra methods
bcda/web/api_test.go - removed feature flags from tests.
bcda/web/router.go - removed feature flags for coverage and patient routes.
bcda/web/router_test.go - removed feature flags from tests.


Security Implications:
None, this change does **not** deal with any PII/PHI at all.

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation:
All tests, pass.

Feedback Requested:
Any and all
