### PR TITLE
BCDA-2503: Optimize response time for bulk data request

### DIFF
--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -467,13 +467,51 @@ func (s *ModelsTestSuite) TestJobwithKeysCompleted() {
 
 }
 
-func (s *ModelsTestSuite) TestGetEnqueJobs_Patient() {
+func (s *ModelsTestSuite) TestGetEnqueJobs_AllResourcesTypes() {
 	assert := s.Assert()
 
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
 		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
 		RequestURL: "/api/v1/Patient/$export",
+		Status:     "Pending",
+	}
+	s.db.Save(&j)
+	defer s.db.Delete(&j)
+
+	enqueueJobs, err := j.GetEnqueJobs([]string{"Patient", "ExplanationOfBenefit", "Coverage"})
+	assert.Nil(err)
+	assert.NotNil(enqueueJobs)
+	assert.Equal(3, len(enqueueJobs))
+	var count = 0
+	for _, queJob := range enqueueJobs {
+		jobArgs := jobEnqueueArgs{}
+		err := json.Unmarshal(queJob.Args, &jobArgs)
+		if err != nil {
+			s.T().Error(err)
+		}
+		assert.Equal(int(j.ID), jobArgs.ID)
+		assert.Equal(constants.DevACOUUID, jobArgs.ACOID)
+		assert.Equal("6baf8254-2e8a-4808-b11d-0fa00c527d2e", jobArgs.UserID)
+		if count == 0 {
+			assert.Equal("Patient", jobArgs.ResourceType)
+		} else if count == 1 {
+			assert.Equal("ExplanationOfBenefit", jobArgs.ResourceType)
+		} else {
+			assert.Equal("Coverage", jobArgs.ResourceType)
+		}
+		assert.Equal(50, len(jobArgs.BeneficiaryIDs))
+		count++
+	}
+}
+
+func (s *ModelsTestSuite) TestGetEnqueJobs_Patient() {
+	assert := s.Assert()
+
+	j := Job{
+		ACOID:      uuid.Parse(constants.DevACOUUID),
+		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
+		RequestURL: "/api/v1/Patient/$export?_type=Patient",
 		Status:     "Pending",
 	}
 	s.db.Save(&j)
@@ -504,7 +542,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_EOB() {
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
 		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
-		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
+		RequestURL: "/api/v1/Patient/$export?_type=ExplanationOfBenefit",
 		Status:     "Pending",
 	}
 	s.db.Save(&j)
@@ -539,7 +577,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_Coverage() {
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
 		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
-		RequestURL: "/api/v1/Coverage/$export",
+		RequestURL: "/api/v1/Patient/$export?_type=Coverage",
 		Status:     "Pending",
 	}
 	s.db.Save(&j)

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -479,7 +479,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_Patient() {
 	s.db.Save(&j)
 	defer s.db.Delete(&j)
 
-	enqueueJobs, err := j.GetEnqueJobs("Patient")
+	enqueueJobs, err := j.GetEnqueJobs([]string{"Patient"})
 	assert.Nil(err)
 	assert.NotNil(enqueueJobs)
 	assert.Equal(1, len(enqueueJobs))
@@ -514,7 +514,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_EOB() {
 	if err != nil {
 		s.T().Error(err)
 	}
-	enqueueJobs, err := j.GetEnqueJobs("ExplanationOfBenefit")
+	enqueueJobs, err := j.GetEnqueJobs([]string{"ExplanationOfBenefit"})
 	assert.Nil(err)
 	assert.NotNil(enqueueJobs)
 	assert.Equal(4, len(enqueueJobs))
@@ -550,7 +550,7 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_Coverage() {
 		s.T().Error(err)
 	}
 
-	enqueueJobs, err := j.GetEnqueJobs("Coverage")
+	enqueueJobs, err := j.GetEnqueJobs([]string{"Coverage"})
 	assert.Nil(err)
 	assert.NotNil(enqueueJobs)
 	assert.Equal(10, len(enqueueJobs))

--- a/bcda/servicemux/servicemux.go
+++ b/bcda/servicemux/servicemux.go
@@ -16,7 +16,7 @@ import (
 	"github.com/soheilhy/cmux"
 )
 
-var keepAliveInterval int = 30
+var keepAliveInterval int = 60
 
 func init() {
 	interval := os.Getenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL")

--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -163,15 +163,12 @@ func bulkRequest(resourceTypes []string, w http.ResponseWriter, r *http.Request)
 	}
 
 	var enqueueJobs []*que.Job
-	for _, t := range resourceTypes {
-		jobs, err := newJob.GetEnqueJobs(t)
-		if err != nil {
-			log.Error(err)
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
-			return
-		}
-		enqueueJobs = append(enqueueJobs, jobs...)
+	enqueueJobs, err = newJob.GetEnqueJobs(resourceTypes)
+	if err != nil {
+		log.Error(err)
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Processing)
+		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		return
 	}
 
         if db.Model(&newJob).Update("job_count", len(enqueueJobs)).Error != nil {


### PR DESCRIPTION
### Fixes [BCDA-2503](https://jira.cms.gov/browse/BCDA-2503)

For large ACOs, the response to a bulk data request can exceed 30 seconds.

### Change Details

- Increase the application timeout to align with the ALB's upper bound of 60 seconds.
- Optimized the logic that is executed when a bulk data request is made, so that retrieval of beneficiaries is performed one time instead of multiple times per resource type.

### Security Implications

This change does not affect data access; it instead optimizes existing logic.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

This feature branch was deployed to `dev` and tested by using the extra large test ACO to make a bulk data request.
- Using code in `master`,  the response time from bulk data request using extra large test ACO is ~2.5s.
- Using code in this feature branch, the response time from bulk data request using extra large test ACO is ~1s. 

### Feedback Requested

Please review.
