### PR TITLE
BCDA-3011: Updated API documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ make performance-test
 
 ## Use the application
 
-See: [API documentation](https://github.com/CMSgov/bcda-app/blob/master/API.md)
+See: [API documentation](https://bcda.cms.gov/sandbox/user-guide/)
 
 ## Handling secrets
 


### PR DESCRIPTION
### Fixes [BCDA-3011](https://jira.cms.gov/browse/BCDA-3011)

Fixing the link the the README to go to the correct link for the API documentation 

### Proposed Changes

* Changed the API documentation link in the README

### Change Details
Changed the link for API documentation to go to [https://bcda.cms.gov/sandbox/user-guide](https://bcda.cms.gov/sandbox/user-guide/)

### Security Implications

This change does *not* deal with PII/PHI. This is purely a change to the documentation to be more usable

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation
Was able to see the link going to the correct location when viewing the README for this branch on GitHub.

This branch has not been deployed to the `dev` environment since this change does not effect the either production or test code but only effects documentation

### Feedback Requested

