### PR TITLE
BCDA-3336: Ensure BDT Scan Runs Locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,12 @@ debug-worker:
 
 bdt:
 	# supply this target with the necessary environment vars, e.g.:
-	# make bdt BDT_BASE_URL=<origin of API> BDT_CLIENT_ID=<client id> BDT_CLIENT_SECRET=<client secret>
+	# make bdt BDT_BASE_URL=<origin of API>
 	docker build --no-cache -t bdt -f Dockerfiles/Dockerfile.bdt .
 	docker run --rm \
 	-e BASE_URL='${BDT_BASE_URL}' \
-	-e CLIENT_ID='${BDT_CLIENT_ID}' \
-	-e SECRET='${BDT_CLIENT_SECRET}' \
+	-e CLIENT_ID='${CLIENT_ID}' \
+	-e SECRET='${CLIENT_SECRET}' \
 	bdt
 
 .PHONY: api-shell debug-api debug-worker docker-bootstrap docker-build lint load-fixtures load-fixtures-ssas load-synthetic-cclf-data load-synthetic-suppression-data package performance-test postman release smoke-test test unit-test worker-shell bdt


### PR DESCRIPTION
### Fixes [BCDA-3336](https://jira.cms.gov/browse/BCDA-3336)

Fixing the BDT script so that it always uses the values for ACO A9994 when using the Makefile target

### Proposed Changes

<!-- List of changes with bullet points here: -->

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database? -->

### Feedback Requested

This solves the issues raised in by the ticket but does lock us into only testing against ACO A9994. I struggled to get a conditional to work in the make file so you could optionally pass in different ACO. Do we need something like that or is this enough since we are only using this for local testing as is?