### PR TITLE
BCDA-2506c Feature: Removed extraneous log statements

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -587,8 +587,6 @@ func StoreSuppressionBBID() (success, failure int, err error) {
 	for _, suppressBene := range suppressList {
 		bbID, err := suppressBene.GetBlueButtonID(bb)
 		if err != nil {
-			fmt.Printf("Failed to find bluebutton id for suppression file: %v.\n", suppressBene.FileID)
-			log.Errorf("Failed to find bluebutton id for suppression file: %v", suppressBene.FileID)
 			failure++
 			continue
 		}


### PR DESCRIPTION
Fixes [BCDA-2506c](https://jira.cms.gov/browse/BCDA-2506c)

Problem:
After implementation of the original BCDA-2506 it was noticed that some log statements were duplicated with similar bits of information.

Proposed Changes:
This change removes the extraneous log statements

Change Details:
bcda/models/models.go  - removed extra log statements

Security Implications:
No, this change does **not** deal with any PII/PHI data

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation:
Tested locally and it works. See new output below

<!-- Insert screenshots if applicable (drag images here) -->
![image](https://user-images.githubusercontent.com/42976557/72636273-b36f9500-392c-11ea-9ea0-ef52b175e53a.png)

Feedback Requested:
Any and all