### PR TITLE
BCDA 3533 Feature: Remove tailing reference of HICN mode

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -469,17 +469,16 @@ type Suppression struct {
 // This method will ensure that a valid BlueButton ID is returned.
 // If you use cclfBeneficiary.BlueButtonID you will not be guaranteed a valid value
 func (cclfBeneficiary *CCLFBeneficiary) GetBlueButtonID(bb client.APIClient) (blueButtonID string, err error) {
-	patientIdMode := "MBI_MODE"
 	modelIdentifier := cclfBeneficiary.MBI
 
-	blueButtonID, err = GetBlueButtonID(bb, modelIdentifier, patientIdMode, "beneficiary", cclfBeneficiary.ID)
+	blueButtonID, err = GetBlueButtonID(bb, modelIdentifier, "beneficiary", cclfBeneficiary.ID)
 	if err != nil {
 		return "", err
 	}
 	return blueButtonID, nil
 }
 
-func GetBlueButtonID(bb client.APIClient, modelIdentifier, patientIdMode, reqType string, modelID uint) (blueButtonID string, err error) {
+func GetBlueButtonID(bb client.APIClient, modelIdentifier, reqType string, modelID uint) (blueButtonID string, err error) {
 	hashedIdentifier := client.HashIdentifier(modelIdentifier)
 
 	jsonData, err := bb.GetPatientByIdentifierHash(hashedIdentifier)
@@ -505,23 +504,20 @@ func GetBlueButtonID(bb client.APIClient, modelIdentifier, patientIdMode, reqTyp
 	blueButtonID = patient.Entry[0].Resource.ID
 	for _, identifier := range patient.Entry[0].Resource.Identifier {
 		if strings.Contains(identifier.System, "us-mbi") {
-			if patientIdMode == "MBI_MODE" {
-				if identifier.Value == modelIdentifier {
-					foundIdentifier = true
-				}
+			if identifier.Value == modelIdentifier {
+				foundIdentifier = true
 			}
 		} else if strings.Contains(identifier.System, "bene_id") && identifier.Value == blueButtonID {
 			foundBlueButtonID = true
 		}
 	}
 	if !foundIdentifier {
-		patientIdMode = strings.Split(patientIdMode, "_")[0]
-		err = fmt.Errorf("%v not found in the identifiers", patientIdMode)
+		err = fmt.Errorf("Identifier not found")
 		log.Error(err)
 		return "", err
 	}
 	if !foundBlueButtonID {
-		err = fmt.Errorf("blue Button identifier not found in the identifiers")
+		err = fmt.Errorf("Blue Button identifier not found in the identifiers")
 		log.Error(err)
 		return "", err
 	}


### PR DESCRIPTION
<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [BCDA-3533](https://jira.cms.gov/browse/BCDA-3533)

All references to HICN mode are removed from the bcda-app codebase, however under `models.go` there is a stale reference to this.

### Proposed Changes

- Prune out HICN mode references
- Deprecate `patientIdMode` as it is no longer necessary.

### Change Details


### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database? -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
