### PR TITLE
BCDA-1551 Feature: Change for recieving plaintext MBI

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -185,6 +185,7 @@ func AddRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) 
 	req.Header.Add("BlueButton-OriginalQuery", req.URL.RawQuery)
 	req.Header.Add("BCDA-JOBID", jobID)
 	req.Header.Add("BCDA-CMSID", cmsID)
+	req.Header.Add("IncludeIdentifiers","mbi")
 
         // Do not set BB-specific headers with blank values
         // Leaving them here, commented out, in case we want to set them to real values in future

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -289,6 +289,7 @@ func (s *BBTestSuite) TestAddRequestHeaders() {
 
 	assert.Equal(s.T(), "543210", req.Header.Get("BCDA-JOBID"))
 	assert.Equal(s.T(), "A00234", req.Header.Get("BCDA-CMSID"))
+	assert.Equal(s.T(), "mbi", req.Header.Get("IncludeIdentifiers"))
 
 }
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -528,7 +528,6 @@ func GetBlueButtonID(bb client.APIClient, modelIdentifier, patientIdMode, reqTyp
 	var foundIdentifier = false
 	var foundBlueButtonID = false
 	blueButtonID = patient.Entry[0].Resource.ID
-	// once this is set to true, what happens with future iterations??
 	for _, identifier := range patient.Entry[0].Resource.Identifier {
 		if strings.Contains(identifier.System, systemMode) {
 			hashedOrRawID := hashedIdentifier

--- a/bcda/testUtils/client.go
+++ b/bcda/testUtils/client.go
@@ -64,7 +64,8 @@ func (bbc *BlueButtonClient) GetData(endpoint, patientID string) (string, error)
 			}
 			cleanData := strings.Replace(string(fData), "20000000000001", patientID, -1)
 			if bbc.MBI != nil {
-				cleanData = strings.Replace(cleanData, "c945694486322cfcf792a4d1c69ea88bf0c134edaf9f1d68a18466f9dc6ec2fe", client.HashIdentifier(*bbc.MBI), -1)
+				// no longer hashed, but this is only a test file with synthetic test data
+				cleanData = strings.Replace(cleanData, "-1Q03Z002871", *bbc.MBI, -1)
 			}
 			return cleanData, err
 		}

--- a/shared_files/synthetic_beneficiary_data/Patient_MBI
+++ b/shared_files/synthetic_beneficiary_data/Patient_MBI
@@ -33,8 +33,8 @@
             "value": "20000000000001"
           },
           {
-            "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
-            "value": "c945694486322cfcf792a4d1c69ea88bf0c134edaf9f1d68a18466f9dc6ec2fe"
+            "system": "http://hl7.org/fhir/sid/us-mbi",
+            "value": "-1Q03Z002871"
           }
         ],
         "name": [


### PR DESCRIPTION
Fixes [BCDA-1551](https://jira.cms.gov/browse/BCDA-1551)

Problem:
As currently implemented our users have no way of identifying patients from the downloaded payload. The identifier values were previously hashed, but with this change values will be presented as usable plain text.

Proposed Changes:
Added the necessary header values to our BFD request to provide a response with a plaintext MBI.

Change Details:
bcda/client/bluebutton.go - added necessary header value
bcda/client/bluebutton_test.go - testing logic for new header value
bcda/models/models.go - changed to validate the plaintext identifier when in MBI mode.
bcda/testUtils/client.go - changed to use synthetic MBI from static data file
shared_files/synthetic_beneficiary_data/Patient_MBI - changed to a synthetic plaintext MBI

Security Implications:
Yes, this change **does** deal with PII/PHI data. We are now receiving plaintext MBI's in our data responses from BFD.
- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [x] security checklist is completed for this change
https://confluence.cms.gov/pages/viewpage.action?pageId=263566369

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

Acceptance Validation:
Yes all tests pass

Feedback Requested:
Any and all
