### PR TITLE
Single DB Connection per Worker Job

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -69,14 +69,12 @@ type Job struct {
 	JobKeys           []JobKey
 }
 
-func (job *Job) CheckCompletedAndCleanup() (bool, error) {
+func (job *Job) CheckCompletedAndCleanup(db *gorm.DB) (bool, error) {
 
 	// Trivial case, no need to keep going
 	if job.Status == "Completed" {
 		return true, nil
 	}
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
 
 	var completedJobs int64
 	db.Model(&JobKey{}).Where("job_id = ?", job.ID).Count(&completedJobs)
@@ -251,7 +249,7 @@ func (aco *ACO) GetBeneficiaries(includeSuppressed bool) ([]CCLFBeneficiary, err
 	var suppressedBBIDs []string
 
 	if !includeSuppressed {
-		suppressedBBIDs = GetSuppressedBlueButtonIDs()
+		suppressedBBIDs = GetSuppressedBlueButtonIDs(db)
 	}
 
 	var err error
@@ -272,9 +270,7 @@ func (aco *ACO) GetBeneficiaries(includeSuppressed bool) ([]CCLFBeneficiary, err
 	return cclfBeneficiaries, nil
 }
 
-func GetSuppressedBlueButtonIDs() []string {
-	db := database.GetGORMDbConnection()
-	defer database.Close(db)
+func GetSuppressedBlueButtonIDs(db *gorm.DB) []string {
 
 	var suppressedBBIDs []string
 

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -404,13 +404,13 @@ func (s *ModelsTestSuite) TestJobCompleted() {
 		JobCount:   1,
 	}
 	s.db.Save(&j)
-	completed, err := j.CheckCompletedAndCleanup()
+	completed, err := j.CheckCompletedAndCleanup(s.db)
 	assert.Nil(s.T(), err)
 	assert.False(s.T(), completed)
 
 	err = s.db.Create(&JobKey{JobID: j.ID, EncryptedKey: []byte("NOT A KEY"), FileName: "SOMETHING.ndjson"}).Error
 	assert.Nil(s.T(), err)
-	completed, err = j.CheckCompletedAndCleanup()
+	completed, err = j.CheckCompletedAndCleanup(s.db)
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), completed)
 	s.db.Delete(&j)
@@ -427,7 +427,7 @@ func (s *ModelsTestSuite) TestJobDefaultCompleted() {
 	}
 	s.db.Save(&j)
 
-	completed, err := j.CheckCompletedAndCleanup()
+	completed, err := j.CheckCompletedAndCleanup(s.db)
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), completed)
 	s.db.Delete(&j)
@@ -443,7 +443,7 @@ func (s *ModelsTestSuite) TestJobwithKeysCompleted() {
 		JobCount:   10,
 	}
 	s.db.Save(&j)
-	completed, err := j.CheckCompletedAndCleanup()
+	completed, err := j.CheckCompletedAndCleanup(s.db)
 	assert.Nil(s.T(), err)
 	assert.False(s.T(), completed)
 
@@ -452,7 +452,7 @@ func (s *ModelsTestSuite) TestJobwithKeysCompleted() {
 		assert.Nil(s.T(), err)
 	}
 	// JobKeys exist, but not enough to make the job complete
-	completed, err = j.CheckCompletedAndCleanup()
+	completed, err = j.CheckCompletedAndCleanup(s.db)
 	assert.Nil(s.T(), err)
 	assert.False(s.T(), completed)
 
@@ -460,7 +460,7 @@ func (s *ModelsTestSuite) TestJobwithKeysCompleted() {
 		err = s.db.Create(&JobKey{JobID: j.ID, EncryptedKey: []byte("NOT A KEY"), FileName: "SOMETHING.ndjson"}).Error
 		assert.Nil(s.T(), err)
 	}
-	completed, err = j.CheckCompletedAndCleanup()
+	completed, err = j.CheckCompletedAndCleanup(s.db)
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), completed)
 	s.db.Delete(&j)

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/bgentry/que-go"
 	"github.com/jackc/pgx"
-        "github.com/jinzhu/gorm"
+	"github.com/jinzhu/gorm"
 	"github.com/newrelic/go-agent"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -128,8 +128,8 @@ func TestWriteEOBDataToFileInvalidACO(t *testing.T) {
 	cmsID := "A00234"
 	beneficiaryIDs := []string{"10000", "11000"}
 
-        db := database.GetGORMDbConnection()
-        defer db.Close()
+	db := database.GetGORMDbConnection()
+	defer db.Close()
 	_, err := writeBBDataToFile(&bbc, db, acoID, cmsID, beneficiaryIDs, "1", "ExplanationOfBenefit")
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
### Fixes Performance Issues

High CPU utilization occurs when a large ACO makes a request.

<img width="940" alt="Screen Shot 2020-01-21 at 12 47 55 PM" src="https://user-images.githubusercontent.com/37818548/72829177-4883ce00-3c4c-11ea-92b7-65cb34283b63.png">

After extensive investigation, it was determined that the high CPU utilization was resulting from the fact that we create a new DB connection for each beneficiary processed in a job.

### Proposed Changes

Reuse the DB connection for all beneficiaries within a single worker's job.

### Change Details

Updated the job processing code to ensure that a DB connection is shared for all processing within the single job.

### Security Implications

This is a performance optimization to existing processing.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Updated CPU utilization chart:

<img width="920" alt="Screen Shot 2020-01-21 at 12 51 02 PM" src="https://user-images.githubusercontent.com/37818548/72829408-b62ffa00-3c4c-11ea-8444-15adfb378332.png">


Additional enhancements to be addressed in [BCDA-2621](https://jira.cms.gov/browse/BCDA-2621)

### Feedback Requested

Please review.
