### PR TITLE
BCDA-3370 Add tests to verify Blue Button client uses gzip encoding

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -152,7 +152,7 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID, cmsI
 	req.URL.RawQuery = params.Encode()
 
 	queryID := uuid.NewRandom()
-	AddRequestHeaders(req, queryID, jobID, cmsID)
+	addRequestHeaders(req, queryID, jobID, cmsID)
 
 	tryCount := 0
 	maxTries := utils.GetEnvInt("BB_REQUEST_MAX_TRIES", 3)
@@ -176,7 +176,7 @@ func (bbc *BlueButtonClient) getData(path string, params url.Values, jobID, cmsI
 	return "", fmt.Errorf("Blue Button request %s failed %d time(s)", queryID, tryCount)
 }
 
-func AddRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) {
+func addRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) {
 	// Info for BB backend: https://jira.cms.gov/browse/BLUEBUTTON-483
 	req.Header.Add("BlueButton-OriginalQueryTimestamp", time.Now().String())
 	req.Header.Add("BlueButton-OriginalQueryId", reqID.String())
@@ -189,6 +189,7 @@ func AddRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) 
 	req.Header.Add("BCDA-JOBID", jobID)
 	req.Header.Add("BCDA-CMSID", cmsID)
 	req.Header.Add("IncludeIdentifiers", "mbi")
+	req.Header.Add("Accept-Encoding", "gzip")
 
 	// Do not set BB-specific headers with blank values
 	// Leaving them here, commented out, in case we want to set them to real values in future

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -338,7 +338,7 @@ func (s *BBRequestTestSuite) TestValidateRequestHeaders() {
 		funcUnderTest func(bbClient *client.BlueButtonClient, jobID, cmsID string) (string, error)
 	}{
 		{
-			"ExplanationOfBenefit",
+			"GetExplanationOfBenefit",
 			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (string, error) {
 				return s.bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, "", time.Now())
 			},


### PR DESCRIPTION
### Fixes [BCDA-3370](https://jira.cms.gov/browse/BCDA-3370)

Ensure that we're making requests to Blue Button API with `Accept-Encoding: gzip` set.

### Change Details

We had initially thought that we need to explicitly add the `Accept-Encoding: gzip` when making requests to Blue Button API. After looking deeper in the implementation, we need to ensure that we **do not** set this header. If the header is present, then the HTTP client needs to explicitly handle the decompression of the gzip data.

The underlying `http.Transport` will handle this for us if we have `DisableCompression: false`. It transparently decompresses the data and the HTTP client is given the decompressed data.

Actual changes:
1. Adding tests to verify that we are handling gzip responses from the server successfully (i.e. the response does not need to be explicitly de-compressed).
2. Add more comments on why we do not (and should not) set the `Accept-Encoding: gzip` header in our request.
3. Refactored our header test to ensure that all of our requests to Blue Button API have the correct headers set. This refactoring uses [Table Drive Tests](https://github.com/golang/go/wiki/TableDrivenTests)

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Local tests + CI build
### Feedback Requested

Please review. If you can look at the table driven test, I think it's a good pattern to start using elsewhere.
