### PR TITLE
Add nosec for G304

### DIFF
--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -288,6 +288,7 @@ func appendErrorToFile(fileUUID, code, detailsCode, detailsDisplay string, jobID
 
 	dataDir := os.Getenv("FHIR_STAGING_DIR")
 	fileName := fmt.Sprintf("%s/%s/%s-error.ndjson", dataDir, jobID, fileUUID)
+	/* #nosec -- opening file defined by variable */
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 
 	if err != nil {


### PR DESCRIPTION
### Fixes Linting Error

The SecureGo team recently improved the linting rules around `G304`.  The details can be found [here](https://github.com/securego/gosec/issues/488).  As a result, one line of our code was flagged for opening an error file named by a variable.  This behavior is intentional, so we should ignore the linting rule.


### Change Details

- Added `#nosec` to the `bcdaworker` file

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Linting succeeds locally.

### Feedback Requested

Please review.