### PR TITLE
BCDA-2714: Update worker pool size configuration in local environment

### DIFF
--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -413,16 +413,7 @@ func setupQueue() *pgx.ConnPool {
 		"ProcessJob": processJob,
 	}
 
-	var workerPoolSize int
-	if len(os.Getenv("WORKER_POOL_SIZE")) == 0 {
-		workerPoolSize = 2
-	} else {
-		workerPoolSize, err = strconv.Atoi(os.Getenv("WORKER_POOL_SIZE"))
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
+	workerPoolSize := utils.GetEnvInt("WORKER_POOL_SIZE", 2)
 	workers := que.NewWorkerPool(qc, wm, workerPoolSize)
 	go workers.Start()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
 #     - BB_HASH_PEPPER
 #     - BB_SERVER_LOCATION
       - BB_TIMEOUT_MS=10000
+      - WORKER_POOL_SIZE=3
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     depends_on:


### PR DESCRIPTION
### Fixes [BCDA-2714](https://jira.cms.gov/browse/BCDA-2714)

Our workers are under-utilized, so lets see how they do with 3 threads doing work instead of 2.  

### Change Details

Increased the `WORKER_POOL_SIZE` from the default of 2 to 3 in local docker-compose stack.  This work was done in conjunction with this PR: https://github.com/CMSgov/bcda-ops/pull/421

### Security Implications

No PHI/PII is affected as part of this change; it is strictly a performance optimization.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Local testing using this feature branch resulted in success.  The majority of the testing in AWS for this feature was documented in the `bcda-ops` PR here: https://github.com/CMSgov/bcda-ops/pull/421

### Feedback Requested

Please review.
