### PR TITLE
BCDA-2621: Write to DB only when BB ID requires an update

### DIFF
--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -271,9 +271,11 @@ func beneBBID(cclfBeneID string, bb client.APIClient, db *gorm.DB) (string, erro
 	if err != nil {
 		return "", err
 	}
-
-	cclfBeneficiary.BlueButtonID = bbID
-	db.Save(&cclfBeneficiary)
+	
+	// Update the value in the DB only if necessary
+	if cclfBeneficiary.BlueButtonID != bbID {
+		db.Model(&cclfBeneficiary).Update("blue_button_id", bbID)	
+	}
 
 	return bbID, nil
 }


### PR DESCRIPTION
### Fixes [BCDA-2621](https://jira.cms.gov/browse/BCDA-2621)

Significant DB CPU utilization optimization was introduced in https://github.com/CMSgov/bcda-app/pull/445.  Despite the optimization, the repeated spikes to ~50% CPU utilization are still a concern.  It was determined that we are performing redundant writes of BB ID to the database.  To reduce the repeated spikes, the redundant writes of BB ID to the database should be addressed.  

The current state of CPU utilization is depicted below (showing the repeated spikes).  The image is pulled from the `Acceptance Validation` portion of https://github.com/CMSgov/bcda-app/pull/445.

<img width="920" alt="72829408-b62ffa00-3c4c-11ea-8444-15adfb378332" src="https://user-images.githubusercontent.com/37818548/73129248-d9d8a480-3fac-11ea-87b4-fb0e9e1f1e73.png">



### Change Details

Updated the job processing code so that a BB ID is only written to the database once per CCLF period.

### Security Implications

This is a performance optimization to existing processing.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

The image below shows CPU utilization during a test execution that is similar to the test execution that generated the CPU utilization metrics above (i.e., test execution using a medium-sized ACO). The redundant spikes have been remediated.  The initial spikes are caused by the initial round of DB writes (one spike for each worker).  

<img width="897" alt="Screen Shot 2020-01-25 at 7 34 19 PM" src="https://user-images.githubusercontent.com/37818548/73129267-510e3880-3fad-11ea-96df-4d38936c2b08.png">


### Feedback Requested

Please review.
