### PR TITLE
BCDA-3428 - Adding timing metrics to CCLF Ingest process

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -192,10 +192,11 @@
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
-  digest = "1:01f60ec456e70c9be269902c08fa189a9d47056a419c4a91a02f19df5e36ab59"
+  digest = "1:a4ae6efef4eb40a1bf75134dd7c3fca69d2cc928ea67cc8fcb75367fd717b0a9"
   name = "github.com/newrelic/go-agent"
   packages = [
     ".",
+    "_integrations/nrlogrus",
     "internal",
     "internal/cat",
     "internal/jsonx",
@@ -398,6 +399,7 @@
     "github.com/jinzhu/gorm/dialects/postgres",
     "github.com/lib/pq",
     "github.com/newrelic/go-agent",
+    "github.com/newrelic/go-agent/_integrations/nrlogrus",
     "github.com/pborman/uuid",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -260,8 +260,8 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importFunc 
 	sc := bufio.NewScanner(rc)
 	for sc.Scan() {
 		close := metrics.NewChild(ctx, fmt.Sprintf("importCCLF%d-readlines", cclfFile.CCLFNum))
-		defer close()
 		b := sc.Bytes()
+		close()
 		if len(bytes.TrimSpace(b)) > 0 {
 			err = importFunc(cclfFile.ID, b, db)
 			if err != nil {

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -149,6 +149,8 @@ func importCCLF0(ctx context.Context, fileMetadata *cclfFileMetadata) (map[strin
 
 func importCCLF8(ctx context.Context, fileMetadata *cclfFileMetadata) error {
 	err := importCCLF(ctx, fileMetadata, func(fileID uint, b []byte, db *gorm.DB) error {
+		close := metrics.NewChild(ctx, "importCCLF8-benecreate")
+		defer close()
 		const (
 			mbiStart, mbiEnd   = 0, 11
 			hicnStart, hicnEnd = 11, 22
@@ -257,6 +259,8 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importFunc 
 	defer rc.Close()
 	sc := bufio.NewScanner(rc)
 	for sc.Scan() {
+		close := metrics.NewChild(ctx, fmt.Sprintf("importCCLF%d-readlines", cclfFile.CCLFNum))
+		defer close()
 		b := sc.Bytes()
 		if len(bytes.TrimSpace(b)) > 0 {
 			err = importFunc(cclfFile.ID, b, db)

--- a/bcda/cclf/metrics/metrics.go
+++ b/bcda/cclf/metrics/metrics.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	newrelic "github.com/newrelic/go-agent"
+	log "github.com/sirupsen/logrus"
+)
+
+// Timer provides methods for timing methods.
+// Typical Usage scenario:
+// ctx, close := Timer.New("Data Ingest")
+// defer close()
+// close1 := Timer.NewChild(ctx, "Ingest #1")
+// // Perform Ingest #1 call
+// close1()
+// close2 := Timer.NewChild(ctx, "Ingest #2")
+// // Perform Ingest #2 call
+// close2()
+type Timer interface {
+	// New creates a new timer and embeds it into the returned context.
+	// To start timing methods, caller should start with this call
+	// and provide the returned context to NewChild().
+	New(name string) (ctx context.Context, close func())
+
+	// NewChild creates a timer (child) from the parent via the supplied context.
+	NewChild(parentCtx context.Context, name string) (close func())
+}
+
+func GetTimer() Timer {
+	target := os.Getenv("DEPLOYMENT_TARGET")
+	if target == "" {
+		target = "local"
+	}
+	config := newrelic.NewConfig(fmt.Sprintf("BCDA-%s", target), os.Getenv("NEW_RELIC_LICENSE_KEY"))
+	config.Enabled = true
+	config.HighSecurity = true
+	app, err := newrelic.NewApplication(config)
+
+	if err != nil {
+		return &noopTimer{}
+	}
+
+	return &timer{app}
+}
+
+// validates that timer implements the interface
+var _ Timer = &timer{}
+
+type timer struct {
+	nr newrelic.Application
+}
+
+func (t *timer) New(name string) (ctx context.Context, close func()) {
+	// Passing in nil http artifacts will allow us to time non-HTTP request
+	txn := t.nr.StartTransaction(name, nil, nil)
+	ctx = newrelic.NewContext(context.Background(), txn)
+
+	f := func() {
+		err := txn.End()
+		log.Warnf("Error occurred when ending transaction %s", err.Error())
+	}
+	return ctx, f
+}
+
+func (t *timer) NewChild(parentCtx context.Context, name string) (close func()) {
+	txn := newrelic.FromContext(parentCtx)
+	if txn == nil {
+		return noop
+	}
+	segment := newrelic.StartSegment(txn, name)
+
+	return func() {
+		err := segment.End()
+		log.Warnf("Error occurred when ending segment %s", err.Error())
+	}
+}
+
+// validates that noopTimer implements the interface
+var _ Timer = &noopTimer{}
+
+type noopTimer struct {
+}
+
+func (t *noopTimer) New(name string) (ctx context.Context, close func()) {
+	return context.Background(), noop
+}
+
+func (t *noopTimer) NewChild(parentCtx context.Context, name string) (close func()) {
+	return noop
+}
+
+func noop() {
+}

--- a/bcda/cclf/metrics/metrics.go
+++ b/bcda/cclf/metrics/metrics.go
@@ -96,6 +96,7 @@ func GetTimer() Timer {
 		return &noopTimer{}
 	}
 
+	log.Info("Using New Relic backed timer.")
 	return &timer{app}
 }
 

--- a/bcda/cclf/metrics/metrics_test.go
+++ b/bcda/cclf/metrics/metrics_test.go
@@ -1,0 +1,98 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent/_integrations/nrlogrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+type MetricTestSuite struct {
+	suite.Suite
+	timer Timer
+	hook  *test.Hook
+}
+
+func (s *MetricTestSuite) SetupTest() {
+	s.hook = test.NewGlobal()
+
+	logrus.SetLevel(logrus.DebugLevel)
+
+	c := newrelic.Config{
+		Enabled: false,
+		Logger:  nrlogrus.StandardLogger(),
+	}
+
+	nr, err := newrelic.NewApplication(c)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), nr)
+
+	// Reset the test hook so we ignore any logs associated
+	// with the setup of NewRelic
+	s.hook.Reset()
+	s.timer = &timer{nr}
+}
+
+func TestMetricTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricTestSuite))
+}
+
+// TestTimer validates that we're reporting the correct timing metrics
+// by validating the log messages emitted by NewRelic
+func (s *MetricTestSuite) TestTimer() {
+
+	txnName := "Txn"
+	// Wrap into a function so we can leverage defer
+	func() {
+		ctx, closeTxn := s.timer.New(txnName)
+		assert.NotNil(s.T(), ctx)
+		assert.NotNil(s.T(), closeTxn)
+		defer closeTxn()
+
+		close1 := s.timer.NewChild(ctx, "child")
+		assert.NotNil(s.T(), close1)
+		defer close1()
+
+	}()
+
+	entries := s.hook.AllEntries()
+	// Unfortunately, we do not receive a log entry for closing a segment.
+	assert.Equal(s.T(), 1, len(entries))
+	assert.NotNil(s.T(), entries[0].Data["duration_ms"])
+	assert.Contains(s.T(), entries[0].Data["name"], txnName)
+}
+
+func (s *MetricTestSuite) TestTimerNoParent() {
+	close := s.timer.NewChild(context.Background(), "someChild")
+	assert.NotNil(s.T(), close)
+	close()
+
+	entries := s.hook.AllEntries()
+	assert.Equal(s.T(), 1, len(entries))
+	assert.Contains(s.T(), entries[0].Message, "No transaction found. Cannot create child.")
+}
+
+func (s *MetricTestSuite) TestNoOpTimer() {
+	timer := &noopTimer{}
+	ctx, closeTxn := timer.New("someTxnName")
+	assert.NotNil(s.T(), ctx)
+	assert.NotNil(s.T(), closeTxn)
+	assert.Equal(s.T(), context.Background(), ctx)
+
+	closeChild := timer.NewChild(ctx, "someChildName")
+	assert.NotNil(s.T(), closeChild)
+}
+
+// TestDefaultTimer validates that we return a non-nil timer
+// when we cannot instantiate a NewRelic backed one.
+func (s *MetricTestSuite) TestDefaultTimer() {
+	t := GetTimer()
+	assert.NotNil(s.T(), t)
+	assert.IsType(s.T(), &noopTimer{}, t)
+}

--- a/vendor/github.com/newrelic/go-agent/_integrations/nrlogrus/nrlogrus.go
+++ b/vendor/github.com/newrelic/go-agent/_integrations/nrlogrus/nrlogrus.go
@@ -1,0 +1,47 @@
+// Package nrlogrus forwards go-agent log messages to logrus.  If you are using
+// logrus for your application and would like the go-agent log messages to end
+// up in the same place, modify your config as follows:
+//
+//    cfg.Logger = nrlogrus.StandardLogger()
+//
+// Only logrus' StandardLogger is supported since there is no method (as of July
+// 2016) to get the level of a logrus.Logger. See
+// https://github.com/sirupsen/logrus/issues/241
+package nrlogrus
+
+import (
+	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent/internal"
+	"github.com/sirupsen/logrus"
+)
+
+func init() { internal.TrackUsage("integration", "logging", "logrus") }
+
+type shim struct{ e *logrus.Entry }
+
+func (s *shim) Error(msg string, c map[string]interface{}) {
+	s.e.WithFields(c).Error(msg)
+}
+func (s *shim) Warn(msg string, c map[string]interface{}) {
+	s.e.WithFields(c).Warn(msg)
+}
+func (s *shim) Info(msg string, c map[string]interface{}) {
+	s.e.WithFields(c).Info(msg)
+}
+func (s *shim) Debug(msg string, c map[string]interface{}) {
+	s.e.WithFields(c).Info(msg)
+}
+func (s *shim) DebugEnabled() bool {
+	lvl := logrus.GetLevel()
+	return lvl >= logrus.DebugLevel
+}
+
+// StandardLogger returns a newrelic.Logger which forwards agent log messages to
+// the logrus package-level exported logger.
+func StandardLogger() newrelic.Logger {
+	return &shim{
+		e: logrus.WithFields(logrus.Fields{
+			"component": "newrelic",
+		}),
+	}
+}


### PR DESCRIPTION
### Implements [BCDA-3428](https://jira.cms.gov/browse/BCDA-3428)

To get better insights into how we can improve our CCLF file ingest performance, we need to time the various methods. 

### Change Details

Adding tracing to the following calls:

1. sortCCLFFiles
2. ImportCCLF0
3. ValidateCCLF8
4. ImportCCLF8
5. CleanupCCLFFiles

### Security Implications
- [x] new software dependencies

Brought in `github.com/newrelic/go-agent/_integrations/nrlogrus`. Only used in test scope to inject a logger to validate our usages of NewRelic transaction/segments.

- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. CI passes
2. Able to ingest CCLF data.
3. Timing metrics reported to NewRelic.

<img width="1148" alt="Screen Shot 2020-08-13 at 4 56 03 PM" src="https://user-images.githubusercontent.com/21049223/90195107-e7f1e500-dd85-11ea-8f25-3b4cb7115fae.png">
<img width="467" alt="Screen Shot 2020-08-13 at 4 55 15 PM" src="https://user-images.githubusercontent.com/21049223/90195112-e9231200-dd85-11ea-843b-783ab1df9952.png">
