### PR TITLE
Update TLS Config to explicitly specify MinVersion

### DIFF
--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -89,7 +89,7 @@ func tlsTransport() (*http.Transport, error) {
 	}
 
 	ssasLogger.Println("Using ca cert sourced from ", filepath.Clean(caFile))
-	tlsConfig := &tls.Config{RootCAs: caCertPool}
+	tlsConfig := &tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12}
 
 	return &http.Transport{TLSClientConfig: tlsConfig}, nil
 }

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -65,7 +65,7 @@ func NewBlueButtonClient() (*BlueButtonClient, error) {
 		return nil, errors.Wrap(err, "could not load Blue Button keypair")
 	}
 
-	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
 
 	if strings.ToLower(os.Getenv("BB_CHECK_CERT")) != "false" {
 		caFile := os.Getenv("BB_CLIENT_CA_FILE")

--- a/bcda/servicemux/servicemux.go
+++ b/bcda/servicemux/servicemux.go
@@ -117,6 +117,7 @@ func (sm *ServiceMux) serveHTTPS(tlsCertPath, tlsKeyPath string) {
 			tls.CurveP256,
 			tls.X25519,
 		},
+		MinVersion: tls.VersionTLS12,
 	}
 
 	sm.Listener = tls.NewListener(sm.Listener, &sm.TLSConfig)


### PR DESCRIPTION
### Fixes Issue Uncovered by GoSec

A new linting rule was added to `gosec` [today](https://github.com/securego/gosec/pull/493/files), and our software is not compliant with the new rule.  The new rule aims to be more strict at analyzing the Min/Max TLS versions supported in the software.

### Change Details

Because our Akamai configuration only support TLSv1.2 and above, we can explicitly specify a `MinVersion` of TLSv1.2 in our Go code.

From Akamai configuration:

<img width="950" alt="Screen Shot 2020-06-26 at 9 57 55 AM" src="https://user-images.githubusercontent.com/37818548/85865274-a2586900-b793-11ea-985b-603354ddb3ff.png">


### Security Implications

In this PR, we are aligning the software configuration defining the minimum TLS version to our infrastructure configuration.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

[Deployed](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1597/parameters/) to `dev` and passed all [smoke tests](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/2053/).

### Feedback Requested

Please review.
