### PR TITLE
Pin `golangci-lint` at v1.24.0

### DIFF
--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -1,7 +1,10 @@
 FROM golang:1.14.1-buster
 
 RUN go get -u github.com/golang/dep/cmd/dep
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN go get -d github.com/golangci/golangci-lint/cmd/golangci-lint; \
+ cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint; \
+ git checkout v1.24.0; \
+ go get -u
 RUN go get -u github.com/xo/usql
 RUN go get -u github.com/securego/gosec/cmd/gosec
 RUN go get -u gotest.tools/gotestsum


### PR DESCRIPTION


### Fixes Dependency Issue With Linting Tool

A new version of `golangci-lint` was released yesterday, and it is causing problems in our environment.  The new version can be found [here](https://github.com/golangci/golangci-lint/releases/tag/v1.25.0).

We are seeing the following errors when using this version to lint our code:
```
src/github.com/golangci/golangci-lint/pkg/golinters/golint.go:21:14: l.LintPkg undefined (type *"github.com/golangci/lint-1".Linter has no field or method LintPkg)
src/github.com/golangci/golangci-lint/pkg/golinters/gomnd.go:13:6: cannot use magic_numbers.Analyzer (type *"github.com/tommy-muehle/go-mnd/vendor/golang.org/x/tools/go/analysis".Analyzer) as type *"golang.org/x/tools/go/analysis".Analyzer in slice literal
Service 'tests' failed to build: The command '/bin/sh -c go get -u github.com/golangci/golangci-lint/cmd/golangci-lint' returned a non-zero code: 2
make: *** [Makefile:15: lint] Error 1
```

### Change Details

- Updated `Dockerfile.tests` so that the `golangci-lint` dependency is pinned at `v.1.24.0` until the issue with `v.1.25.0` can be resolved.
- Created a [JIRA ticket](https://jira.cms.gov/browse/BCDA-3020) to revisit to ensure we can use latest/greatest version of this linting tool.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

This feature branch builds locally and in [Jenkins](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1460/).

### Feedback Requested

Please review.
