### PR TITLE
 BCDA 2729 Feature: Set X-Content-Type-Options header to nosniff

### DIFF
--- a/bcda/web/middleware.go
+++ b/bcda/web/middleware.go
@@ -55,6 +55,7 @@ func SecurityHeader(next http.Handler) http.Handler {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 			w.Header().Set("Cache-Control", "no-cache; no-store; must-revalidate; max-age=0")
 			w.Header().Set("Pragma", "no-cache")
+			w.Header().Set("X-Content-Type-Options", "no-sniff")
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/bcda/web/middleware.go
+++ b/bcda/web/middleware.go
@@ -55,7 +55,7 @@ func SecurityHeader(next http.Handler) http.Handler {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 			w.Header().Set("Cache-Control", "no-cache; no-store; must-revalidate; max-age=0")
 			w.Header().Set("Pragma", "no-cache")
-			w.Header().Set("X-Content-Type-Options", "no-sniff")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/bcda/web/middleware_test.go
+++ b/bcda/web/middleware_test.go
@@ -155,7 +155,7 @@ func (s *MiddlewareTestSuite) TestSecurityHeader() {
 	assert.NotEmpty(s.T(), result.Header.Get("Cache-Control"), "sets cache control settings")
 	assert.NotEmpty(s.T(), result.Header.Get("X-Content-Type-Options"), "sets x-content-type-options")
 	assert.Equal(s.T(), result.Header.Get("Pragma"), "no-cache", "pragma header should be no-cache")
-	assert.Equal(s.T(), result.Header.Get("X-Content-Type-Options"), "no-sniff", "x-content-type header should be no-sniff")
+	assert.Equal(s.T(), result.Header.Get("X-Content-Type-Options"), "nosniff", "x-content-type header should be no-sniff")
 	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "must-revalidate", "ensures must-revalidate control added")
 	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "no-cache", "ensures no-cache control added")
 	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "no-store", "ensures no-store control added")

--- a/bcda/web/middleware_test.go
+++ b/bcda/web/middleware_test.go
@@ -153,7 +153,9 @@ func (s *MiddlewareTestSuite) TestSecurityHeader() {
 
 	assert.NotEmpty(s.T(), result.Header.Get("Strict-Transport-Security"), "sets STS header")
 	assert.NotEmpty(s.T(), result.Header.Get("Cache-Control"), "sets cache control settings")
+	assert.NotEmpty(s.T(), result.Header.Get("X-Content-Type-Options"), "sets x-content-type-options")
 	assert.Equal(s.T(), result.Header.Get("Pragma"), "no-cache", "pragma header should be no-cache")
+	assert.Equal(s.T(), result.Header.Get("X-Content-Type-Options"), "no-sniff", "x-content-type header should be no-sniff")
 	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "must-revalidate", "ensures must-revalidate control added")
 	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "no-cache", "ensures no-cache control added")
 	assert.Contains(s.T(), result.Header.Get("Cache-Control"), "no-store", "ensures no-store control added")


### PR DESCRIPTION
### Fixes [BCDA-2729](https://jira.cms.gov/browse/BCDA-2729)

Set X-Content-Type-Options header to `nosniff` per ZAP analysis

### Proposed Changes

Add header to existing security headers

### Change Details

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation

- https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1374/

`curl --insecure -i https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/_version`
```
HTTP/2 200
date: Mon, 16 Mar 2020 19:17:39 GMT
content-type: application/json
content-length: 23
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-content-type-options: nosniff
```


`curl --insecure -i https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/_auth`
```
HTTP/2 200
date: Mon, 16 Mar 2020 19:18:07 GMT
content-type: application/json
content-length: 24
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-content-type-options: nosniff
```

`curl --insecure -i https://bcda-api-dev-402091678.us-east-1.elb.amazonaws.com/api/v1`
```
/metadata
HTTP/2 200
date: Mon, 16 Mar 2020 19:18:22 GMT
content-type: application/json
content-length: 1699
cache-control: no-cache; no-store; must-revalidate; max-age=0
pragma: no-cache
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-content-type-options: nosniff
```

### Feedback Requested

Any other headers missing?
