### PR TITLE
BCDA-3398 - Support running unit tests in parallel

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -328,7 +329,7 @@ type httpLogger struct {
 }
 
 func (h *httpLogger) RoundTrip(req *http.Request) (*http.Response, error) {
-	go h.logRequest(req)
+	go h.logRequest(req.Clone(context.Background()))
 	resp, err := h.t.RoundTrip(req)
 	if resp != nil {
 		h.logResponse(req, resp)

--- a/bcda/web/api_test.go
+++ b/bcda/web/api_test.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	expiryHeaderFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+	acoUnderTest       = constants.SmallACOUUID
 )
 
 type APITestSuite struct {
@@ -321,7 +322,7 @@ func (s *APITestSuite) TestBulkPatientRequestBBClientFailure() {
 }
 
 func bulkEOBRequestHelper(endpoint, since string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -357,7 +358,7 @@ func bulkEOBRequestHelper(endpoint, since string, s *APITestSuite) {
 }
 
 func bulkEOBRequestInvalidSinceFormatHelper(endpoint, since string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -458,7 +459,7 @@ func bulkEOBRequestMissingTokenHelper(endpoint string, s *APITestSuite) {
 func bulkEOBRequestNoQueueHelper(endpoint string, s *APITestSuite) {
 	qc = nil
 
-	acoID := constants.SmallACOUUID
+	acoID := acoUnderTest
 	jobCount, err := s.getJobCount(acoID)
 	assert.NoError(s.T(), err)
 
@@ -491,7 +492,7 @@ func bulkEOBRequestNoQueueHelper(endpoint string, s *APITestSuite) {
 }
 
 func bulkPatientRequestHelper(endpoint, since string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 
 	defer func() {
 		s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{})
@@ -528,7 +529,7 @@ func bulkPatientRequestHelper(endpoint, since string, s *APITestSuite) {
 }
 
 func bulkPatientRequestInvalidSinceFormatHelper(endpoint, since string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -570,7 +571,7 @@ func bulkPatientRequestInvalidSinceFormatHelper(endpoint, since string, s *APITe
 }
 
 func bulkCoverageRequestHelper(endpoint string, requestParams RequestParams, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 
 	defer func() {
 		s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{})
@@ -607,7 +608,7 @@ func bulkCoverageRequestHelper(endpoint string, requestParams RequestParams, s *
 }
 
 func bulkCoverageRequestInvalidSinceFormatHelper(endpoint, since string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -649,7 +650,7 @@ func bulkCoverageRequestInvalidSinceFormatHelper(endpoint, since string, s *APIT
 }
 
 func bulkCoverageRequestInvalidSinceDateHelper(endpoint, since string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -691,7 +692,7 @@ func bulkCoverageRequestInvalidSinceDateHelper(endpoint, since string, s *APITes
 }
 
 func bulkCoverageRequestInvalidOutputHelper(endpoint, outputFormat string, s *APITestSuite) {
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -739,7 +740,7 @@ func bulkPatientRequestBBClientFailureHelper(endpoint string, s *APITestSuite) {
 	err := os.Setenv("BB_CLIENT_CERT_FILE", "blah")
 	assert.Nil(s.T(), err)
 
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 
 	jobCount, err := s.getJobCount(acoID)
 	assert.NoError(s.T(), err)
@@ -773,7 +774,7 @@ func bulkRequestInvalidTypeHelper(endpoint string, s *APITestSuite) {
 func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	err := os.Setenv("DEPLOYMENT_TARGET", "prod")
 	assert.Nil(s.T(), err)
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err = s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 
@@ -815,7 +816,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	var lastRequestJob models.Job
-	s.db.Last(&lastRequestJob)
+	s.db.Where("aco_id = ?", acoID).Last(&lastRequestJob)
 	s.db.Unscoped().Delete(&lastRequestJob)
 
 	// change status to Failed and serve job
@@ -826,7 +827,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	lastRequestJob = models.Job{}
-	s.db.Last(&lastRequestJob)
+	s.db.Where("aco_id = ?", acoID).Last(&lastRequestJob)
 	s.db.Unscoped().Delete(&lastRequestJob)
 
 	// change status to Archived
@@ -837,7 +838,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	lastRequestJob = models.Job{}
-	s.db.Last(&lastRequestJob)
+	s.db.Where("aco_id = ?", acoID).Last(&lastRequestJob)
 	s.db.Unscoped().Delete(&lastRequestJob)
 
 	// change status to Expired
@@ -848,7 +849,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	lastRequestJob = models.Job{}
-	s.db.Last(&lastRequestJob)
+	s.db.Where("aco_id = ?", acoID).Last(&lastRequestJob)
 	s.db.Unscoped().Delete(&lastRequestJob)
 
 	// different aco same endpoint
@@ -859,7 +860,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	lastRequestJob = models.Job{}
-	s.db.Last(&lastRequestJob)
+	s.db.Where("aco_id = ?", acoID).Last(&lastRequestJob)
 	s.db.Unscoped().Delete(&lastRequestJob)
 
 	// same aco different endpoint
@@ -883,7 +884,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 	assert.Equal(s.T(), http.StatusTooManyRequests, s.rr.Code)
 
 	lastRequestJob = models.Job{}
-	s.db.Last(&lastRequestJob)
+	s.db.Where("aco_id = ?", acoID).Last(&lastRequestJob)
 	s.db.Unscoped().Delete(&lastRequestJob)
 
 	os.Unsetenv("DEPLOYMENT_TARGET")
@@ -892,7 +893,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 func bulkConcurrentRequestTimeHelper(endpoint string, s *APITestSuite) {
 	err := os.Setenv("DEPLOYMENT_TARGET", "prod")
 	assert.Nil(s.T(), err)
-	acoID := constants.DevACOUUID
+	acoID := acoUnderTest
 	err = s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
 	assert.Nil(s.T(), err)
 

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -13,7 +13,7 @@ mkdir -p test_results/latest
 DB_HOST_URL=${DB}?sslmode=disable
 TEST_DB_URL=${DB}/bcda_test?sslmode=disable
 echo "Running unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race -p 1 ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html


### PR DESCRIPTION
### Fixes [BCDA-3398](https://jira.cms.gov/browse/BCDA-3398)

To improve developer efficiencies, we want to run our unit tests in parallel. We could not do this before due to 429 responses when submitting jobs.

### Change Details
1. Switch over api_test.go to use Small ACO. It was using Dev ACO, which can cause collisions with other tests.
2. Update our job update commands in bulkConcurrentRequestHelper to no longer assume that the latest created job was created by api_test.go. This assumption is no longer true since we're running tests in parallel.
3. Fix race found after running tests in a parallel.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

1. Ran unit tests locally to ensure that they pass reliably.
2. CI Passes.