### PR TITLE
BCDA-2592 Feature: Log CMS ID for API requests

### DIFF
--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -65,9 +65,17 @@ func ParseToken(next http.Handler) http.Handler {
 
 				ad.TokenID = claims.Id
 				ad.ACOID = aco.UUID.String()
+				ad.CMSID = *aco.CMSID
 			default:
+				var aco, err = GetACOByUUID(claims.ACOID)
+				if err != nil {
+					log.Errorf("no aco for ACO ID %s because %v", claims.ACOID, err)
+					next.ServeHTTP(w, r)
+					return
+				}
 				ad.TokenID = claims.UUID
 				ad.ACOID = claims.ACOID
+				ad.CMSID = *aco.CMSID
 			}
 		}
 		ctx := context.WithValue(r.Context(), "token", token)

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -47,13 +47,13 @@ func (s *MiddlewareTestSuite) SetupSuite() {
 }
 
 func (s *MiddlewareTestSuite) SetupTest() {
-	userID := "82503A18-BF3B-436D-BA7B-BAE09B7FFD2F"
+	cmsID := "A9995"
 	acoID := "DBBD1CE1-AE24-435C-807D-ED45953077D3"
 	tokenID := "d63205a8-d923-456b-a01b-0992fcb40968"
 	s.token, _ = auth.TokenStringWithIDs(tokenID, acoID)
 	s.ad = auth.AuthData{
 		TokenID: tokenID,
-		UserID:  userID,
+		CMSID:  cmsID,
 		ACOID:   acoID,
 	}
 	s.server = httptest.NewServer(s.CreateRouter())

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -86,10 +86,6 @@ func (o OktaAuthPlugin) RevokeSystemCredentials(clientID string) error {
 // Manufactures an access token for the given credentials
 func (o OktaAuthPlugin) MakeAccessToken(creds Credentials) (string, error) {
 	clientID := creds.ClientID
-	// Also accept clientID via creds.UserID to match alpha auth implementation
-	if clientID == "" {
-		clientID = creds.UserID
-	}
 
 	if clientID == "" {
 		return "", fmt.Errorf("client ID required")

--- a/bcda/auth/okta_test.go
+++ b/bcda/auth/okta_test.go
@@ -94,10 +94,6 @@ func (s *OktaAuthPluginTestSuite) TestMakeAccessToken() {
 	ts, err = s.o.MakeAccessToken(Credentials{ClientID: mockID, ClientSecret: mockSecret})
 	assert.NotEmpty(s.T(), ts)
 	assert.Nil(s.T(), err)
-
-	ts2, err := s.o.MakeAccessToken(Credentials{UserID: mockID, ClientSecret: mockSecret})
-	assert.NotEqual(s.T(), ts, ts2)
-	assert.Nil(s.T(), err)
 }
 
 func (s *OktaAuthPluginTestSuite) TestOktaRevokeAccessToken() {

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -64,7 +64,6 @@ func GetProvider() Provider {
 
 type AuthData struct {
 	ACOID    string
-	UserID   string
 	TokenID  string
 	ClientID string
 	SystemID string
@@ -72,7 +71,6 @@ type AuthData struct {
 }
 
 type Credentials struct {
-	UserID       string    `json:"user_id"`
 	ClientID     string    `json:"client_id"`
 	ClientSecret string    `json:"client_secret"`
 	ClientName   string    `json:"client_name"`

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -64,8 +64,8 @@ func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 
 	if ad, ok := r.Context().Value("ad").(auth.AuthData); ok {
 		logFields["aco_id"] = ad.ACOID
-		logFields["user_id"] = ad.UserID
 		logFields["token_id"] = ad.TokenID
+		logFields["cms_id"] = ad.CMSID
 	}
 
 	entry.Logger = entry.Logger.WithFields(logFields)

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -39,7 +39,7 @@ func contextToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ad := auth.AuthData{
 			ACOID:   "dbbd1ce1-ae24-435c-807d-ed45953077d3",
-			UserID:  "82503a18-bf3b-436d-ba7b-bae09b7ffdff",
+			CMSID:   "A9995",
 			TokenID: "665341c9-7d0c-4844-b66f-5910d9d0822f",
 		}
 
@@ -96,7 +96,7 @@ func (s *LoggingMiddlewareTestSuite) TestLogRequest() {
 		// TODO: Solution for go-chi logging middleware relying on Request.TLS
 		// assert.Equal(s.T(), server.URL+"/", logFields["uri"])
 		assert.Equal("dbbd1ce1-ae24-435c-807d-ed45953077d3", logFields["aco_id"], "ACO in log entry should match the token.")
-		assert.Equal("82503a18-bf3b-436d-ba7b-bae09b7ffdff", logFields["user_id"], "Sub in log entry should match the token.")
+		assert.Equal("A9995", logFields["cms_id"], "CMS ID in log entry should match the token.")
 		assert.Equal("665341c9-7d0c-4844-b66f-5910d9d0822f", logFields["token_id"], "Token ID in log entry should match the token.")
 	}
 
@@ -173,7 +173,7 @@ func (s *LoggingMiddlewareTestSuite) TestPanic() {
 		// TODO: Solution for go-chi logging middleware relying on Request.TLS
 		// assert.Equal(s.T(), server.URL+"/panic", logFields["uri"])
 		assert.Equal("dbbd1ce1-ae24-435c-807d-ed45953077d3", logFields["aco_id"], "ACO in log entry should match the token.")
-		assert.Equal("82503a18-bf3b-436d-ba7b-bae09b7ffdff", logFields["user_id"], "Sub in log entry should match the token.")
+		assert.Equal("A9995", logFields["cms_id"], "CMS ID in log entry should match the token.")
 		assert.Equal("665341c9-7d0c-4844-b66f-5910d9d0822f", logFields["token_id"], "Token ID in log entry should match the token.")
 		if i == 1 {
 			assert.Equal("Test", logFields["panic"])


### PR DESCRIPTION
### Fixes [BCDA-2592](https://jira.cms.gov/browse/BCDA-2592)
In addition to the UUID that we use internally to represent ACO's, we would like our logs to contain the CMS ID (the one formatted like: A0000).  This PR adds this value to the logs for all three auth providers in the code base (Alpha, Okta, and SSAS).

### Proposed Changes
- Ensure the logging middleware contains data for the CMS ID
- Replace the defunct `AuthData.UserID` with `AuthData.CMSID`
- Remove any remaining `AuthData.UserID` and `Credentials.UserID` references

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

More information is now contained in the log, but it is [publicly available information](https://data.cms.gov/Special-Programs-Initiatives-Medicare-Shared-Savin/Performance-Year-2020-Medicare-Shared-Savings-Prog/kuwq-yjm7).

### Acceptance Validation
#### Splunk results in `dev` (SSAS provider)
![Screen Shot 2020-01-29 at 7 03 56 PM](https://user-images.githubusercontent.com/2533561/73408806-6516aa80-42cb-11ea-9933-96720ed75174.png)

#### Local logs (alpha provider)
![Screen Shot 2020-01-29 at 7 18 48 PM](https://user-images.githubusercontent.com/2533561/73409100-495fd400-42cc-11ea-9deb-efe4cdbe4d4b.png)

### Feedback Requested
- All improvements welcome
