### PR TITLE
BCDA-2728 Feature: Add "cache-control" and "pragma:no-cache" to security header

### DIFF
--- a/bcda/web/middleware.go
+++ b/bcda/web/middleware.go
@@ -1,9 +1,10 @@
 package web
 
 import (
+	"net/http"
+
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
-	"net/http"
 )
 
 func ValidateBulkRequestHeaders(next http.Handler) http.Handler {
@@ -48,10 +49,12 @@ func ConnectionClose(next http.Handler) http.Handler {
 	})
 }
 
-func HSTSHeader(next http.Handler) http.Handler {
+func SecurityHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if servicemux.IsHTTPS(r) {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+			w.Header().Set("Cache-Control", "no-cache; no-store; must-revalidate; max-age=0")
+			w.Header().Set("Pragma", "no-cache")
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/bcda/web/middleware_test.go
+++ b/bcda/web/middleware_test.go
@@ -151,7 +151,14 @@ func (s *MiddlewareTestSuite) TestSecurityHeader() {
 	router.ServeHTTP(w, req)
 	result := w.Result()
 
-	assert.NotEmpty(s.T(), result.Header.Get("Strict-Transport-Security"), "sets HSTS header")
+	assert.NotEmpty(s.T(), result.Header.Get("Strict-Transport-Security"), "sets STS header")
+	assert.NotEmpty(s.T(), result.Header.Get("Cache-Control"), "sets cache control settings")
+	assert.Equal(s.T(), result.Header.Get("Pragma"), "no-cache", "pragma header should be no-cache")
+	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "must-revalidate", "ensures must-revalidate control added")
+	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "no-cache", "ensures no-cache control added")
+	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "no-store", "ensures no-store control added")
+	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "max-age=0", "ensures max-age=0 control added")
+
 }
 
 func (s *MiddlewareTestSuite) TearDownTest() {

--- a/bcda/web/middleware_test.go
+++ b/bcda/web/middleware_test.go
@@ -128,9 +128,9 @@ func (s *MiddlewareTestSuite) TestConnectionCloseHeader() {
 	assert.Equal(s.T(), "close", result.Header.Get("Connection"), "sets 'Connection: close' header")
 }
 
-func (s *MiddlewareTestSuite) TestHSTSHeader() {
+func (s *MiddlewareTestSuite) TestSecurityHeader() {
 	router := chi.NewRouter()
-	router.Use(HSTSHeader)
+	router.Use(SecurityHeader)
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("Test router"))
 		if err != nil {

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -15,7 +15,7 @@ import (
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
+	r.Use(auth.ParseToken, logging.NewStructuredLogger(), SecurityHeader, ConnectionClose)
 
 	// Serve up the swagger ui folder
 	swagger_path := "./swaggerui"
@@ -41,13 +41,13 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	return auth.NewAuthRouter(logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
+	return auth.NewAuthRouter(logging.NewStructuredLogger(), SecurityHeader, ConnectionClose)
 }
 
 func NewDataRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, logging.NewStructuredLogger(), HSTSHeader, ConnectionClose)
+	r.Use(auth.ParseToken, logging.NewStructuredLogger(), SecurityHeader, ConnectionClose)
 	r.With(auth.RequireTokenAuth, auth.RequireTokenJobMatch).
 		Get(m.WrapHandler("/data/{jobID}/{fileName}", serveData))
 	return r


### PR DESCRIPTION
### Fixes [BCDA-2728](https://jira.cms.gov/browse/BCDA-2728)

Finding from ACT: Add must-revalidate, Add Pragma 
Also add other headers provided to us by Akamai CDN 

### Proposed Changes

- Adds `must-revalidate`, `no-store`, `no-cache`, `max-age=0` to cache control header
- Adds `Pragma:no-cache` to header
- Rename `HSTSHeader` to `SecurityHeader` to be more generic
- Indicates that once a resource becomes stale, caches must not use their stale copy without successful validation on the origin server.
- Add accompanying unit tests

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1371/

`curl --insecure -i https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/api/v1/metadata`
```
HTTP/2 200
date: Mon, 16 Mar 2020 17:11:24 GMT
content-type: application/json
content-length: 1699
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
```

___

`curl --insecure -i https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/_auth`
```
HTTP/2 200
date: Mon, 16 Mar 2020 17:12:11 GMT
content-type: application/json
content-length: 24
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
```

___

`curl --insecure -i https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/_version`
```
HTTP/2 200
date: Mon, 16 Mar 2020 17:12:16 GMT
content-type: application/json
content-length: 23
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
```

___

`curl --insecure -I https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/api/v1/swagger/swagger.json`
```
HTTP/2 405
date: Mon, 16 Mar 2020 17:20:14 GMT
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
```

### Feedback Requested

Anything else to add? 
