### PR TITLE
BCDA 3265: Switched user guide location to stage environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - PATIENT_IDENTIFIER_MODE=MBI_MODE
       - BCDA_ENABLE_NEW_GROUP=true
       - PRIORITY_ACO_IDS=A9990,A9991,A9992,A9993,A9994
+      - USER_GUIDE_LOC=https://stage.bcda.cms.gov
     volumes:
      - .:/go/src/github.com/CMSgov/bcda-app
     ports:


### PR DESCRIPTION
### Fixes [BCDA-3265](https://jira.cms.gov/browse/BCDA-3265)

Set the user guide location to `stage.bcda.cms.gov` when developing locally

### Proposed Changes

<!-- List of changes with bullet points here: -->

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database? -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
