### PR TITLE
Adding custom Bulk Data Test Suite and Test Runner tool

### DIFF
--- a/Dockerfiles/Dockerfile.bdt
+++ b/Dockerfiles/Dockerfile.bdt
@@ -13,4 +13,4 @@ RUN git apply ../bdt-bcda/patch.file
 
 RUN npm install
 
-CMD ["./bdt/run-bdt.sh"]
+CMD ["./run-bdt.sh"]

--- a/Dockerfiles/Dockerfile.bdt
+++ b/Dockerfiles/Dockerfile.bdt
@@ -1,0 +1,16 @@
+FROM node:current-slim
+
+WORKDIR '/'
+
+RUN apt update -y && apt install curl jq git -y
+
+RUN git clone https://github.com/smart-on-fhir/bdt.git
+RUN git clone https://github.com/orenfromberg/bdt-bcda.git
+WORKDIR '/bdt-bcda'
+RUN git format-patch -k --stdout 82b855a545211a2f4881f1560e05e29e20c084d6..HEAD > patch.file
+WORKDIR '/bdt'
+RUN git apply ../bdt-bcda/patch.file
+
+RUN npm install
+
+CMD ["./bdt/run-bdt.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+bdt:
+	# Please set env vars BDT_CLIENT_ID and BDT_CLIENT_SECRET before running
+	docker build -t bdt -f Dockerfiles/Dockerfile.bdt .
+	docker run --rm \
+	-e CLIENT_ID='${BDT_CLIENT_ID}'
+	-e SECRET='${BDT_CLIENT_SECRET}'
+	bdt
+
 package:
 	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,3 @@
-bdt:
-	# Please set env vars BDT_CLIENT_ID and BDT_CLIENT_SECRET before running
-	docker build -t bdt -f Dockerfiles/Dockerfile.bdt .
-	docker run --rm \
-	-e CLIENT_ID='${BDT_CLIENT_ID}' \
-	-e SECRET='${BDT_CLIENT_SECRET}' \
-	bdt
-
 package:
 	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1
@@ -133,5 +125,15 @@ debug-worker:
 	@echo "Starting debugger. This may take a while..."
 	@-bash -c "trap 'docker-compose stop' EXIT; \
 		docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --no-deps -T --rm -v $(shell pwd):/go/src/github.com/CMSgov/bcda-app worker dlv debug"
+
+bdt:
+	# supply this target with the necessary environment vars, e.g.:
+	# make bdt BDT_BASE_URL=<origin of API> BDT_CLIENT_ID=<client id> BDT_CLIENT_SECRET=<client secret>
+	docker build -t bdt -f Dockerfiles/Dockerfile.bdt .
+	docker run --rm \
+	-e BASE_URL='${BDT_BASE_URL}' \
+	-e CLIENT_ID='${BDT_CLIENT_ID}' \
+	-e SECRET='${BDT_CLIENT_SECRET}' \
+	bdt
 
 .PHONY: api-shell debug-api debug-worker docker-bootstrap docker-build lint load-fixtures load-fixtures-ssas load-synthetic-cclf-data load-synthetic-suppression-data package performance-test postman release smoke-test test unit-test worker-shell

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ bdt:
 	# Please set env vars BDT_CLIENT_ID and BDT_CLIENT_SECRET before running
 	docker build -t bdt -f Dockerfiles/Dockerfile.bdt .
 	docker run --rm \
-	-e CLIENT_ID='${BDT_CLIENT_ID}'
-	-e SECRET='${BDT_CLIENT_SECRET}'
+	-e CLIENT_ID='${BDT_CLIENT_ID}' \
+	-e SECRET='${BDT_CLIENT_SECRET}' \
 	bdt
 
 package:

--- a/Makefile
+++ b/Makefile
@@ -136,4 +136,4 @@ bdt:
 	-e SECRET='${BDT_CLIENT_SECRET}' \
 	bdt
 
-.PHONY: api-shell debug-api debug-worker docker-bootstrap docker-build lint load-fixtures load-fixtures-ssas load-synthetic-cclf-data load-synthetic-suppression-data package performance-test postman release smoke-test test unit-test worker-shell
+.PHONY: api-shell debug-api debug-worker docker-bootstrap docker-build lint load-fixtures load-fixtures-ssas load-synthetic-cclf-data load-synthetic-suppression-data package performance-test postman release smoke-test test unit-test worker-shell bdt

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ debug-worker:
 bdt:
 	# supply this target with the necessary environment vars, e.g.:
 	# make bdt BDT_BASE_URL=<origin of API> BDT_CLIENT_ID=<client id> BDT_CLIENT_SECRET=<client secret>
-	docker build -t bdt -f Dockerfiles/Dockerfile.bdt .
+	docker build --no-cache -t bdt -f Dockerfiles/Dockerfile.bdt .
 	docker run --rm \
 	-e BASE_URL='${BDT_BASE_URL}' \
 	-e CLIENT_ID='${BDT_CLIENT_ID}' \


### PR DESCRIPTION
### Fixes [BCDA-3154](https://jira.cms.gov/browse/BCDA-3154)

This branch adds a make recipe for running the bulk data test suite against bcda.

To test, checkout this branch and use the following command to test the sandbox env:

```
$ make bdt BDT_BASE_URL=https://sandbox.bdca.cms.gov BDT_CLIENT_ID=3841c594-a8c0-41e5-98cc-38bb45360d3c BDT_CLIENT_SECRET=f9780d323588f1cdfc3e63e95a8cbdcdd47602ff48a537b51dc5d7834bf466416a716bd4508e904a
```

### Proposed Changes

* Adding make recipe
* Adding Dockerfile

### Change Details

The Dockerfile checks out the original repo as well as a forked repo (based off the work of @richbraman) that has the changes necessary to authenticate with our API.

A patch is generated and applied against the original repo. We do this instead of trying to push our changes back to the original repo. This way, we can apply our changes to the most updated version of the bulk data test suite tool.

Here are my changes against @richbraman 's: https://github.com/richbraman/bdt-bcda/compare/master...orenfromberg:master

Here are my changes against the original repo: https://github.com/smart-on-fhir/bdt/compare/master...orenfromberg:master

### Security Implications

- [x] new software dependencies

This adds the bulk data test suite.

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [ ] no PHI/PII is affected by this change

### Acceptance Validation

I was able to test that this tool was applied successfully to the dev and sandbox environments.

I updated the tools doc on confluence: https://confluence.cms.gov/pages/viewpage.action?pageId=120235389

### Feedback Requested

All feedback is welcome.
