### PR TITLE
Bug Fix: Only the worker should transition job state

### DIFF
--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -303,21 +303,9 @@ func jobStatus(w http.ResponseWriter, r *http.Request) {
 	case "Pending":
 		fallthrough
 	case "In Progress":
-		// Check the job status in case it is done and just needs a small poke
-		complete, err := job.CheckCompletedAndCleanup()
-
-		if err != nil {
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
-			return
-		}
-		if !complete {
-			w.Header().Set("X-Progress", job.StatusMessage())
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		fallthrough
-
+		w.Header().Set("X-Progress", job.StatusMessage())
+		w.WriteHeader(http.StatusAccepted)
+		return
 	case "Completed":
 		// If the job should be expired, but the cleanup job hasn't run for some reason, still respond with 410
 		if job.UpdatedAt.Add(GetJobTimeout()).Before(time.Now()) {


### PR DESCRIPTION

### Fixes Race Condition in Transitioning Job State to `Completed`

If the job status endpoint is called while the job is `In Progress`, the API attempts to double-check the job to see if it is actually done.  In the event where the workers complete the job during the small window of time where the API is double-checking, the files will never get moved from `staging` to `payload` because the API 
As a result, we'll need to fix this to ensure job state is only transitioned by workers.

### Change Details

Updated the job status endpoint functionality so that if the job is `In Progress`, we simply return the progress; we no longer attempt to see if the job is `Complete`.

### Security Implications

No PII/PHI is dealt with in this change.  This is a bug fix which eliminates a potential race condition in transitioning job state.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Validated via smoke test execution on `dev` and `test`.

### Feedback Requested

Please review.
