### PR TITLE
BCDA-1799 Feature: Added oauth endpoint to capability statement

### DIFF
--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -57,15 +57,9 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 					Service: []fhirmodels.CodeableConcept{
 						{
 							Coding: []fhirmodels.Coding{
-								{Display: "OAuth", Code: "OAuth", System: "http://hl7.org/fhir/ValueSet/restful-security-service"},
-							},
-							Text: "OAuth",
-						},
-						{
-							Coding: []fhirmodels.Coding{
 								{Display: "SMART-on-FHIR", Code: "SMART-on-FHIR", System: "http://hl7.org/fhir/ValueSet/restful-security-service"},
 							},
-							Text: "SMART-on-FHIR",
+							Text: "OAuth2 using SMART-on-FHIR",
 						},
 					},
 				},
@@ -117,7 +111,23 @@ func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *f
 			},
 		},
 	}
+	addOauthEndpointToStatement(statement, baseurl)
 	return statement
+}
+
+func addOauthEndpointToStatement(statement *fhirmodels.CapabilityStatement, baseUrl string) {
+	securityComponent := statement.Rest[0].Security
+	extension := []fhirmodels.Extension{
+		{
+			Url: "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+		},
+		{
+			Url:      "token",
+			ValueUri: baseUrl + "/auth/token",
+		},
+	}
+	securityComponent.Extension = extension
+	statement.Rest[0].Security = securityComponent
 }
 
 func WriteCapabilityStatement(statement *fhirmodels.CapabilityStatement, w http.ResponseWriter) {


### PR DESCRIPTION
Fixes [BCDA-1799](https://jira.cms.gov/browse/BCDA-1799)

Problem:
According to the fhir spec here: http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-cs
oauth endpoints need to be included in our capability statement. Doing this change will make us more compliant with fhir standards.

Proposed Changes:
Added oauth token endpoint to our capability statement.

Change Details:
bcda/responseutils/writer.go - Added token endpoint to our capability statement.

Security Implications:
No this change **does not** deal with PII/PHI at all.

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation:
Yes, all tests pass and was able to see the new endpoint.

![image](https://user-images.githubusercontent.com/42976557/70251582-cac43b80-174d-11ea-8101-04638472f1f3.png)

Feedback Requested:
Any and all. There's two items of concern for this fix.
1) The top level link provided in the extension url is broken. "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris" is provided in the example capability statement but doesn't look like it's being maintained.

2) The extension object itself is not being nested as shown in the oauth endpoint example here:
![image](https://user-images.githubusercontent.com/42976557/70261555-ae7dca00-1760-11ea-8c99-f89cdce474f7.png)

See our screenshot for the difference. Not quite sure if this is a big deal, but currently I don't see a way to add an extension object within another extension object given the strict nature of the fhir models: github.com/eug48/fhir/models. Seems like that image is not representative of their own model capabilities...