### PR TITLE
Fixes Race Condition in Unit Tests

### DIFF
--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -156,7 +156,7 @@ func (s *CLITestSuite) TestGenerateClientCredentials() {
 	s.testApp.Writer = buf
 	assert := assert.New(s.T())
 
-	args := []string{"bcda", "generate-client-credentials", "--cms-id", "A9994"}
+	args := []string{"bcda", "generate-client-credentials", "--cms-id", "A8880"}
 	err := s.testApp.Run(args)
 	assert.Nil(err)
 	assert.Regexp(regexp.MustCompile(".+\n.+\n.+"), buf.String())

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -749,7 +749,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 func bulkConcurrentRequestTimeHelper(endpoint string, s *APITestSuite) {
 	err := os.Setenv("DEPLOYMENT_TARGET", "prod")
 	assert.Nil(s.T(), err)
-	acoID := constants.DevACOUUID
+	acoID := constants.MediumACOUUID
 	err = s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -749,7 +749,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 func bulkConcurrentRequestTimeHelper(endpoint string, s *APITestSuite) {
 	err := os.Setenv("DEPLOYMENT_TARGET", "prod")
 	assert.Nil(s.T(), err)
-	acoID := constants.MediumACOUUID
+	acoID := constants.DevACOUUID
 	err = s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 

--- a/db/fixtures.sql
+++ b/db/fixtures.sql
@@ -23,9 +23,9 @@ HwIDAQAB
 --   for unit, smoke, and Postman tests
 
 insert into acos(uuid, cms_id, name, client_id)
-     values ('A40404F7-1EF2-485A-9B71-40FE7ACDCBC2', null, 'ACO Sit Amet', 'A40404F7-1EF2-485A-9B71-40FE7ACDCBC2'),
-            ('c14822fa-19ee-402c-9248-32af98419fe3', null, 'ACO Revoked',  'c14822fa-19ee-402c-9248-32af98419fe3'),
-            ('82f55b6a-728e-4c8b-807e-535caad7b139', null, 'ACO Not Revoked', '82f55b6a-728e-4c8b-807e-535caad7b139'),
+     values ('A40404F7-1EF2-485A-9B71-40FE7ACDCBC2', 'A8880', 'ACO Sit Amet', 'A40404F7-1EF2-485A-9B71-40FE7ACDCBC2'),
+            ('c14822fa-19ee-402c-9248-32af98419fe3', 'A8881', 'ACO Revoked',  'c14822fa-19ee-402c-9248-32af98419fe3'),
+            ('82f55b6a-728e-4c8b-807e-535caad7b139', 'T8882', 'ACO Not Revoked', '82f55b6a-728e-4c8b-807e-535caad7b139'),
             ('3461C774-B48F-11E8-96F8-529269fb1459', 'A9990', 'ACO Small', '3461C774-B48F-11E8-96F8-529269fb1459'),
             ('C74C008D-42F8-4ED9-BF88-CEE659C7F692', 'A9991', 'ACO Medium', 'C74C008D-42F8-4ED9-BF88-CEE659C7F692'),
             ('8D80925A-027E-43DD-8AED-9A501CC4CD91', 'A9992', 'ACO Large', '8D80925A-027E-43DD-8AED-9A501CC4CD91'),

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -41,7 +41,7 @@ DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL go run github.com/CMSg
 echo "Successfully imported all CCLF Files"
 
 echo "Running unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -41,7 +41,7 @@ DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL go run github.com/CMSg
 echo "Successfully imported all CCLF Files"
 
 echo "Running unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -41,7 +41,7 @@ DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL go run github.com/CMSg
 echo "Successfully imported all CCLF Files"
 
 echo "Running unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race -p 1 ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html


### PR DESCRIPTION
### Fixes Race Condition in Unit Tests

Some of our unit tests reference the same ACO identifier; and, because our unit tests share a test database, race conditions can occur because our unit tests are executed in parallel to speed up the pipeline.

### Change Details

- Run tests in sequence, similar to how the SSAS tests are executed
- Update fixtures to ensure we can reference ACOs by name

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Several tests executions succeeded locally.
Tests are passing in Travis.
Tests are passing in [Jenkins](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1537/).

### Feedback Requested

Please review.
