### PR TITLE
BCDA-3145|3398 - Fixing more failures around test parallelization

### DIFF
--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -714,7 +714,7 @@ func (s *CLITestSuite) TestImportSuppressionDirectory() {
 	buf := new(bytes.Buffer)
 	s.testApp.Writer = buf
 
-	path := "../../shared_files/synthetic1800MedicareFiles/test/"
+	path := "../../shared_files/synthetic1800MedicareFiles/test2/"
 
 	args := []string{"bcda", "import-suppression-directory", "--directory", path}
 	err := s.testApp.Run(args)
@@ -727,7 +727,7 @@ func (s *CLITestSuite) TestImportSuppressionDirectory() {
 	testUtils.ResetFiles(s.Suite, path)
 
 	fs := []models.SuppressionFile{}
-	db.Where("name in (?)", []string{"T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000009", "T#EFT.ON.ACO.NGD1800.DPRF.D190816.T0241390"}).Find(&fs)
+	db.Where("name in (?)", []string{"T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000010", "T#EFT.ON.ACO.NGD1800.DPRF.D190816.T0241391"}).Find(&fs)
 	assert.Len(fs, 2)
 	for _, f := range fs {
 		err := f.Delete()

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -84,7 +85,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFile() {
 		bbc.On("GetExplanationOfBenefit", beneficiaryIDs[i]).Return(bbc.GetBundleData("ExplanationOfBenefit", beneficiaryID))
 	}
 
-	_, err := writeBBDataToFile(&bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
+	_, err := writeBBDataToFile(context.Background(), &bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
 	assert.NoError(s.T(), err)
 
 	files, err := ioutil.ReadDir(stagingDir)
@@ -119,7 +120,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFile() {
 }
 
 func (s *MainTestSuite) TestWriteEOBDataToFileNoClient() {
-	_, err := writeBBDataToFile(nil, nil, "9c05c1f8-349d-400f-9b69-7963f2262b08", "A00234", []string{"20000", "21000"}, "1", "ExplanationOfBenefit", "", time.Now())
+	_, err := writeBBDataToFile(context.Background(), nil, nil, "9c05c1f8-349d-400f-9b69-7963f2262b08", "A00234", []string{"20000", "21000"}, "1", "ExplanationOfBenefit", "", time.Now())
 	assert.NotNil(s.T(), err)
 }
 
@@ -131,7 +132,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFileInvalidACO() {
 
 	db := database.GetGORMDbConnection()
 	defer db.Close()
-	_, err := writeBBDataToFile(&bbc, db, acoID, cmsID, beneficiaryIDs, "1", "ExplanationOfBenefit", "", time.Now())
+	_, err := writeBBDataToFile(context.Background(), &bbc, db, acoID, cmsID, beneficiaryIDs, "1", "ExplanationOfBenefit", "", time.Now())
 	assert.NotNil(s.T(), err)
 }
 
@@ -171,7 +172,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold() 
 	os.RemoveAll(stagingDir)
 	testUtils.CreateStaging(jobID)
 
-	fileUUID, err := writeBBDataToFile(&bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
+	fileUUID, err := writeBBDataToFile(context.Background(), &bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
 	assert.NoError(s.T(), err)
 
 	errorFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_STAGING_DIR"), jobID, fileUUID)
@@ -221,7 +222,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFileWithErrorsAboveFailureThreshold() 
 	jobID := "1"
 	testUtils.CreateStaging(jobID)
 
-	_, err := writeBBDataToFile(&bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
+	_, err := writeBBDataToFile(context.Background(), &bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
 	assert.Equal(s.T(), "number of failed requests has exceeded threshold", err.Error())
 
 	stagingDir := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
@@ -275,7 +276,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {
 		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
 	}
 
-	_, err := writeBBDataToFile(&bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
+	_, err := writeBBDataToFile(context.Background(), &bbc, db, acoID, cmsID, cclfBeneficiaryIDs, jobID, "ExplanationOfBenefit", "", time.Now())
 	assert.EqualError(s.T(), err, "number of failed requests has exceeded threshold")
 
 	files, err := ioutil.ReadDir(stagingDir)
@@ -341,7 +342,7 @@ func (s *MainTestSuite) TestAppendErrorToFile() {
 	acoID := "328e83c3-bc46-4827-836c-0ba0c713dc7d"
 	jobID := "1"
 	testUtils.CreateStaging(jobID)
-	appendErrorToFile(acoID, "", "", "", jobID)
+	appendErrorToFile(context.Background(), acoID, "", "", "", jobID)
 
 	filePath := fmt.Sprintf("%s/%s/%s-error.ndjson", os.Getenv("FHIR_STAGING_DIR"), jobID, acoID)
 	fData, err := ioutil.ReadFile(filePath)

--- a/shared_files/synthetic1800MedicareFiles/test2/T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000010
+++ b/shared_files/synthetic1800MedicareFiles/test2/T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000010
@@ -1,0 +1,3 @@
+HDR_BENEDATASHR20190729
+8SG0A00AA001120500001Janice                        Marie                         J                                       19700227288 Waterpool Dr.                                      AddressLine2                                           City                                                   FakeCity                                NY110390889U20190301201907191-800TN               T9992                                                                      
+TRL_BENEDATASHR201907291         

--- a/shared_files/synthetic1800MedicareFiles/test2/T#EFT.ON.ACO.NGD1800.DPRF.D190816.T0241391
+++ b/shared_files/synthetic1800MedicareFiles/test2/T#EFT.ON.ACO.NGD1800.DPRF.D190816.T0241391
@@ -1,0 +1,2 @@
+HDR_BENEDATASHR20190816
+1000098787           Rypkujwbxgejrgxdcrk                                         Potvbaeoaxmlayezfrlvlvmfsjn             1920072721682 Lgwqmuogfioxvfjcmntfihctvaxqgmrlaubxuhbm Way                                                                                                                   Fmykhrgzbpytdgyadwty                    ST00000    M2019081320190812     T         1-800T T9994Rbmyuksjxlfykxpailcnjeokcfwdlxyxifmo ACO                              

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -13,7 +13,7 @@ mkdir -p test_results/latest
 DB_HOST_URL=${DB}?sslmode=disable
 TEST_DB_URL=${DB}/bcda_test?sslmode=disable
 echo "Running unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race -p 1 ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --junitfile test_results/${timestamp}/junit.xml -- -race ./... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html


### PR DESCRIPTION
### Fixes issues from [BCDA-3398](https://jira.cms.gov/browse/BCDA-3398)
### Resolves [BCDA-3145](https://jira.cms.gov/browse/BCDA-3145)

### Change Details

1. Remove global transaction from bcdaworker. Since multiple threads are calling processjobs, we need to ensure that we do not overwrite the transaction. This should remove some error logs we've seen on the worker logs.

```
{"file":"/go/src/github.com/CMSgov/bcda-app/bcdaworker/main.go:356","func":"main.fhirBundleToResourceNDJSON","level":"error","msg":"improper segment use: the Transaction must be used in a single goroutine and segments must be ended in \"last started first ended\" order: see https://github.com/newrelic/go-agent/blob/master/GUIDE.md#segments","time":"2020-09-02T11:56:46-04:00"}
```

2. Use different test data for cli_test#TestImportSuppressionDirectory. This ensures isolation from the suppression_test.go.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Ran tests locally and several times on dev to resolve race condition and fix issue with suppression test.
