### PR TITLE
BCDA-2718 Best Practices: Dev deployment prompt added to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,13 +51,13 @@ and would like to solicit the team's feedback. Optionally, provide background
 information regarding your questions and concerns. -->
 
 ### Acceptance Validation
-- [ ] This branch has been deployed to the AWS `dev` environment
-<!-- If no, why does this change not break CI/CD?  How is it not affected by using a persistent
-  database? -->
-
 <!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
 
 <!-- Insert screenshots if applicable (drag images here) -->
+
+<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Deploy/build 
+<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
+  database? -->
 
 ### Feedback Requested
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,7 +55,7 @@ information regarding your questions and concerns. -->
 
 <!-- Insert screenshots if applicable (drag images here) -->
 
-<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Deploy/build 
+<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
 <!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
   database? -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,6 +51,8 @@ and would like to solicit the team's feedback. Optionally, provide background
 information regarding your questions and concerns. -->
 
 ### Acceptance Validation
+<!-- Show off how you deployed to the AWS dev environment, or give an excuse why that's totally unnecessary -->
+[ ] This branch has been deployed to the AWS `dev` environment
 
 <!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,7 +51,7 @@ and would like to solicit the team's feedback. Optionally, provide background
 information regarding your questions and concerns. -->
 
 ### Acceptance Validation
-[ ] This branch has been deployed to the AWS `dev` environment
+- [ ] This branch has been deployed to the AWS `dev` environment
 <!-- If no, why does this change not break CI/CD?  How is it not affected by using a persistent
   database? -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,8 +51,9 @@ and would like to solicit the team's feedback. Optionally, provide background
 information regarding your questions and concerns. -->
 
 ### Acceptance Validation
-<!-- Show off how you deployed to the AWS dev environment, or give an excuse why that's totally unnecessary -->
 [ ] This branch has been deployed to the AWS `dev` environment
+<!-- If no, why does this change not break CI/CD?  How is it not affected by using a persistent
+  database? -->
 
 <!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
 


### PR DESCRIPTION
### Fixes [BCDA-2718](https://jira.cms.gov/browse/BCDA-2718)
This conscientious team "learned" the same lesson repeatedly over a couple of sprints: most changes could benefit from being tested in `dev`.  How do we remind ourselves?  This PR drafts language that could prompt us in _every_ PR.

### Proposed Changes
- Add comments to the `Acceptance validation` section to clarify that, while deployment to `dev` is not _required_, you should have carefully thought through why your code couldn't _possibly_ be affected by the deployment environment, or require additional changes to the CI/CD pipeline.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

There is a slight risk that unreviewed code deployed to `dev` could open up security risks.  These risks are mitigated by the isolation we place on that environment.

### Acceptance Validation
- [ ] This branch has been deployed to the AWS `dev` environment
<!-- If no, why does this change not break CI/CD?  How is it not affected by using a persistent
  database? -->
No. This change is limited to the PR process, and will not affect running code, databases, or integrations.

### Feedback Requested
- What words would you change?
- Is using a checkbox affective?  Would a subheading be more useful?  Or would we just like to stick to comments?
- What other examples should we give of things that can work locally but break during/after deployment?
- Note the [sister PR for bcda-ssas-app](https://github.com/CMSgov/bcda-ssas-app/pull/33)