### PR TITLE
BCDA-3509 - Pin bdt version to FHIR r3 compatible revision

### DIFF
--- a/Dockerfiles/Dockerfile.bdt
+++ b/Dockerfiles/Dockerfile.bdt
@@ -7,6 +7,9 @@ RUN apt update -y && apt install git -y
 RUN git clone https://github.com/smart-on-fhir/bdt.git
 WORKDIR '/bdt'
 
+# Pinning bdt version that is compatible with FHIR R3
+RUN git checkout bc64ac546d309969034fca3c9f9a5a01d4d7563f
+
 COPY bdt/config.js .
 COPY bdt/run-bdt.sh .
 


### PR DESCRIPTION
### Fixes [BCDA-3509](https://jira.cms.gov/browse/BCDA-3509)

We are seeing failures on the FHIR scan related to issues with the CapabilityStatement response.

It turns out the bdt scan is checking for a field that is available only in FHIR r4. Since we are responding back using FHR r3, we were seeing this test failure.

### Change Details

Pin BDT version to an earlier revision that was validating CapabilityStatements against the FHIR r3 schema.

### Follow Up Work

Since we're pinning the version of BDT, we've created a [follow up ticket](https://jira.cms.gov/browse/BCDA-3594) to un-pin the bdt version and resolve the test failures. It's assumed we'll start this work after we've moved over to FHIR r4.
 
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Successful FHIR scan run 


![Screen Shot 2020-08-27 at 11 32 24 AM](https://user-images.githubusercontent.com/21049223/91475584-06adac80-e859-11ea-869c-ce6b591fcd37.png)
