### PR TITLE
Update order of Postman tests to avoid 429 in production

### DIFF
--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "76eb20da-4538-4a88-b7ff-957b594da09f",
+		"_postman_id": "8746ef2b-bd2a-4de5-b37b-aac54ea34056",
 		"name": "Beneficiary Claims Data API Tests, Sequential",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -639,93 +639,6 @@
 			"response": []
 		},
 		{
-			"name": "Start Patient export Valid Since",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"id": "0b4c1e3e-a40d-45e2-8be1-81199866a2b1",
-						"exec": [
-							"pm.test(\"Status code is 202\", function() {",
-							"    pm.response.to.have.status(202);",
-							"});",
-							"",
-							"pm.test(\"Has Content-Location header\", function() {",
-							"    pm.response.to.have.header(\"Content-Location\");",
-							"});",
-							"",
-							"pm.environment.set(\"patientValidSinceJobUrl\", pm.response.headers.get(\"Content-Location\"));"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "b822f300-2ead-4f25-b623-22c68df6b017",
-						"exec": [
-							"let timestamp = new Date().toJSON();",
-							"pm.environment.set('now', timestamp);"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/fhir+json"
-					},
-					{
-						"key": "Prefer",
-						"type": "text",
-						"value": "respond-async"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "{{scheme}}://{{host}}/api/v1/Patient/$export?_type=Patient&_since={{now}}",
-					"protocol": "{{scheme}}",
-					"host": [
-						"{{host}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"Patient",
-						"$export"
-					],
-					"query": [
-						{
-							"key": "_type",
-							"value": "Patient"
-						},
-						{
-							"key": "_since",
-							"value": "{{now}}"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
 			"name": "Start Coverage export",
 			"event": [
 				{
@@ -1043,185 +956,6 @@
 					"raw": "{{patientDataUrl}}",
 					"host": [
 						"{{patientDataUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Patient export Valid Since job status",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"id": "dc6615ac-febe-49d0-98b6-9b4b8614bfcf",
-						"exec": [
-							"pm.test(\"Status code is 202 or 200\", function() {",
-							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
-							"});",
-							"",
-							"if (pm.response.code === 202) {",
-							"    pm.test(\"X-Progress header is In Progress\", function() {",
-							"        pm.expect(/^In Progress \\(\\d{1,3}%\\)$/.test(pm.response.headers.get(\"X-Progress\"))).to.be.true;",
-							"    });",
-							"} else if (pm.response.code === 200) {",
-							"    const schema = {",
-							"        \"properties\": {",
-							"            \"transactionTime\": {",
-							"                \"type\": \"string\"",
-							"            },",
-							"            \"request\": {",
-							"                \"type\": \"string\"",
-							"            },",
-							"            \"requiresAccessToken\": {",
-							"                \"type\": \"boolean\"",
-							"            },",
-							"            \"output\": {",
-							"                \"type\": \"array\"",
-							"            },",
-							"            \"error\": {",
-							"                \"type\": \"array\"",
-							"            }",
-							"        }",
-							"    };",
-							"    ",
-							"    var respJson = pm.response.json();",
-							"    ",
-							"    pm.test(\"Schema is valid\", function() {",
-							"        pm.expect(tv4.validate(respJson, schema)).to.be.true;",
-							"    });",
-							"    ",
-							"    pm.environment.set(\"patientValidSinceDataUrl\", respJson.output[0].url);",
-							"}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "ebe6d81b-ef2b-48c6-88c1-bbaffdc28c4b",
-						"exec": [
-							"const retryDelay = 5000;",
-							"const maxRetries = 10;",
-							"",
-							"var eobJobReq = {",
-							"  url: pm.environment.get(\"patientValidSinceJobUrl\"),",
-							"  method: \"GET\",",
-							"  header: \"Authorization: Bearer \" + pm.environment.get(\"token\")",
-							"};",
-							"",
-							"function awaitExportJob(retryCount) {",
-							"    pm.sendRequest(eobJobReq, function (err, response) {",
-							"        if (err) {",
-							"            console.error(err);",
-							"        } else if (response.code == 202) {",
-							"            pm.test(\"X-Progress header is Pending or In Progress\", function() {",
-							"               pm.expect(/^(Pending|In Progress \\(\\d{1,3}%\\))$/.test(response.headers.get(\"X-Progress\"))).to.be.true;",
-							"            });",
-							"            if (retryCount < maxRetries) {",
-							"                console.log(\"Patient export still in progress. Retrying...\");",
-							"                setTimeout(function() {",
-							"                    awaitExportJob(++retryCount);",
-							"                }, retryDelay);",
-							"            } else {",
-							"                console.log(\"Retry limit reached for Patient job status.\");",
-							"                postman.setNextRequest(null);",
-							"            }",
-							"        } else if (response.code == 200) {",
-							"            console.log(\"Patient export job complete.\");",
-							"        } else {",
-							"            console.error(\"Unexpected response from Patient export job: \" + response.status);",
-							"        }",
-							"    });",
-							"}",
-							"",
-							"awaitExportJob(1);"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/fhir+json",
-						"disabled": true
-					},
-					{
-						"key": "Prefer",
-						"type": "text",
-						"value": "respond-async",
-						"disabled": true
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "{{patientValidSinceJobUrl}}",
-					"host": [
-						"{{patientValidSinceJobUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Patient export data Valid Since",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"id": "9cc089de-3f67-4a42-9290-8e32afdbeb97",
-						"exec": [
-							"pm.test(\"Status code is 200\", function() {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Body does not contain data\", function() {",
-							"    pm.expect(pm.response.length === 0)",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "{{patientValidSinceDataUrl}}",
-					"host": [
-						"{{patientValidSinceDataUrl}}"
 					]
 				}
 			},
@@ -2124,6 +1858,272 @@
 							"key": "_type",
 							"value": "ExplanationOfBenefit"
 						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Start Patient export Valid Since",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "0b4c1e3e-a40d-45e2-8be1-81199866a2b1",
+						"exec": [
+							"pm.test(\"Status code is 202\", function() {",
+							"    pm.response.to.have.status(202);",
+							"});",
+							"",
+							"pm.test(\"Has Content-Location header\", function() {",
+							"    pm.response.to.have.header(\"Content-Location\");",
+							"});",
+							"",
+							"pm.environment.set(\"patientValidSinceJobUrl\", pm.response.headers.get(\"Content-Location\"));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "b822f300-2ead-4f25-b623-22c68df6b017",
+						"exec": [
+							"let timestamp = new Date().toJSON();",
+							"pm.environment.set('now', timestamp);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/fhir+json"
+					},
+					{
+						"key": "Prefer",
+						"type": "text",
+						"value": "respond-async"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}/api/v1/Patient/$export?_type=Patient&_since={{now}}",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"Patient",
+						"$export"
+					],
+					"query": [
+						{
+							"key": "_type",
+							"value": "Patient"
+						},
+						{
+							"key": "_since",
+							"value": "{{now}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Patient export Valid Since job status",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "dc6615ac-febe-49d0-98b6-9b4b8614bfcf",
+						"exec": [
+							"pm.test(\"Status code is 202 or 200\", function() {",
+							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
+							"});",
+							"",
+							"if (pm.response.code === 202) {",
+							"    pm.test(\"X-Progress header is In Progress\", function() {",
+							"        pm.expect(/^In Progress \\(\\d{1,3}%\\)$/.test(pm.response.headers.get(\"X-Progress\"))).to.be.true;",
+							"    });",
+							"} else if (pm.response.code === 200) {",
+							"    const schema = {",
+							"        \"properties\": {",
+							"            \"transactionTime\": {",
+							"                \"type\": \"string\"",
+							"            },",
+							"            \"request\": {",
+							"                \"type\": \"string\"",
+							"            },",
+							"            \"requiresAccessToken\": {",
+							"                \"type\": \"boolean\"",
+							"            },",
+							"            \"output\": {",
+							"                \"type\": \"array\"",
+							"            },",
+							"            \"error\": {",
+							"                \"type\": \"array\"",
+							"            }",
+							"        }",
+							"    };",
+							"    ",
+							"    var respJson = pm.response.json();",
+							"    ",
+							"    pm.test(\"Schema is valid\", function() {",
+							"        pm.expect(tv4.validate(respJson, schema)).to.be.true;",
+							"    });",
+							"    ",
+							"    pm.environment.set(\"patientValidSinceDataUrl\", respJson.output[0].url);",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "ebe6d81b-ef2b-48c6-88c1-bbaffdc28c4b",
+						"exec": [
+							"const retryDelay = 5000;",
+							"const maxRetries = 10;",
+							"",
+							"var eobJobReq = {",
+							"  url: pm.environment.get(\"patientValidSinceJobUrl\"),",
+							"  method: \"GET\",",
+							"  header: \"Authorization: Bearer \" + pm.environment.get(\"token\")",
+							"};",
+							"",
+							"function awaitExportJob(retryCount) {",
+							"    pm.sendRequest(eobJobReq, function (err, response) {",
+							"        if (err) {",
+							"            console.error(err);",
+							"        } else if (response.code == 202) {",
+							"            pm.test(\"X-Progress header is Pending or In Progress\", function() {",
+							"               pm.expect(/^(Pending|In Progress \\(\\d{1,3}%\\))$/.test(response.headers.get(\"X-Progress\"))).to.be.true;",
+							"            });",
+							"            if (retryCount < maxRetries) {",
+							"                console.log(\"Patient export still in progress. Retrying...\");",
+							"                setTimeout(function() {",
+							"                    awaitExportJob(++retryCount);",
+							"                }, retryDelay);",
+							"            } else {",
+							"                console.log(\"Retry limit reached for Patient job status.\");",
+							"                postman.setNextRequest(null);",
+							"            }",
+							"        } else if (response.code == 200) {",
+							"            console.log(\"Patient export job complete.\");",
+							"        } else {",
+							"            console.error(\"Unexpected response from Patient export job: \" + response.status);",
+							"        }",
+							"    });",
+							"}",
+							"",
+							"awaitExportJob(1);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/fhir+json",
+						"disabled": true
+					},
+					{
+						"key": "Prefer",
+						"type": "text",
+						"value": "respond-async",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{patientValidSinceJobUrl}}",
+					"host": [
+						"{{patientValidSinceJobUrl}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Patient export data Valid Since",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "9cc089de-3f67-4a42-9290-8e32afdbeb97",
+						"exec": [
+							"pm.test(\"Status code is 200\", function() {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Body does not contain data\", function() {",
+							"    pm.expect(pm.response.length === 0)",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{patientValidSinceDataUrl}}",
+					"host": [
+						"{{patientValidSinceDataUrl}}"
 					]
 				}
 			},


### PR DESCRIPTION
The ordering of the newest Postman tests related to `_since` result in a `429` in `prod`.  This was not encountered in any of the lower environments because `429` is only relevant in `prod`.


### Change Details

- Updated the sequence of tests to ensure the same resource type is not requested back-to-back in the Postman tests.

### Security Implications

No PHI/PII is affected by this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Feature branch was used to run integration tests against `prod` successfully [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/1754/parameters/).

### Feedback Requested

Please review.
