### PR TITLE
BCDA-2491 Feature: Filter CCLF files to valid date range

### DIFF
--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 const BADUUID = "QWERTY-ASDFG-ZXCVBN-POIUYT"
+var origDate string
 
 type CLITestSuite struct {
 	suite.Suite
@@ -45,6 +46,8 @@ func (s *CLITestSuite) SetupSuite() {
 	}
 	testUtils.SetUnitTestKeysForAuth()
 	auth.InitAlphaBackend() // should be a provider thing ... inside GetProvider()?
+	origDate = os.Getenv("CCLF_REF_DATE")
+	os.Setenv("CCLF_REF_DATE", "181125")
 }
 
 func (s *CLITestSuite) SetupTest() {
@@ -54,6 +57,10 @@ func (s *CLITestSuite) SetupTest() {
 
 func (s *CLITestSuite) TearDownTest() {
 	testUtils.PrintSeparator()
+}
+
+func (s *CLITestSuite) TearDownSuite() {
+	os.Setenv("CCLF_REF_DATE", origDate)
 }
 
 func TestCLITestSuite(t *testing.T) {

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -296,8 +296,9 @@ func getCCLFArchiveMetadata(filePath string) (cclfFileMetadata, error) {
 	}
 
 	// Files must be no older than 45 days
-	filesBefore := refDate.Add(time.Duration(int64(time.Hour) * int64(24)))
-	if t.Before(filesBefore) || t.After(time.Now()) {
+	filesNotBefore := refDate.Add(-1 * time.Duration(int64(time.Hour) * int64(24 * 45)))
+	filesNotAfter := refDate
+	if t.Before(filesNotBefore) || t.After(filesNotAfter) {
 		fmt.Printf("Date '%s' from file %s is out of range; comparison date %s\n", date, filePath, refDate.Format("060102"))
 		err = errors.New(fmt.Sprintf("date '%s' from file %s out of range; comparison date %s", date, filePath, refDate.Format("060102")))
 		log.Error(err)

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -253,6 +253,7 @@ func importCCLF(fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *g
 }
 
 func getCCLFArchiveMetadata(filePath string) (cclfFileMetadata, error) {
+	maxFileDays := utils.GetEnvInt("CCLF_MAX_AGE", 45)
 	refDateString := os.Getenv("CCLF_REF_DATE")
 	refDate, err := time.Parse("060102", refDateString)
 	if err != nil {
@@ -295,8 +296,8 @@ func getCCLFArchiveMetadata(filePath string) (cclfFileMetadata, error) {
 		return metadata, err
 	}
 
-	// Files must be no older than 45 days
-	filesNotBefore := refDate.Add(-1 * time.Duration(int64(time.Hour) * int64(24 * 45)))
+	// Files must not be too old
+	filesNotBefore := refDate.Add(-1 * time.Duration(int64(maxFileDays*24) * int64(time.Hour)))
 	filesNotAfter := refDate
 	if t.Before(filesNotBefore) || t.After(filesNotAfter) {
 		fmt.Printf("Date '%s' from file %s is out of range; comparison date %s\n", date, filePath, refDate.Format("060102"))

--- a/bcda/cclf/testutils/cclfUtils_test.go
+++ b/bcda/cclf/testutils/cclfUtils_test.go
@@ -14,9 +14,21 @@ type CCLFUtilTestSuite struct {
 	suite.Suite
 }
 
+var origDate string
+
+func (s *CCLFUtilTestSuite) SetupSuite() {
+	origDate = os.Getenv("CCLF_REF_DATE")
+}
+
 func (s *CCLFUtilTestSuite) SetupTest() {
 	models.InitializeGormModels()
+	os.Setenv("CCLF_REF_DATE", "D181201")
 }
+
+func (s *CCLFUtilTestSuite) TearDownSuite() {
+	os.Setenv("CCLF_REF_DATE", origDate)
+}
+
 
 func TestCCLFTestSuite(t *testing.T) {
 	suite.Run(t, new(CCLFUtilTestSuite))
@@ -24,6 +36,7 @@ func TestCCLFTestSuite(t *testing.T) {
 
 func (s *CCLFUtilTestSuite) TestImportInvalidSizeACO() {
 	assert := assert.New(s.T())
+	os.Setenv("CCLF_REF_DATE", "D190617")
 	err := ImportCCLFPackage("NOTREAL", "test")
 	assert.EqualError(err, "invalid argument for ACO size")
 }

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -44,11 +44,16 @@ type APITestSuite struct {
 	reset func()
 }
 
+var origDate string
+
 func (s *APITestSuite) SetupSuite() {
 	s.reset = testUtils.SetUnitTestKeysForAuth() // needed until token endpoint moves to auth
+	origDate = os.Getenv("CCLF_REF_DATE")
+	os.Setenv("CCLF_REF_DATE", "191224")
 }
 
 func (s *APITestSuite) TearDownSuite() {
+	os.Setenv("CCLF_REF_DATE", origDate)
 	s.reset()
 }
 


### PR DESCRIPTION
### Fixes [BCDA-2491](https://jira.cms.gov/browse/BCDA-2491)
If for some reason an old CCLF file is presented, or a post-dated CCLF file, we should not attempt to ingest the data. 

### Proposed Changes
- Ignore CCLF files in the future
- Ignore CCLF files more the 45 days in the past

### Change Details
- For testing purposes, allow for an optional environmental variable to set the file comparison date, which defaults to `time.Now()`

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

If anything, this change improves security by reducing the range of unexpected and probably incorrect data that will be used by BCDA.

### Acceptance Validation
- Existing and new tests passing

### Feedback Requested
- Is there any downside to using the environmental variable for selecting a file comparison date?