### PR TITLE
Ignore G404 in test data generator file

### DIFF
--- a/test/datagenerator/1800medicare.go
+++ b/test/datagenerator/1800medicare.go
@@ -1,3 +1,4 @@
+/* #nosec G404 */
 package main
 
 import (


### PR DESCRIPTION

### Fixes Linting Error

The SecureGo team recently improved the linting rules around `G404`.  The details can be found here.  As a result, some of our test code was marked with `Use of weak random number generator (math/rand instead of crypto/rand)`.  Since only test code was affected (and we don't need a cryptographically secure random number generator in our test code), we should be ignoring `G404` in the affected file.


### Change Details

- Added `#nosec G404` to the file in our test suite.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Linting succeeds locally.

### Feedback Requested

Please review.