### PR TITLE
BCDA-2833: Update error logging to comply with OperationOutcome format

### DIFF
--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -121,7 +121,7 @@ func RequireTokenJobMatch(next http.Handler) http.Handler {
 		ad, ok := r.Context().Value(AuthDataContextKey).(AuthData)
 		if !ok {
 			log.Error()
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Not_found)
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.Not_found, "")
 			responseutils.WriteError(oo, w, http.StatusNotFound)
 			return
 		}
@@ -130,7 +130,7 @@ func RequireTokenJobMatch(next http.Handler) http.Handler {
 		i, err := strconv.Atoi(jobID)
 		if err != nil {
 			log.Error(err)
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Not_found)
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.Not_found, "")
 			responseutils.WriteError(oo, w, http.StatusNotFound)
 			return
 		}
@@ -142,7 +142,7 @@ func RequireTokenJobMatch(next http.Handler) http.Handler {
 		err = db.Find(&job, "id = ? and aco_id = ?", i, ad.ACOID).Error
 		if err != nil {
 			log.Error(err)
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.Not_found)
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.Not_found, "")
 			responseutils.WriteError(oo, w, http.StatusNotFound)
 			return
 		}
@@ -151,6 +151,6 @@ func RequireTokenJobMatch(next http.Handler) http.Handler {
 }
 
 func respond(w http.ResponseWriter, status int) {
-	oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, "", responseutils.TokenErr)
+	oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.TokenErr, "")
 	responseutils.WriteError(oo, w, status)
 }

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -11,7 +11,7 @@ import (
 
 func CreateOpOutcome(severity, code, detailsCode, detailsDisplay string) *fhirmodels.OperationOutcome {
 	fhirmodels.DisableOperationOutcomeDiagnosticsFileLine()
-	oo := fhirmodels.CreateOpOutcome(severity, code, "", detailsDisplay)
+	oo := fhirmodels.CreateOpOutcome(severity, code, detailsCode, detailsDisplay)
 	return oo
 }
 

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -316,7 +316,7 @@ func bulkEOBRequestMissingTokenHelper(endpoint string, s *APITestSuite) {
 
 	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
 	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.TokenErr, respOO.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), responseutils.TokenErr, respOO.Issue[0].Details.Coding[0].Code)
 }
 
 func bulkEOBRequestNoQueueHelper(endpoint string, s *APITestSuite) {
@@ -342,7 +342,7 @@ func bulkEOBRequestNoQueueHelper(endpoint string, s *APITestSuite) {
 
 	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
 	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.Processing, respOO.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), responseutils.Processing, respOO.Issue[0].Details.Coding[0].Code)
 }
 
 func bulkPatientRequestHelper(endpoint, since string, s *APITestSuite) {
@@ -742,14 +742,16 @@ func validateRequestHelper(endpoint string, s *APITestSuite) {
 	assert.Nil(s.T(), resourceTypes)
 	assert.Equal(s.T(), responseutils.Error, err.Issue[0].Severity)
 	assert.Equal(s.T(), responseutils.Exception, err.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Code)
+	assert.Equal(s.T(), "Invalid resource type", err.Issue[0].Details.Coding[0].Display)
 
 	_, _, req = bulkRequestHelper(endpoint, "Patient,Patient", "")
 	resourceTypes, err = validateRequest(req)
 	assert.Nil(s.T(), resourceTypes)
 	assert.Equal(s.T(), responseutils.Error, err.Issue[0].Severity)
 	assert.Equal(s.T(), responseutils.Exception, err.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Code)
+        assert.Equal(s.T(), "Repeated resource type", err.Issue[0].Details.Coding[0].Display)
 }
 
 func bulkRequestHelper(endpoint, resourceType, since string) (string, func(http.ResponseWriter, *http.Request), *http.Request) {
@@ -801,7 +803,7 @@ func (s *APITestSuite) TestJobStatusInvalidJobID() {
 
 	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
 	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.DbErr, respOO.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), responseutils.DbErr, respOO.Issue[0].Details.Coding[0].Code)
 }
 
 func (s *APITestSuite) TestJobStatusJobDoesNotExist() {
@@ -826,7 +828,7 @@ func (s *APITestSuite) TestJobStatusJobDoesNotExist() {
 
 	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
 	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.DbErr, respOO.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), responseutils.DbErr, respOO.Issue[0].Details.Coding[0].Code)
 }
 
 func (s *APITestSuite) TestJobStatusPending() {

--- a/bcda/web/middleware.go
+++ b/bcda/web/middleware.go
@@ -15,25 +15,21 @@ func ValidateBulkRequestHeaders(next http.Handler) http.Handler {
 		preferHeader := h.Get("Prefer")
 
 		if acceptHeader == "" {
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, "", responseutils.FormatErr)
-			oo.Issue[0].Diagnostics = "Accept header is required"
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, responseutils.FormatErr, "Accept header is required")
 			responseutils.WriteError(oo, w, http.StatusBadRequest)
 			return
 		} else if acceptHeader != "application/fhir+json" {
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, "", responseutils.FormatErr)
-			oo.Issue[0].Diagnostics = "application/fhir+json is the only supported response format"
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, responseutils.FormatErr, "application/fhir+json is the only supported response format")
 			responseutils.WriteError(oo, w, http.StatusBadRequest)
 			return
 		}
 
 		if preferHeader == "" {
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, "", responseutils.FormatErr)
-			oo.Issue[0].Diagnostics = "Prefer header is required"
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, responseutils.FormatErr, "Prefer header is required")
 			responseutils.WriteError(oo, w, http.StatusBadRequest)
 			return
 		} else if preferHeader != "respond-async" {
-			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, "", responseutils.FormatErr)
-			oo.Issue[0].Diagnostics = "Only asynchronous responses are supported"
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Structure, responseutils.FormatErr, "Only asynchronous responses are supported")
 			responseutils.WriteError(oo, w, http.StatusBadRequest)
 			return
 		}

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -184,8 +184,8 @@ func TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(t *testing.T) {
 		t.Fail()
 	}
 
