### PR TITLE
BCDA-2596 Maintenance: Remove users table

### DIFF
--- a/bcda/auth/alpha_test.go
+++ b/bcda/auth/alpha_test.go
@@ -128,7 +128,6 @@ func (s *AlphaAuthPluginTestSuite) TestResetSecret() {
 func (s *AlphaAuthPluginTestSuite) TestAccessToken() {
 	cmsID := testUtils.RandomHexID()[0:4]
 	acoUUID, _ := models.CreateACO("TestAccessToken", &cmsID)
-	user, _ := models.CreateUser("Test Access Token", "testaccesstoken@examplecom", acoUUID)
 	cc, err := s.p.RegisterSystem(acoUUID.String(), "", "")
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), cc)
@@ -145,7 +144,6 @@ func (s *AlphaAuthPluginTestSuite) TestAccessToken() {
 	assert.Empty(s.T(), ts)
 	assert.Contains(s.T(), err.Error(), "invalid credentials")
 	connections["TestAccessToken"].Where("client_id = ?", cc.ClientID).Delete(&models.ACO{})
-	connections["TestAccessToken"].Delete(&user)
 
 	ts, err = s.p.MakeAccessToken(auth.Credentials{})
 	assert.NotNil(s.T(), err)
@@ -175,10 +173,8 @@ func (s *AlphaAuthPluginTestSuite) TestRevokeAccessToken() {
 }
 
 func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
-	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
 	acoID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	validClaims := jwt.MapClaims{
-		"sub": userID,
 		"aco": acoID,
 		"id":  "d63205a8-d923-456b-a01b-0992fcb40968",
 		"iat": time.Now().Unix(),
@@ -193,7 +189,6 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 
 	unknownAco := jwt.New(jwt.SigningMethodRS512)
 	unknownAco.Claims = jwt.MapClaims{
-		"sub": userID,
 		"aco": uuid.NewRandom().String(),
 		"id":  "d63205a8-d923-456b-a01b-0992fcb40968",
 		"iat": time.Now().Unix(),
@@ -216,7 +211,6 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 
 	missingClaims := jwt.New(jwt.SigningMethodRS512)
 	missingClaims.Claims = jwt.MapClaims{
-		"sub": userID,
 		"aco": acoID,
 		"id":  "d63205a8-d923-456b-a01b-0992fcb40968",
 	}
@@ -227,7 +221,6 @@ func (s *AlphaAuthPluginTestSuite) TestValidateAccessToken() {
 
 	expiredToken := jwt.New(jwt.SigningMethodRS512)
 	expiredToken.Claims = jwt.MapClaims{
-		"sub": userID,
 		"aco": acoID,
 		"id":  uuid.NewRandom().String(),
 		"iat": time.Now().Unix(),

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -63,20 +63,11 @@ func ParseToken(next http.Handler) http.Handler {
 				db := database.GetGORMDbConnection()
 				defer database.Close(db)
 
-				var user models.User
-				if db.First(&user, "aco_id = ?", aco.UUID).RecordNotFound() {
-					log.Errorf("no user for ACO with id of %v", aco.UUID)
-					next.ServeHTTP(w, r)
-					return
-				}
-
 				ad.TokenID = claims.Id
 				ad.ACOID = aco.UUID.String()
-				ad.UserID = user.UUID.String()
 			default:
 				ad.TokenID = claims.UUID
 				ad.ACOID = claims.ACOID
-				ad.UserID = claims.Subject
 			}
 		}
 		ctx := context.WithValue(r.Context(), "token", token)

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -154,7 +154,6 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchWithWrongACO() {
 
 	j := models.Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Failed",
 	}
@@ -193,7 +192,6 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchWithRightACO() {
 
 	j := models.Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Failed",
 	}
@@ -237,7 +235,6 @@ func (s *MiddlewareTestSuite) TestRequireTokenACOMatchInvalidToken() {
 
 	j := models.Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Failed",
 	}

--- a/bcda/auth/mokta.go
+++ b/bcda/auth/mokta.go
@@ -156,7 +156,6 @@ func (m *Mokta) NewCustomToken(overrides OktaToken) (string, error) {
 		"exp": time.Now().Add(time.Hour * time.Duration(values.ExpiresIn)).Unix(),
 		"cid": values.ClientID,
 		"scp": values.Scopes,
-		"sub": values.Subject,
 	}
 
 	return token.SignedString(m.privateKey)

--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -159,11 +159,6 @@ func adFromClaims(claims *CommonClaims) (AuthData, error) {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
-	var user models.User
-	if err = db.First(&user, "aco_id = ?", aco.UUID).Error; err != nil {
-		return ad, fmt.Errorf("no user for ACO with id of %v", aco.UUID)
-	}
-
 	return ad, nil
 }
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -41,7 +41,6 @@ func InitializeGormModels() *gorm.DB {
 	// you need to run a script to migrate existing data to its new home or shape?
 	db.AutoMigrate(
 		&ACO{},
-		&User{},
 		&Job{},
 		&JobKey{},
 		&CCLFBeneficiaryXref{},
@@ -60,8 +59,6 @@ type Job struct {
 	gorm.Model
 	ACO               ACO       `gorm:"foreignkey:ACOID;association_foreignkey:UUID"` // aco
 	ACOID             uuid.UUID `gorm:"type:char(36)" json:"aco_id"`
-	User              User      `gorm:"foreignkey:UserID;association_foreignkey:UUID"` // user
-	UserID            uuid.UUID `gorm:"type:char(36)"`
 	RequestURL        string    `json:"request_url"` // request_url
 	Status            string    `json:"status"`      // status
 	JobCount          int
@@ -139,7 +136,6 @@ func (job *Job) GetEnqueJobs(resourceTypes []string) (enqueJobs []*que.Job, err 
 				args, err := json.Marshal(jobEnqueueArgs{
 					ID:             int(job.ID),
 					ACOID:          job.ACOID.String(),
-					UserID:         job.UserID.String(),
 					BeneficiaryIDs: jobIDs,
 					ResourceType:   rt,
 				})
@@ -386,34 +382,6 @@ func CreateACO(name string, cmsID *string) (uuid.UUID, error) {
 	return aco.UUID, db.Error
 }
 
-type User struct {
-	gorm.Model
-	UUID  uuid.UUID `gorm:"primary_key; type:char(36)" json:"uuid"` // uuid
-	Name  string    `json:"name"`                                   // name
-	Email string    `json:"email"`                                  // email
-	ACO   ACO       `gorm:"foreignkey:ACOID;association_foreignkey:UUID"`
-	ACOID uuid.UUID `gorm:"type:char(36)" json:"aco_id"` // aco_id
-}
-
-func CreateUser(name string, email string, acoUUID uuid.UUID) (User, error) {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
-	var aco ACO
-	var user User
-	// If we don't find the ACO return a blank user and an error
-	if db.First(&aco, "UUID = ?", acoUUID).RecordNotFound() {
-		return user, fmt.Errorf("unable to locate ACO with id of %v", acoUUID)
-	}
-	// check for duplicate email addresses and only make one if it isn't found
-	if db.First(&user, "email = ?", email).RecordNotFound() {
-		user = User{UUID: uuid.NewRandom(), Name: name, Email: email, ACOID: aco.UUID}
-		db.Create(&user)
-		return user, nil
-	} else {
-		return user, fmt.Errorf("unable to create user for %v because a user with that Email address already exists", email)
-	}
-}
-
 // CLI command only support; note that we are choosing to fail quickly and let the user (one of us) figure it out
 func CreateAlphaACO(acoCMSID string, db *gorm.DB) (ACO, error) {
 	var count int
@@ -604,7 +572,6 @@ func StoreSuppressionBBID() (success, failure int, err error) {
 type jobEnqueueArgs struct {
 	ID             int
 	ACOID          string
-	UserID         string
 	BeneficiaryIDs []string
 	ResourceType   string
 }

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -367,29 +367,6 @@ OwIDAQAB
 	assert.Equal(s.T(), keyStr, string(pemBytes))
 }
 
-func (s *ModelsTestSuite) TestCreateUser() {
-	name, email, sampleUUID, duplicateName := "First Last", "firstlast@example.com", "DBBD1CE1-AE24-435C-807D-ED45953077D3", "Duplicate Name"
-
-	// Make a user for an ACO that doesn't exist
-	badACOUser, err := CreateUser(name, email, uuid.NewRandom())
-	//No ID because it wasn't saved
-	assert.True(s.T(), badACOUser.ID == 0)
-	// Should get an error
-	assert.NotNil(s.T(), err)
-
-	// Make a good user
-	user, err := CreateUser(name, email, uuid.Parse(sampleUUID))
-	assert.Nil(s.T(), err)
-	assert.NotNil(s.T(), user.UUID)
-	assert.NotNil(s.T(), user.ID)
-
-	// Try making a duplicate user for the same E-mail address
-	duplicateUser, err := CreateUser(duplicateName, email, uuid.Parse(sampleUUID))
-	// Got a user, not the one that was requested
-	assert.True(s.T(), duplicateUser.Name == name)
-	assert.NotNil(s.T(), err)
-}
-
 func TestModelsTestSuite(t *testing.T) {
 	suite.Run(t, new(ModelsTestSuite))
 }
@@ -398,7 +375,6 @@ func (s *ModelsTestSuite) TestJobCompleted() {
 
 	j := Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
 		Status:     "Pending",
 		JobCount:   1,
@@ -420,7 +396,6 @@ func (s *ModelsTestSuite) TestJobDefaultCompleted() {
 	// Job is completed, but no keys exist.  This is fine, it is still complete
 	j := Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
 		Status:     "Completed",
 		JobCount:   10,
@@ -437,7 +412,6 @@ func (s *ModelsTestSuite) TestJobwithKeysCompleted() {
 
 	j := Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
 		Status:     "Pending",
 		JobCount:   10,
@@ -472,7 +446,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_AllResourcesTypes() {
 
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
-		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
 		RequestURL: "/api/v1/Patient/$export",
 		Status:     "Pending",
 	}
@@ -492,7 +465,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_AllResourcesTypes() {
 		}
 		assert.Equal(int(j.ID), jobArgs.ID)
 		assert.Equal(constants.DevACOUUID, jobArgs.ACOID)
-		assert.Equal("6baf8254-2e8a-4808-b11d-0fa00c527d2e", jobArgs.UserID)
 		if count == 0 {
 			assert.Equal("Patient", jobArgs.ResourceType)
 		} else if count == 1 {
@@ -510,7 +482,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_Patient() {
 
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
-		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
 		RequestURL: "/api/v1/Patient/$export?_type=Patient",
 		Status:     "Pending",
 	}
@@ -530,7 +501,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_Patient() {
 		}
 		assert.Equal(int(j.ID), jobArgs.ID)
 		assert.Equal(constants.DevACOUUID, jobArgs.ACOID)
-		assert.Equal("6baf8254-2e8a-4808-b11d-0fa00c527d2e", jobArgs.UserID)
 		assert.Equal("Patient", jobArgs.ResourceType)
 		assert.Equal(50, len(jobArgs.BeneficiaryIDs))
 	}
@@ -541,7 +511,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_EOB() {
 
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
-		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
 		RequestURL: "/api/v1/Patient/$export?_type=ExplanationOfBenefit",
 		Status:     "Pending",
 	}
@@ -576,7 +545,6 @@ func (s *ModelsTestSuite) TestGetEnqueJobs_Coverage() {
 
 	j := Job{
 		ACOID:      uuid.Parse(constants.DevACOUUID),
-		UserID:     uuid.Parse("6baf8254-2e8a-4808-b11d-0fa00c527d2e"),
 		RequestURL: "/api/v1/Patient/$export?_type=Coverage",
 		Status:     "Pending",
 	}

--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -132,11 +132,6 @@ func bulkRequest(resourceTypes []string, w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	user := models.User{}
-	// Arbitrarily use the first user in order to satisfy foreign key constraint "jobs_user_id_fkey" until user is removed from jobs table
-	db.First(&user)
-	userID := user.UUID
-
 	scheme := "http"
 	if servicemux.IsHTTPS(r) {
 		scheme = "https"
@@ -144,7 +139,6 @@ func bulkRequest(resourceTypes []string, w http.ResponseWriter, r *http.Request)
 
 	newJob := models.Job{
 		ACOID:      uuid.Parse(acoID),
-		UserID:     userID,
 		RequestURL: fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL),
 		Status:     "Pending",
 	}

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -37,7 +37,6 @@ var (
 type jobEnqueueArgs struct {
 	ID             int
 	ACOID          string
-	UserID         string
 	BeneficiaryIDs []string
 	ResourceType   string
 }

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -359,7 +359,6 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 
 	j := models.Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
 		Status:     "Pending",
 		JobCount:   1,
@@ -373,7 +372,6 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 	jobArgs := jobEnqueueArgs{
 		ID:             int(j.ID),
 		ACOID:          j.ACOID.String(),
-		UserID:         j.UserID.String(),
 		BeneficiaryIDs: []string{"10000", "11000"},
 		ResourceType:   "ExplanationOfBenefit",
 	}
@@ -404,7 +402,6 @@ func (s *MainTestSuite) TestProcessJob_InvalidJobID() {
 	qjArgs, _ := json.Marshal(jobEnqueueArgs{
 		ID:             99999999,
 		ACOID:          "00000000-0000-0000-0000-000000000000",
-		UserID:         "00000000-0000-0000-0000-000000000000",
 		BeneficiaryIDs: []string{},
 		ResourceType:   "Patient",
 	})
@@ -423,7 +420,6 @@ func (s *MainTestSuite) TestProcessJob_NoBBClient() {
 
 	j := models.Job{
 		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:     uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL: "/api/v1/Patient/$export",
 		Status:     "Pending",
 		JobCount:   1,
@@ -433,7 +429,6 @@ func (s *MainTestSuite) TestProcessJob_NoBBClient() {
 	qjArgs, _ := json.Marshal(jobEnqueueArgs{
 		ID:             int(j.ID),
 		ACOID:          j.ACOID.String(),
-		UserID:         j.UserID.String(),
 		BeneficiaryIDs: []string{},
 		ResourceType:   "Patient",
 	})
@@ -464,7 +459,6 @@ func (s *MainTestSuite) TestUpdateJobStats() {
 
 	j := models.Job{
 		ACOID:             uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-		UserID:            uuid.Parse("82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"),
 		RequestURL:        "",
 		Status:            "",
 		JobCount:          4,

--- a/db/api.sql
+++ b/db/api.sql
@@ -9,20 +9,9 @@ create table acos (
   public_key text null
 );
 
-create table users (
-  uuid uuid not null primary key,
-  name text not null,
-  email text not null unique,
-  aco_id uuid not null,
-  created_at timestamp with time zone not null default now(),
-  updated_at timestamp with time zone not null default now(),
-  foreign key (aco_id) references acos (uuid)
-);
-
 create table jobs (
   id serial not null primary key,
   aco_id uuid not null references acos,
-  user_id uuid not null references users,
   request_url text not null,
   status text not null,
   created_at timestamp with time zone not null default now()

--- a/db/fixtures.sql
+++ b/db/fixtures.sql
@@ -31,21 +31,6 @@ insert into acos(uuid, cms_id, name, client_id)
             ('8D80925A-027E-43DD-8AED-9A501CC4CD91', 'A9992', 'ACO Large', '8D80925A-027E-43DD-8AED-9A501CC4CD91'),
             ('55954dba-d4d9-438d-bd03-453da4993fe9', 'A9993', 'ACO Extra Large', '55954dba-d4d9-438d-bd03-453da4993fe9');
 
-
-insert into users values ('82503A18-BF3B-436D-BA7B-BAE09B7FFD2F', 'User One', 'userone@email.com', 'DBBD1CE1-AE24-435C-807D-ED45953077D3', default, default);
-insert into users values ('EFE6E69A-CD6B-4335-A2F2-4DBEDCCD3E73', 'User Two', 'usertwo@email.com', 'DBBD1CE1-AE24-435C-807D-ED45953077D3', default, default);
-
-insert into users values ('B6DFAD18-62A1-4EA3-B623-38F11D49E0F6', 'User Three', 'userthree@email.com', 'A40404F7-1EF2-485A-9B71-40FE7ACDCBC2', default, default);
-insert into users values ('1E270119-E503-4F13-A6AC-54EC3FB44478', 'User Four', 'userfour@email.com', 'A40404F7-1EF2-485A-9B71-40FE7ACDCBC2', default, default);
-
-insert into users values ('7e125f32-edcc-444f-9d56-1434421bab40', 'User toRevoke', 'userrevoked@email.com', 'c14822fa-19ee-402c-9248-32af98419fe3', default, default);
-insert into users values ('1ec70f78-7bb1-434b-9024-1d88c253ccec', 'User toNotRevoke', 'usernotrevoked@email.com', 'c14822fa-19ee-402c-9248-32af98419fe3', default, default);
-
-insert into users values ('8c5f7cca-6ecd-4c18-83f8-15e59db3337b', 'User toRevoke', 'userrevoked2@email.com', '82f55b6a-728e-4c8b-807e-535caad7b139', default, default);
-insert into users values ('f85b3fc7-9d4e-49e1-8e7b-9feb3fb9f01b', 'User toNotRevoke', 'usernotrevoked2@email.com', '82f55b6a-728e-4c8b-807e-535caad7b139', default, default);
-
-insert into users values ('6baf8254-2e8a-4808-b11d-0fa00c527d2e', 'Dev User', 'devuser@acodev.com', '0c527d2e-2e8a-4808-b11d-0fa06baf8254', default, default);
-
 insert into tokens values ('d63205a8-d923-456b-a01b-0992fcb40968', 'fake.token.value', 'true');
 insert into tokens values ('f5bd210a-5f95-4ba6-a167-2e9c95b5fbc1', 'fake.token.value', 'false');
 

--- a/db/migrations/20200120-drop-users.sql
+++ b/db/migrations/20200120-drop-users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jobs DROP COLUMN user_id;
+DROP TABLE users;

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -2,8 +2,7 @@
 
 set -e
 function cleanup {
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM jobs WHERE aco_id = '"'"$ACO_ID"'"'"'
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM users WHERE aco_id = '"'"$ACO_ID"'"'"'
+        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM jobs WHERE aco_id IN (SELECT uuid FROM acos where cms_id = '"'"A9996"'"')"'
         docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM acos WHERE cms_id = '"'"'A9996'"'"'"'
         docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM encryption_keys WHERE system_id IN (SELECT id FROM systems WHERE group_id = '"'"'smoke-test-group'"'"')"'
         docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM secrets WHERE system_id IN (SELECT id FROM systems WHERE group_id = '"'"'smoke-test-group'"'"')"'
@@ -19,7 +18,6 @@ echo "waiting for API to rebuild with SSAS as auth provider"
 sleep 30
 
 ACO_ID=$(docker-compose exec api sh -c 'tmp/bcda create-aco --name "Smoke Test ACO" --cms-id A9996' | tail -n1 | tr -d '\r')
-USER_ID=$(docker-compose exec api sh -c 'tmp/bcda create-user --name "SSAS Smoke Test User" --email ssassmoketest@example.com --aco-id '$ACO_ID | tail -n1)
 SAVE_KEY_RESULT=$(docker-compose exec api sh -c 'tmp/bcda save-public-key --cms-id A9996 --key-file "../shared_files/ATO_public.pem"' | tail -n1)
 GROUP_ID=$(docker-compose exec api sh -c 'tmp/bcda create-group --id "smoke-test-group" --name "Smoke Test Group" --aco-id A9996' | tail -n1 | tr -d '\r')
 CREDS=($(docker-compose exec api sh -c 'tmp/bcda generate-client-credentials --cms-id A9996' | tail -n2 | tr -d '\r'))


### PR DESCRIPTION
### Fixes [BCDA-2596](https://jira.cms.gov/browse/BCDA-2596)
Our authentication and authorization no longer has the concept of a user, but jobs and alpha tokens still reference them.  This PR removes all user references.

### Proposed Changes
- Drop `users` table
- Drop `jobs.user_id` column
- Remove all code and fixture references

### Migration Strategy
In `dev` and `test`:
- Deploy code
- `psql -f db/migrations/20200120-drop-users.sql` from deployer's laptop
- Verify success (`users` table should be gone)

In `opensbx` and `prod`:
- Deploy code
- Transfer `db/migrations/20200120-drop-users.sql` to API server in AWS environment
- SSH to server and run `psql -f 20200120-drop-users.sql`
- Verify success (`users` table should be gone)

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

This change should be security-neutral, removing unused database and code artifacts.

### Acceptance Validation
All tests still run ✅ 

### Feedback Requested
Are there any other references?