### PR TITLE
BCDA-3034: Address G0601, protecting us against accessing invalid memory

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -621,14 +621,15 @@ func StoreSuppressionBBID() (success, failure int, err error) {
 
 	var suppressList []Suppression
 	db.Find(&suppressList)
-	for _, suppressBene := range suppressList {
+	for _, bene := range suppressList {
+		suppressBene := bene
 		bbID, err := suppressBene.GetBlueButtonID(bb)
 		if err != nil {
 			failure++
 			continue
 		}
 		suppressBene.BlueButtonID = bbID
-		db.Save(&suppressBene) /* #nosec G601 */
+		db.Save(&suppressBene)
 		success++
 	}
 	return success, failure, nil


### PR DESCRIPTION

### Fixes [BCDA-3034](https://jira.cms.gov/browse/BCDA-3034)

A new rule was added to the security linter we use (`gosec`), and it detected an issue with one of our `for` loops.

Background information: 

- [Here](https://github.com/securego/gosec/issues/438) is the initial issue identified as a gap in `gosec`.
- [Here](https://github.com/securego/gosec/pull/443) is the implementation of the new rule.

### Change Details

- Updated the `for` loop to ensure we are using a new memory address for each element in the `RangeStmt`.   

### Security Implications

This is a code enhancement, identified by our `gosec` linter, ensuring we are handling memory properly within a `RangeStmt`.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

All automated tests in local and Travis are still passing.

### Feedback Requested

Please review.
