### PR TITLE
BCDA-2506b Feature: Fixed bug for sql statement for null blue_button_ids

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -282,7 +282,7 @@ func GetSuppressedBlueButtonIDs() []string {
 			FROM (
 				SELECT blue_button_id, MAX(effective_date) max_date
 				FROM suppressions
-				WHERE effective_date <= NOW() AND preference_indicator != '' AND blue_button_id != ''
+				WHERE effective_date <= NOW() AND preference_indicator != '' AND blue_button_id != '' AND blue_button_id IS NOT NULL
 				GROUP BY blue_button_id
 			) h
 			JOIN suppressions s ON s.blue_button_id = h.blue_button_id and s.effective_date = h.max_date
@@ -583,7 +583,7 @@ func StoreSuppressionBBID() (success, failure int, err error) {
 	}
 
 	var suppressList []Suppression
-	db.Find(&suppressList, "blue_button_id = ''")
+	db.Find(&suppressList, "blue_button_id = '' OR blue_button_id is NULL")
 	for _, suppressBene := range suppressList {
 		bbID, err := suppressBene.GetBlueButtonID(bb)
 		if err != nil {


### PR DESCRIPTION
Fixes [BCDA-2506b](https://jira.cms.gov/browse/BCDA-2506b)

Problem:
After merging and testing the original feature ticket BCDA-2506, a bug was discovered in our smoke tests for blue button ids that were set as NULL. Our original query only checked for empty string values but we also need to account for values set to NULL as well.

Proposed Changes:
Adds a null check to both the suppression query list and for the population of suppression records that need to request for blue button ids.

Change Details:
bcda/models/models.go - Adds a null check

Security Implications:
This particular change does not, but the overall change in ticket BCDA-2506 does deal with PII/PHI data. It uses hashed hicn values to make request for BB ids.

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [x] security checklist is completed for this change
https://confluence.cms.gov/pages/viewpage.action?spaceKey=BCDA&title=20-01-13%3A+Query+by+MBI+instead+of+by+HICN+-+Security+Checklist

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation:
Tested locally, with null db values.

Feedback Requested:
Any and all