### PR TITLE
Ignore gosec rule G307 when deferring file closure

### DIFF
--- a/bcda/cclf/testutils/cclfUtils.go
+++ b/bcda/cclf/testutils/cclfUtils.go
@@ -75,7 +75,7 @@ func ImportCCLFPackage(acoSize, environment string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer newZipFile.Close()
+	defer newZipFile.Close() // #nosec G307
 	zipWriter := zip.NewWriter(newZipFile)
 
 	// Add all 3 files to the same zip
@@ -110,7 +110,7 @@ func AddFileToZip(zipWriter *zip.Writer, filename string) error {
 	if err != nil {
 		return err
 	}
-	defer fileToZip.Close()
+	defer fileToZip.Close() // #nosec G307
 
 	// Get the file information
 	info, err := fileToZip.Stat()

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -162,7 +162,7 @@ func validate(metadata *suppressionFileMetadata) error {
 		log.Error(err)
 		return err
 	}
-	defer f.Close()
+	defer f.Close() // #nosec G307
 
 	var (
 		headTrailStart, headTrailEnd = 0, 15
@@ -318,7 +318,7 @@ func importSuppressionMetadata(metadata *suppressionFileMetadata, importFunc fun
 		log.Error(err)
 		return err
 	}
-	defer f.Close()
+	defer f.Close() // #nosec G307
 
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -189,7 +189,7 @@ func writeBBDataToFile(bb client.APIClient, db *gorm.DB, acoID string, acoCMSID 
 		return "", err
 	}
 
-	defer f.Close()
+	defer f.Close() // #nosec G307
 
 	w := bufio.NewWriter(f)
 	errorCount := 0
@@ -304,7 +304,7 @@ func appendErrorToFile(fileUUID, code, detailsCode, detailsDisplay string, jobID
 		log.Error(err)
 	}
 
-	defer f.Close()
+	defer f.Close() // #nosec G307
 
 	ooBytes, err := json.Marshal(oo)
 	if err != nil {

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -134,7 +134,7 @@ func writeResults(filename string, buf bytes.Buffer) {
 	if len(data) > 0 {
 		fn := fmt.Sprintf("%s/%s.html", reportFilePath, filename)
 		fmt.Printf("Writing results: %s\n", fn)
-		err := ioutil.WriteFile(fn, data, 0644)
+		err := ioutil.WriteFile(fn, data, 0600)
 		if err != nil {
 			panic(err)
 		}

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -134,7 +134,7 @@ func writeFile(resp *http.Response, filename string) {
 	if err != nil {
 		panic(err)
 	}
-	defer out.Close()
+	defer out.Close() // #nosec G307
 	num, err := io.Copy(out, resp.Body)
 	if err != nil && num <= 0 {
 		panic(err)


### PR DESCRIPTION
### Fixes Out-of-Band Modification to Linting Rule G307

Out-of-band modifications to `gosec` affected BCDA's codebase, related to deferring `Close()` on `os.File`.
The change to `gosec` can be viewed [here](https://github.com/securego/gosec/pull/441/files).

### Change Details

`nosec` was added to the affected code, to ignore the linting suggestion, in order to un-block the build.  In addition, a new ticket was created to re-address the situation in a manner that can be planned out (as opposed to rushed to un-block the build).
The new ticket is [BCDA-2804](https://jira.cms.gov/browse/BCDA-2804).

### Security Implications

No PHI/PII is affected in this update.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

Linting is passing in local, Travis, and Jenkins now.

### Feedback Requested

Please review.
