### PR TITLE
BCDA-3429 - Use COPY FROM to bulk load CCLF beneficary data

### DIFF
--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -203,7 +203,6 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer im
 
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
-	db.LogMode(true)
 
 	err = db.Create(&cclfFile).Error
 	if err != nil {

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -214,7 +214,7 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer im
 
 	fileMetadata.fileID = cclfFile.ID
 
-	importStatusInterval := utils.GetEnvInt("CCLF_IMPORT_STATUS_RECORDS_INTERVAL", 1000)
+	importStatusInterval := utils.GetEnvInt("CCLF_IMPORT_STATUS_RECORDS_INTERVAL", 10000)
 	importedCount := 0
 	var rawFile *zip.File
 

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -149,7 +149,7 @@ func importCCLF0(ctx context.Context, fileMetadata *cclfFileMetadata) (map[strin
 func importCCLF8(ctx context.Context, fileMetadata *cclfFileMetadata) error {
 	importer := &cclf8Importer{
 		logger:            log.StandardLogger(),
-		maxPendingQueries: utils.GetEnvInt("STATEMENT_EXEC_COUNT", 100000),
+		maxPendingQueries: utils.GetEnvInt("STATEMENT_EXEC_COUNT", 200000),
 	}
 
 	err := importCCLF(ctx, fileMetadata, importer)

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -148,27 +147,12 @@ func importCCLF0(ctx context.Context, fileMetadata *cclfFileMetadata) (map[strin
 }
 
 func importCCLF8(ctx context.Context, fileMetadata *cclfFileMetadata) error {
-	err := importCCLF(ctx, fileMetadata, func(fileID uint, b []byte, db *gorm.DB) error {
-		close := metrics.NewChild(ctx, "importCCLF8-benecreate")
-		defer close()
-		const (
-			mbiStart, mbiEnd   = 0, 11
-			hicnStart, hicnEnd = 11, 22
-		)
-		cclfBeneficiary := &models.CCLFBeneficiary{
-			FileID: fileID,
-			MBI:    string(bytes.TrimSpace(b[mbiStart:mbiEnd])),
-			HICN:   string(bytes.TrimSpace(b[hicnStart:hicnEnd])),
-		}
-		err := db.Create(cclfBeneficiary).Error
-		if err != nil {
-			fmt.Println("Could not create CCLF8 beneficiary record.")
-			err = errors.Wrap(err, "could not create CCLF8 beneficiary record")
-			log.Error(err)
-			return err
-		}
-		return nil
-	})
+	importer := &cclf8Importer{
+		logger:            log.StandardLogger(),
+		maxPendingQueries: utils.GetEnvInt("STATEMENT_EXEC_COUNT", 100000),
+	}
+
+	err := importCCLF(ctx, fileMetadata, importer)
 
 	if err != nil {
 		updateImportStatus(fileMetadata, constants.ImportFail)
@@ -178,7 +162,7 @@ func importCCLF8(ctx context.Context, fileMetadata *cclfFileMetadata) error {
 	return nil
 }
 
-func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importFunc func(uint, []byte, *gorm.DB) error) error {
+func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer importer) (err error) {
 	if fileMetadata == nil {
 		fmt.Println("CCLF file not found.")
 		err := errors.New("CCLF file not found")
@@ -219,6 +203,7 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importFunc 
 
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
+	db.LogMode(true)
 
 	err = db.Create(&cclfFile).Error
 	if err != nil {
@@ -258,26 +243,48 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importFunc 
 	}
 	defer rc.Close()
 	sc := bufio.NewScanner(rc)
+
+	// Open transaction to encompass entire CCLF file ingest.
+	txn, err := db.DB().Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			err = importer.flush(ctx)
+		}
+
+		if err != nil {
+			err = txn.Rollback()
+		}
+
+		if err = txn.Commit(); err == nil {
+			successMsg := fmt.Sprintf("Successfully imported %d records from CCLF%d file %s.", importedCount, fileMetadata.cclfNum, fileMetadata)
+			fmt.Println(successMsg)
+			log.Infof(successMsg)
+		}
+	}()
+
 	for sc.Scan() {
 		close := metrics.NewChild(ctx, fmt.Sprintf("importCCLF%d-readlines", cclfFile.CCLFNum))
 		b := sc.Bytes()
 		close()
-		if len(bytes.TrimSpace(b)) > 0 {
-			err = importFunc(cclfFile.ID, b, db)
-			if err != nil {
-				log.Error(err)
-				return err
-			}
-			importedCount++
-			if importedCount%importStatusInterval == 0 {
-				fmt.Printf("CCLF%d records imported: %d\n", fileMetadata.cclfNum, importedCount)
-			}
+
+		if len(bytes.TrimSpace(b)) == 0 {
+			continue
+		}
+
+		err = importer.do(ctx, txn, cclfFile.ID, b)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+
+		importedCount++
+		if importedCount%importStatusInterval == 0 {
+			fmt.Printf("CCLF%d records imported: %d\n", fileMetadata.cclfNum, importedCount)
 		}
 	}
-
-	successMsg := fmt.Sprintf("Successfully imported %d records from CCLF%d file %s.", importedCount, fileMetadata.cclfNum, fileMetadata)
-	fmt.Println(successMsg)
-	log.Infof(successMsg)
 
 	return nil
 }

--- a/bcda/cclf/importer.go
+++ b/bcda/cclf/importer.go
@@ -1,0 +1,103 @@
+package cclf
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/CMSgov/bcda-app/bcda/cclf/metrics"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type importer interface {
+	do(ctx context.Context, tx *sql.Tx, fileID uint, b []byte) error
+
+	// flush should be called once the import process is complete.
+	// This will guarantee any remaining work involved with the importer is complete.
+	flush(ctx context.Context) error
+}
+
+// A cclf8Importer is not safe for concurrent use by multiple goroutines.
+// It should be scoped to a single *sql.Tx
+type cclf8Importer struct {
+	logger *logrus.Logger
+
+	inprogress *sql.Stmt
+
+	pendingQueries    int
+	maxPendingQueries int
+}
+
+// validates that cclf8Importer implements the interface
+var _ importer = &cclf8Importer{}
+
+func (cclfImporter *cclf8Importer) do(ctx context.Context, tx *sql.Tx, fileID uint, b []byte) error {
+	if cclfImporter.inprogress == nil {
+		if err := cclfImporter.refreshStatement(ctx, tx); err != nil {
+			return errors.Wrap(err, "failed to refresh statement")
+		}
+	}
+
+	if cclfImporter.pendingQueries >= cclfImporter.maxPendingQueries {
+		if err := cclfImporter.flush(ctx); err != nil {
+			return errors.Wrap(err, "failed to flush statement")
+		}
+		if err := cclfImporter.refreshStatement(ctx, tx); err != nil {
+			return errors.Wrap(err, "failed to refresh statement")
+		}
+		cclfImporter.pendingQueries = 0
+	}
+
+	close := metrics.NewChild(ctx, "importCCLF8-benecreate")
+	defer close()
+	const (
+		mbiStart, mbiEnd   = 0, 11
+		hicnStart, hicnEnd = 11, 22
+	)
+	cclfBeneficiary := &models.CCLFBeneficiary{
+		FileID: fileID,
+		MBI:    string(bytes.TrimSpace(b[mbiStart:mbiEnd])),
+		HICN:   string(bytes.TrimSpace(b[hicnStart:hicnEnd])),
+	}
+	_, err := cclfImporter.inprogress.Exec(cclfBeneficiary.FileID, cclfBeneficiary.HICN, cclfBeneficiary.MBI)
+	if err != nil {
+		fmt.Println("Could not create CCLF8 beneficiary record.")
+		err = errors.Wrap(err, "could not create CCLF8 beneficiary record")
+		cclfImporter.logger.Error(err)
+		return err
+	}
+	cclfImporter.pendingQueries++
+	return nil
+}
+
+func (cclfImporter *cclf8Importer) flush(ctx context.Context) error {
+	stmt := cclfImporter.inprogress
+	if stmt == nil {
+		cclfImporter.logger.Warn("No statement to flush.")
+		return nil
+	}
+
+	if _, err := stmt.Exec(); err != nil {
+		return err
+	}
+
+	if err := stmt.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cclfImporter *cclf8Importer) refreshStatement(ctx context.Context, tx *sql.Tx) error {
+	stmt, err := tx.PrepareContext(ctx, pq.CopyIn("cclf_beneficiaries", "file_id", "hicn", "mbi"))
+	if err != nil {
+		return err
+	}
+
+	cclfImporter.inprogress = stmt
+	return nil
+}

--- a/bcda/cclf/importer_test.go
+++ b/bcda/cclf/importer_test.go
@@ -202,7 +202,7 @@ func (s *ImporterTestSuite) TestFlushOnNoExistingStatement() {
 func getBeneficiary(fileID uint) *models.CCLFBeneficiary {
 	return &models.CCLFBeneficiary{
 		FileID: fileID,
-		// We expect 11 byte sfor HICN and MBI - we'll ensure that each of the values are AT LEAST 11 bytes
+		// We expect 11 bytes for HICN and MBI - we'll ensure that each of the values are AT LEAST 11 bytes
 		HICN: fmt.Sprintf("HICN%07d", rand.Uint64()),
 		MBI:  fmt.Sprintf("MBI%08d", rand.Uint64()),
 	}

--- a/bcda/cclf/importer_test.go
+++ b/bcda/cclf/importer_test.go
@@ -1,0 +1,209 @@
+package cclf
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/pkg/errors"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ImporterTestSuite struct {
+	suite.Suite
+
+	tx   *sql.Tx
+	mock sqlmock.Sqlmock
+
+	db *sql.DB
+}
+
+func (s *ImporterTestSuite) SetupTest() {
+	var err error
+	s.db, s.mock, err = sqlmock.New()
+	assert.NoError(s.T(), err)
+
+	s.mock.ExpectBegin()
+	tx, err := s.db.Begin()
+	assert.NoError(s.T(), err)
+
+	s.tx = tx
+}
+
+func (s *ImporterTestSuite) AfterTest(_, _ string) {
+	assert.NoError(s.T(), s.mock.ExpectationsWereMet())
+	s.db.Close()
+}
+
+func TestMetricTestSuite(t *testing.T) {
+	suite.Run(t, new(ImporterTestSuite))
+}
+
+// TestCCLF8ImporterHappyPath verifies that we're able to flush statements
+// that have exceeded the query threshold
+func (s *ImporterTestSuite) TestCCLF8ImporterHappyPath() {
+	var benes []*models.CCLFBeneficiary
+	fileID := uint(rand.Uint32())
+	for i := 0; i < 100; i++ {
+		benes = append(benes, getBeneficiary(fileID))
+	}
+
+	tests := []struct {
+		name              string
+		maxPendingQueries int
+	}{
+		{"NoFlush", 100000},
+		{"InProgressFlush", 7},
+		{"SingleExecPerFlush", 1},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			s.SetupTest()
+			defer s.AfterTest("", "")
+
+			importer := &cclf8Importer{
+				logger:            logrus.New(),
+				maxPendingQueries: tt.maxPendingQueries,
+			}
+
+			execCount := 0
+			prepare := s.mock.ExpectPrepare(regexp.QuoteMeta(`COPY "cclf_beneficiaries" ("file_id", "hicn", "mbi")`))
+			for _, bene := range benes {
+				hicn := string([]byte(bene.HICN)[0:11])
+				mbi := string([]byte(bene.MBI)[0:11])
+				prepare.ExpectExec().WithArgs(bene.FileID, hicn, mbi).WillReturnResult(sqlmock.NewResult(1, 1))
+
+				data := append([]byte(mbi), []byte(hicn)...)
+				err := importer.do(context.Background(), s.tx, fileID, data)
+				assert.NoError(t, err)
+
+				execCount++
+				// The last bene import call will not close out the in progress statement.
+				if execCount%tt.maxPendingQueries == 0 && execCount < len(benes) {
+					prepare.ExpectExec().WithArgs().WillReturnResult(sqlmock.NewResult(1, 1))
+					prepare.WillBeClosed()
+					prepare = s.mock.ExpectPrepare(regexp.QuoteMeta(`COPY "cclf_beneficiaries" ("file_id", "hicn", "mbi")`))
+				}
+			}
+
+			// Calling flush should close out the pending prepared statement
+			prepare.ExpectExec().WithArgs().WillReturnResult(sqlmock.NewResult(1, 1))
+			prepare.WillBeClosed()
+			importer.flush(context.Background())
+		})
+	}
+}
+
+func (s *ImporterTestSuite) TestCCLF8ImporterErrorPaths() {
+	type errorType int
+	const (
+		execWithArgsError errorType = 1
+		execEmptyError    errorType = 2
+		closeError        errorType = 3
+		doErrorOnFlush    errorType = 4
+	)
+
+	type doError struct {
+		et  errorType
+		err error
+	}
+
+	fileID := uint(rand.Uint32())
+	bene := getBeneficiary(fileID)
+
+	tests := []struct {
+		name string
+		err  doError
+	}{
+		{"ErrorOnExecWithArgs", doError{execWithArgsError, errors.New("Some error when exec call with bene args")}},
+		{"ErrorOnExecEmpty", doError{execEmptyError, errors.New("Some exec error when attempting to flush statement")}},
+		{"ErrorOnClose", doError{closeError, errors.New("Some exec error when attempting to close statement")}},
+		{"ErrorOnFlushOnDo", doError{doErrorOnFlush, errors.New("Some exec error when attempting to flush statement")}},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			s.SetupTest()
+			defer s.AfterTest("", "")
+
+			importer := &cclf8Importer{
+				logger:            logrus.New(),
+				maxPendingQueries: 1,
+			}
+
+			prepare := s.mock.ExpectPrepare(regexp.QuoteMeta(`COPY "cclf_beneficiaries" ("file_id", "hicn", "mbi")`))
+			hicn := string([]byte(bene.HICN)[0:11])
+			mbi := string([]byte(bene.MBI)[0:11])
+			data := append([]byte(mbi), []byte(hicn)...)
+
+			execWithArgs := prepare.ExpectExec().WithArgs(bene.FileID, hicn, mbi)
+			execNoArgs := prepare.ExpectExec().WithArgs()
+
+			switch tt.err.et {
+			case execWithArgsError:
+				execWithArgs.WillReturnError(tt.err.err)
+			case execEmptyError:
+				// Need to ensure that the exec call with args succeeds to ensure that we hit the failure on the exec with no args
+				execWithArgs.WillReturnResult(sqlmock.NewResult(1, 1))
+				execNoArgs.WillReturnError(tt.err.err)
+			case closeError:
+				execWithArgs.WillReturnResult(sqlmock.NewResult(1, 1))
+				execNoArgs.WillReturnResult(sqlmock.NewResult(1, 1))
+				prepare.WillReturnCloseError(tt.err.err)
+			case doErrorOnFlush:
+				execWithArgs.WillReturnResult(sqlmock.NewResult(1, 1))
+				execNoArgs.WillReturnResult(sqlmock.NewResult(1, 1))
+				prepare.WillReturnCloseError(tt.err.err)
+
+				// Run an import call, this'll force the next importer.do call to
+				// fail on the attempt to flush (which will fail)
+				err := importer.do(context.Background(), s.tx, fileID, data)
+				assert.NoError(t, err)
+			}
+
+			errOnDo := importer.do(context.Background(), s.tx, fileID, data)
+			errOnFlush := importer.flush(context.Background())
+
+			switch tt.err.et {
+			case execWithArgsError:
+				assert.Contains(t, errOnDo.Error(), "could not create CCLF8 beneficiary record")
+				assert.Contains(t, errors.Cause(errOnDo).Error(), tt.err.err.Error())
+			case execEmptyError, closeError:
+				assert.NoError(t, errOnDo)
+				assert.Contains(t, errOnFlush.Error(), tt.err.err.Error())
+			case doErrorOnFlush:
+				assert.Contains(t, errOnDo.Error(), "failed to flush statement")
+				assert.Contains(t, errors.Cause(errOnDo).Error(), tt.err.err.Error())
+			}
+
+		})
+	}
+}
+
+func (s *ImporterTestSuite) TestFlushOnNoExistingStatement() {
+	importer := &cclf8Importer{
+		logger:            logrus.New(),
+		maxPendingQueries: 10,
+	}
+	assert.NoError(s.T(), importer.flush(context.Background()))
+}
+
+func getBeneficiary(fileID uint) *models.CCLFBeneficiary {
+	return &models.CCLFBeneficiary{
+		FileID: fileID,
+		// We expect 11 byte sfor HICN and MBI - we'll ensure that each of the values are AT LEAST 11 bytes
+		HICN: fmt.Sprintf("HICN%07d", rand.Uint64()),
+		MBI:  fmt.Sprintf("MBI%08d", rand.Uint64()),
+	}
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/go.mod
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/go.mod
@@ -1,1 +1,3 @@
 module github.com/DATA-DOG/go-sqlmock
+
+go 1.14


### PR DESCRIPTION
### Fixes [BCDA-3429](https://jira.cms.gov/browse/BCDA-3429)

We want to improve CCLF ingestion process by optimizing how we insert data into our Postgres instance.

### Proposed Changes

Change ingest pattern from single INSERT call per beneficiary to use COPY FROM that allows us to stream all of the beneficiary records.

### Change Details

When using single INSERT per beneficiary, we're paying overhead on opening and committing the transaction for every single INSERT call.

Postgres documentation recommends using COPY FROM statement to perform this bulk loading. With this approach, we open a single transaction to encompass the entire CCLF ingest process for a given CCLF file. Once all beneficiaries have been inserted, we'll commit the transaction. This process is repeated for every CCLF file that needs to be ingested.

The transaction encompasses several statements. Each statement will be capped at 100k beneficiaries (by default). Even though this should affect Postgres (it should be able to handle millions of insert calls in the statement), we wanted to provide an upper bound to avoid issues with large data sets. Once a statement hits the 100k count, we'll flush the statement and recreate a new statement to contain the remaining beneficiaries.

Since the entire CCLF file ingest is captured within a single transaction, we will no longer have partial beneficiary data inserted into our database. It'll be all or nothing.

Implementation based on: https://pkg.go.dev/github.com/lib/pq?tab=doc#hdr-Bulk_imports

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

1. Added unit tests to verify that statements are committed once the maximum is reached.
2. Run CCLF ingest on dev to confirm functionality.

![Screen Shot 2020-08-25 at 11 08 50 AM](https://user-images.githubusercontent.com/21049223/91205828-6e31f380-e6c3-11ea-8e89-6d788851df39.png)

3. Verified beneficiary counts are equivalent using `INSERT ...` and `COPY FROM...`