### PR TITLE
BCDA-3072: Suppression Logic Based on MBI (Keep Deprecated HICN in Model for now)

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -521,6 +521,7 @@ type Suppression struct {
 	SuppressionFile     SuppressionFile
 	FileID              uint      `gorm:"not null"`
 	MBI                 string    `gorm:"type:varchar(11);index:idx_suppression_mbi"`
+	HICN                string    `gorm:"type:varchar(11)"`
 	SourceCode          string    `gorm:"type:varchar(5)"`
 	EffectiveDt         time.Time `gorm:"column:effective_date"`
 	PrefIndicator       string    `gorm:"column:preference_indicator;type:char(1)"`


### PR DESCRIPTION
### Fixes [BCDA-3072](https://jira.cms.gov/browse/BCDA-3072)

The majority of the work for BCDA-3072 was performed under https://github.com/CMSgov/bcda-app/pull/497.  However, a small bug was introduced.  We should not yet be removing `HICN` from the data model to avoid violations of `not null` constraints.  This data retention (clean up of `HICN` from data model) is slated to be done as part of [this ticket](https://jira.cms.gov/browse/BCDA-3176).

### Change Details

Reverted the change introduced [here](https://github.com/CMSgov/bcda-app/pull/497/files#diff-efd18a7d1940026f39dee80f50bb3bebL525) to avoid violation of `not null` constraints.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
> Security checklist can be acquired [here](https://confluence.cms.gov/pages/viewpage.action?spaceKey=BCDA&title=20-06-05+Security+Checklist%3A+Running+opt-out+logic+solely+based+on+MBI).
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change


### Acceptance Validation

In addition to the testing performed as part of https://github.com/CMSgov/bcda-app/pull/497, this change was deployed to `dev` and worked as expected.

### Feedback Requested

Please review.
