### PR TITLE
BCDA-3378 Add timeout option in make lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ package:
 	-e GPG_SEC_KEY_FILE='${GPG_SEC_KEY_FILE}' \
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
+
+LINT_TIMEOUT ?= 3m
 lint:
-	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=3m
+	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=$(LINT_TIMEOUT) --verbose
 	docker-compose -f docker-compose.test.yml run --rm tests gosec ./...
 
 # The following vars are available to tests needing SSAS admin credentials; currently they are used in smoke-test


### PR DESCRIPTION
### Fixes [BCDA-3378](https://jira.cms.gov/browse/BCDA-3378)

We want to be able to dynamically set the lint timeout option to handle different execution environments.

1. Add an optional lint timeout (`LINT_TIMEOUT `) parameter (defaulted to 3m) to the make-lint command.
    This option will allow callers to dynamically set a timeout to match their environment.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

- Ran BCDA - Build and Package job successfully. [Job link](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1652/)

### Feedback Requested

Please review
