### PR TITLE
BCDA-3498 - Re-enable cutoff time lookup on smoke-tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       - BCDA_ENABLE_NEW_GROUP=true
       - PRIORITY_ACO_IDS=A9990,A9991,A9992,A9993,A9994
       - USER_GUIDE_LOC=https://stage.bcda.cms.gov
-      - CCLF_CUTOFF_DATE_DAYS=0 # Set to 0 so we allow all CCLF files to be considered.
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     ports:


### PR DESCRIPTION
### Relates to [BCDA-3498](https://jira.cms.gov/browse/BCDA-3498)

We want to shorten the feedback loop for issues with implementation issues. This means running smoke tests with a similar configuration that's being used in production.

### Change Details

1. Re-enable cutoff time parameter when retrieving the latest CCLF file. This means that we'll remove the environment variable (CCLF_CUTOFF_TIME_DAYS) that was set to 0 (disabled).

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

CI tests passing