-	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary abcdef10000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary abcdef10000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}
-{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary abcdef11000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary abcdef11000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}`
+	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary abcdef10000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary abcdef10000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}
+{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary abcdef11000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary abcdef11000 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}`
 	assert.Equal(t, ooResp+"\n", string(fData))
 	bbc.AssertExpectations(t)
 
@@ -241,8 +241,8 @@ func TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(t *testing.T) {
 		t.Fail()
 	}
 
-	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary a1000089833 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary a1000089833 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}
-{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"display":"Error retrieving ExplanationOfBenefit for beneficiary a1000065301 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary a1000065301 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}`
+	ooResp := `{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary a1000089833 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary a1000089833 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}
+{"resourceType":"OperationOutcome","issue":[{"severity":"Error","code":"Exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary a1000065301 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary a1000065301 in ACO 387c3a62-96fa-4d93-a5d0-fd8725509dd9"}}]}`
 	assert.Equal(t, ooResp+"\n", string(fData))
 	bbc.AssertExpectations(t)
 	// should not have requested third beneficiary EOB because failure threshold was reached after second

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8746ef2b-bd2a-4de5-b37b-aac54ea34056",
+		"_postman_id": "005ac677-4efe-428a-b89f-e5ba2ae30abf",
 		"name": "Beneficiary Claims Data API Tests, Sequential",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -195,9 +195,15 @@
 							"    pm.response.to.have.status(401);",
 							"});",
 							"",
+							"var respJson = pm.response.json();",
+							"",
 							"pm.test(\"Resource type is OperationOutcome\", function() {",
 							"    var respJson = pm.response.json();",
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
+							"});",
+							"",
+							"pm.test(\"Issue details code is Invalid Token\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Invalid Token\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -265,8 +271,8 @@
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
 							"",
-							"pm.test(\"Issue details text is Invalid Token\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid Token\")",
+							"pm.test(\"Issue details code is Invalid Token\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Invalid Token\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -334,8 +340,8 @@
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
 							"",
-							"pm.test(\"Issue details text is Invalid Token\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid Token\")",
+							"pm.test(\"Issue details code is Invalid Token\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Invalid Token\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1337,8 +1343,12 @@
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
 							"",
-							"pm.test(\"Issue details text is Request Error\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Request Error\")",
+							"pm.test(\"Issue details code is Request Error\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Request Error\")",
+							"});",
+							"",
+							"pm.test(\"Issue details text is Repeated Resource Type\", function() {",
+							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Repeated resource type\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1574,8 +1584,13 @@
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
 							"",
-							"pm.test(\"Issue details text is Request Error\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Request Error\")",
+							"pm.test(\"Issue details code is Request Error\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Request Error\")",
+							"});",
+							"",
+							"",
+							"pm.test(\"Issue details text is Invalid Resource Type\", function() {",
+							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid resource type\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1649,9 +1664,12 @@
 							"pm.test(\"Resource type is OperationOutcome\", function() {",
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
+							"pm.test(\"Issue details code is Request Error\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Request Error\")",
+							"});",
 							"",
-							"pm.test(\"Issue details text is Request Error\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Request Error\")",
+							"pm.test(\"Issue details text is Repeated Resource Type\", function() {",
+							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Repeated resource type\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1727,8 +1745,12 @@
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
 							"",
-							"pm.test(\"Issue details text is Request Error\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Request Error\")",
+							"pm.test(\"Issue details code is Request Error\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Request Error\")",
+							"});",
+							"",
+							"pm.test(\"Issue details text is Invalid Resource Type\", function() {",
+							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid resource type\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1804,8 +1826,12 @@
 							"    pm.expect(respJson.resourceType).to.eql(\"OperationOutcome\")",
 							"});",
 							"",
-							"pm.test(\"Issue details text is Request Error\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Request Error\")",
+							"pm.test(\"Issue details code is Request Error\", function() {",
+							"    pm.expect(respJson.issue[0].details.coding[0].code).to.eql(\"Request Error\")",
+							"});",
+							"",
+							"pm.test(\"Issue details text is Invalid group ID\", function() {",
+							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid group ID\")",
 							"});"
 						],
 						"type": "text/javascript"


### PR DESCRIPTION

### Fixes [BCDA-2833](https://jira.cms.gov/browse/BCDA-2833)

In some cases throughout our code, translation of error scenarios to a FHIR-compliant `OperationOutcome` format was omitting key details.

### Change Details

- Updated our utility function to properly propagate the `detailsCode`.
- Updated usage throughout the application to properly designate between `detailsCode` and `detailsString`.
- Updated relevant tests to handle the new usage of utility function.

### Security Implications

PHI/PII is not affected by this change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

All integration tests were run locally with successful results.  There is nothing in the AWS environment or persistent DB which would require this to be tested in `dev`.

### Feedback Requested

Please review.
