### PR TITLE
Ensure suppression test data is removed once test is complete

### DIFF
--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -1185,6 +1185,7 @@ func (s *ModelsTestSuite) TestChangingBCDASuppressionPeriod() {
 	if err != nil {
 		s.FailNow("Failed to save suppression", err.Error())
 	}
+	defer s.db.Unscoped().Delete(&bene2Suppression)
 
 	result1 := GetSuppressedBlueButtonIDs(db)
 	assert.Len(s.T(), result1, 1)


### PR DESCRIPTION

### Fixes Issue With Test Data Maintenance

In one suppression test, we were leaving dangling data in the database which could potentially be interfering with other tests.

### Proposed Changes

Ensure test data gets cleaned up appropriately.

### Change Details

- Added a `defer` statement in one of our suppressions tests, to appropriately clean up data created as part of the test.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Passing in all environments.  [Here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1558/) is the Jenkins execution.

### Feedback Requested

Please review.
