### PR TITLE
 BCDA-3304 - Remove unnecessary dependency between queue-db and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ package:
 LINT_TIMEOUT ?= 3m
 lint:
 	docker-compose -f docker-compose.test.yml build tests
-	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=$(LINT_TIMEOUT) --verbose --concurrency=1
+	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=$(LINT_TIMEOUT) --verbose
 	docker-compose -f docker-compose.test.yml run --rm tests gosec ./...
 
 # The following vars are available to tests needing SSAS admin credentials; currently they are used in smoke-test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ package:
 LINT_TIMEOUT ?= 3m
 lint:
 	docker-compose -f docker-compose.test.yml build tests
-	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=$(LINT_TIMEOUT) --verbose
+	docker-compose -f docker-compose.test.yml run --rm tests golangci-lint run --deadline=$(LINT_TIMEOUT) --verbose --concurrency=1
 	docker-compose -f docker-compose.test.yml run --rm tests gosec ./...
 
 # The following vars are available to tests needing SSAS admin credentials; currently they are used in smoke-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       - "5433:5432"
     volumes:
       - ./db/worker.sql:/docker-entrypoint-initdb.d/schema.sql
-    depends_on:
-      - documentation
   db:
     image: postgres
     environment:


### PR DESCRIPTION
### Fixes [BCDA-3304](https://jira.cms.gov/browse/BCDA-3304)

Removes a failure point around the documentation Docker container.

```
ERROR: for documentation  You cannot remove a running container DOCUMENTATION_ID. Stop the container before attempting removal or force remove
```

This was a result of each Make (lint, package, unit-test) command re-creating the documentation container.

### Proposed Changes

Update docker-compose files to allow for concurrent execution of multiple stages without needing to sleep between stages.

### Change Details

1. Remove unneeded dependency between the queue-db container and the documentation container.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Successfully ran build & deploy job

![Screen Shot 2020-08-04 at 3 06 46 PM](https://user-images.githubusercontent.com/21049223/89345655-0b6daf00-d665-11ea-924c-f4627f5b26ed.png)
