### PR TITLE
BCDA-3293 Remove dependency on upstream repo for BDT

### DIFF
--- a/Dockerfiles/Dockerfile.bdt
+++ b/Dockerfiles/Dockerfile.bdt
@@ -4,12 +4,8 @@ WORKDIR '/'
 
 RUN apt update -y && apt install curl jq git -y
 
-RUN git clone https://github.com/smart-on-fhir/bdt.git
 RUN git clone https://github.com/orenfromberg/bdt-bcda.git
 WORKDIR '/bdt-bcda'
-RUN git format-patch -k --stdout 82b855a545211a2f4881f1560e05e29e20c084d6..HEAD > patch.file
-WORKDIR '/bdt'
-RUN git apply ../bdt-bcda/patch.file
 
 RUN npm install
 


### PR DESCRIPTION
### Fixes [BCDA-3293](https://jira.cms.gov/browse/BCDA-3293)

This branch removes the patching that we do so that our job does not break whenever an update to the original repo happens.

### Proposed Changes

Removing Dockerfile script that creates and applies a patch.

### Change Details

From now on we assume all the code we want to run is in our own fork.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [ ] no PHI/PII is affected by this change


### Acceptance Validation

Docker image is properly built and executed.

### Feedback Requested

Going forward we will need to periodically merge in the changes from the upstream repo. Does this make sense? All feedback is welcome.
