### PR TITLE
BCDA-3510 - Only create job iff all of its dependent information was populated

### DIFF
--- a/bcda/web/api.go
+++ b/bcda/web/api.go
@@ -184,7 +184,7 @@ func bulkRequest(resourceTypes []string, w http.ResponseWriter, r *http.Request,
 	defer func() {
 		if err != nil {
 			if err1 := db.Model(&newJob).Update("status", "Failed").Error; err1 != nil {
-				err1 = errors.Wrap(err1, "Failed to update job status to Failed")
+				err1 = errors.Wrap(err1, "error when updating job status to \"Failed\"")
 				log.Error(err1)
 			}
 		}

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -93,7 +93,9 @@ func processJob(j *que.Job) error {
 		// us plenty of headroom to ensure that the parent job will never be found.
 		maxNotFoundRetries := int32(utils.GetEnvInt("BCDA_WORKER_MAX_JOB_NOT_FOUND_RETRIES", 3))
 		if j.ErrorCount >= maxNotFoundRetries {
-			log.Errorf("No job found for ID: %d acoID: %s. Retries exhausted. Removing job from queue.", jobArgs.ID, jobArgs.ACOID)
+			log.Errorf("No job found for ID: %d acoID: %s. Retries exhausted. Removing job from queue.", jobArgs.ID, 
+			jobArgs.ACOID)
+			// By returning a nil error response, we're singaling to que-go to remove this job from the jobqueue.
 			return nil
 		}
 

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -86,9 +86,23 @@ func processJob(j *que.Job) error {
 	}
 
 	var exportJob models.Job
-	err = db.First(&exportJob, "ID = ?", jobArgs.ID).Error
-	if err != nil {
-		return errors.Wrap(err, "could not retrieve job from database")
+	result := db.First(&exportJob, "ID = ?", jobArgs.ID)
+
+	if result.RecordNotFound() {
+		// Based on the current backoff delay (j.ErrorCount^4 + 3 seconds), this should've given
+		// us plenty of headroom to ensure that the parent job will never be found.
+		maxNotFoundRetries := int32(utils.GetEnvInt("BCDA_WORKER_MAX_JOB_NOT_FOUND_RETRIES", 3))
+		if j.ErrorCount >= maxNotFoundRetries {
+			log.Errorf("No job found for ID %d. Retries exhausted. Removing job from queue.", jobArgs.ID)
+			return nil
+		}
+
+		log.Warnf("No job found for ID %d. Will retry.", jobArgs.ID)
+		return errors.Wrap(gorm.ErrRecordNotFound, "could not retrieve job from database")
+	}
+
+	if result.Error != nil {
+		return errors.Wrap(result.Error, "could not retrieve job from database")
 	}
 
 	var aco models.ACO

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -93,11 +93,11 @@ func processJob(j *que.Job) error {
 		// us plenty of headroom to ensure that the parent job will never be found.
 		maxNotFoundRetries := int32(utils.GetEnvInt("BCDA_WORKER_MAX_JOB_NOT_FOUND_RETRIES", 3))
 		if j.ErrorCount >= maxNotFoundRetries {
-			log.Errorf("No job found for ID %d. Retries exhausted. Removing job from queue.", jobArgs.ID)
+			log.Errorf("No job found for ID: %d acoID: %s. Retries exhausted. Removing job from queue.", jobArgs.ID, jobArgs.ACOID)
 			return nil
 		}
 
-		log.Warnf("No job found for ID %d. Will retry.", jobArgs.ID)
+		log.Warnf("No job found for ID %d acoID: %s. Will retry.", jobArgs.ID, jobArgs.ACOID)
 		return errors.Wrap(gorm.ErrRecordNotFound, "could not retrieve job from database")
 	}
 


### PR DESCRIPTION
### Fixes [BCDA-3510](https://jira.cms.gov/browse/BCDA-3510)

During the job creation process, we can encounter situations that cause a particular job to get stuck in the `Pending` or `In Progress` state.

For example, a job is created that depends on 10 queuejobs. We update our Job details (in the DB) to expect 10 queuejobs to be complete. After updating the job, we successfully insert 9 queuejobs, but fail to insert the last queuejob. The created job would process 9 jobs and be stuck indefinitely in the `In Progress` state.

Because of this edge case, we need to ensure that jobs are only created once all of its dependent information is present. This includes having all of the queuejobs successfully added.

Since we're adding queuejobs prior to adding the actual parent job, we can encounter a situation where the queue worker fails to find its parent. We've added some conditional logic to handle this situation. It will allow for transient errors (we picked up the queuejob before we've been able to insert the parent job) as well as the situation where we've added queuejobs and failed to add its parent job.

Since the queuejobs and job may exist in different databases, we cannot use a transaction to encompass all of these inserts.
 
### Change Details
1. Change API implementation to add the parent Job **after** computing all of its fields (job count, transaction time) and **after** successfully adding the necessary queuejobs to the queue.
2. Updated worker logic to retry a missing parent Job a certain number of times (defaulted to 3) before it assumes that the queuejob is orphaned and removes itself from the queue.


### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Updated unit tests to verify jobs are not created when we encounter issues during job initialization process.
