### PR TITLE
BCDA-3297 Swagger to OpenAPI Conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bcdaworker/debug
 test_results/*
 .idea
 bcda/swaggerui/swagger.json
+bcda/swaggerui/openapi.json
 bcdaworker/data/*
 bcdaworker/archive/*
 bcdaworker/tmpdata/*

--- a/Dockerfiles/Dockerfile.openapi
+++ b/Dockerfiles/Dockerfile.openapi
@@ -1,0 +1,9 @@
+FROM swaggerapi/swagger-converter:v1.0.2
+
+COPY bcda/swaggerui swaggerui
+COPY ops/swagger_to_openapi.sh .
+RUN chmod u+x swagger_to_openapi.sh
+RUN apk update
+RUN apk add curl jq
+
+CMD ["./swagger_to_openapi.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 package:
 	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1
-	docker-compose up documentation
+	docker-compose up documentation openapi
 	docker build -t packaging -f Dockerfiles/Dockerfile.package .
 	docker run --rm \
 	-e BCDA_GPG_RPM_PASSPHRASE='${BCDA_GPG_RPM_PASSPHRASE}' \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,14 @@ services:
       dockerfile: Dockerfiles/Dockerfile.documentation
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
+  openapi:
+    build:
+      context: .
+      dockerfile: Dockerfiles/Dockerfile.openapi
+    volumes:
+      - ./bcda/swaggerui:/swagger-converter/swaggerui
+    depends_on:
+      - documentation
   ssas:
     build:
       context: .

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -29,6 +29,12 @@ then
   exit 1
 fi
 
+if [ ! -f ../bcda/swaggerui/openapi.json ]
+then
+  echo "OpenAPI doc generation must be completed prior to creating package."
+  exit 1
+fi
+
 cd ../bcda
 go clean
 echo "Building bcda binary..." 

--- a/ops/swagger_to_openapi.sh
+++ b/ops/swagger_to_openapi.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is intended to be run from within the Docker "openapi_converter" container
+#
+set -e
+set -o pipefail
+
+java -jar -DswaggerUrl=swagger.yaml /swagger-converter/jetty-runner.jar /swagger-converter/server.war &
+sleep 30
+curl -X POST -d "@swaggerui/swagger.json" localhost:8080/api/convert -H "Content-Type: application/json" -o temp.json
+cat temp.json | jq > swaggerui/openapi.json


### PR DESCRIPTION
### Fixes [BCDA-3297](https://jira.cms.gov/browse/BCDA-3297)

Included with the Swagger documentation we also want to also include OpenAPI documentation

### Proposed Changes

* Added new openapi conversion docker container and migration script
* Added check to stop packaging if documentation fails to generate

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
Deployed to dev. OpenAPI documentation is available at https://dev.bcda.cms.gov/api/v1/swagger/openapi.json

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
