### PR TITLE
BCDA-2414 Add indexes to cclf_beneficiaries

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -436,9 +436,9 @@ func (cclfFile *CCLFFile) Delete() error {
 type CCLFBeneficiary struct {
 	gorm.Model
 	CCLFFile     CCLFFile
-	FileID       uint   `gorm:"not null"`
-	HICN         string `gorm:"type:varchar(11);not null"`
-	MBI          string `gorm:"type:char(11);not null"`
+	FileID       uint   `gorm:"not null;index:idx_cclf_beneficiaries_file_id"`
+	HICN         string `gorm:"type:varchar(11);not null;index:idx_cclf_beneficiaries_hicn"`
+	MBI          string `gorm:"type:char(11);not null;index:idx_cclf_beneficiaries_mbi"`
 	BlueButtonID string `gorm:"type: text"`
 }
 

--- a/db/migrations/20191211-index-cclf-imports.sql
+++ b/db/migrations/20191211-index-cclf-imports.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_cclf_beneficiaries_file_id ON public.cclf_beneficiaries USING btree (file_id);
+CREATE INDEX idx_cclf_beneficiaries_hicn ON public.cclf_beneficiaries USING btree (hicn);

--- a/db/migrations/20191211-index-cclf-imports.sql
+++ b/db/migrations/20191211-index-cclf-imports.sql
@@ -1,2 +1,3 @@
 CREATE INDEX idx_cclf_beneficiaries_file_id ON public.cclf_beneficiaries USING btree (file_id);
 CREATE INDEX idx_cclf_beneficiaries_hicn ON public.cclf_beneficiaries USING btree (hicn);
+CREATE INDEX idx_cclf_beneficiaries_mbi ON public.cclf_beneficiaries USING btree (mbi);

--- a/db/migrations/20191211-index-cclf-imports.sql
+++ b/db/migrations/20191211-index-cclf-imports.sql
@@ -1,3 +1,0 @@
-CREATE INDEX idx_cclf_beneficiaries_file_id ON public.cclf_beneficiaries USING btree (file_id);
-CREATE INDEX idx_cclf_beneficiaries_hicn ON public.cclf_beneficiaries USING btree (hicn);
-CREATE INDEX idx_cclf_beneficiaries_mbi ON public.cclf_beneficiaries USING btree (mbi);


### PR DESCRIPTION
### Fixes [BCDA-2414](https://jira.cms.gov/browse/BCDA-2414)
The `aco.GetBeneficiaries()` method is slower than we'd like.  In particular, https://github.com/CMSgov/bcda-app/blob/c5c04b84b08fd1a1416dd665e167016b412101e9/bcda/models/models.go#L265 has been taking about 11 seconds to complete.

After adding indexes on two columns, it is sped up 100-fold.

### Proposed Changes
- Add two indexes to the `cclf_beneficiaries` table
    - `hicn`
    - `file_id` 

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

The addition of these indexes has a small impact on availability.  The intended (and tested) impact is a significant increase in speed for some queries.  The possible unintended impact would be a slowdown for writes to the table, but 1) the chance is low and 2) this would affect automated processes only, not user queries.

### Migration Strategy
This is already active in `prod` and `dev`.  GORM will update the `test` during the next deployment, and we will run a Jenkins job to update `opensbx`.

### Acceptance Validation
Sample query execution time
- Before indexes: ~11s
- After indexes: ~.1s

### Feedback Requested
- Are other queries affected?
- Is there a different index type anyone would recommend?