### PR TITLE
BCDA-3589 - Consolidate JobEnqueueArgs definition

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -197,7 +197,7 @@ func AddJobsToQueue(job *Job, CMSID string, resourceTypes []string, since string
 			jobIDs = append(jobIDs, fmt.Sprint(b.ID))
 			if len(jobIDs) >= maxBeneficiaries || rowCount >= len(beneficiaries) {
 
-				args, err := json.Marshal(jobEnqueueArgs{
+				args, err := json.Marshal(JobEnqueueArgs{
 					ID:              int(job.ID),
 					ACOID:           job.ACOID.String(),
 					BeneficiaryIDs:  jobIDs,
@@ -527,7 +527,7 @@ func GetBlueButtonID(bb client.APIClient, modelIdentifier, reqType string, model
 
 // This is not a persistent model so it is not necessary to include in GORM auto migrate.
 // swagger:ignore
-type jobEnqueueArgs struct {
+type JobEnqueueArgs struct {
 	ID              int
 	ACOID           string
 	BeneficiaryIDs  []string

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -665,7 +665,7 @@ func (s *ModelsTestSuite) TestGetEnqueueJobs() {
 			assert.Equal(t, len(tt.expectedJobArgs), len(enqueueJobs))
 
 			for i, expected := range tt.expectedJobArgs {
-				jobArgs := jobEnqueueArgs{}
+				jobArgs := JobEnqueueArgs{}
 				err := json.Unmarshal(enqueueJobs[i].Args, &jobArgs)
 				if err != nil {
 					assert.NoError(t, err)

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -34,15 +34,6 @@ var (
 	qc *que.Client
 )
 
-type jobEnqueueArgs struct {
-	ID              int
-	ACOID           string
-	BeneficiaryIDs  []string
-	ResourceType    string
-	Since           string
-	TransactionTime time.Time
-}
-
 func init() {
 	createWorkerDirs()
 	log.SetFormatter(&log.JSONFormatter{})
@@ -80,7 +71,7 @@ func processJob(j *que.Job) error {
 	db := database.GetGORMDbConnection()
 	defer database.Close(db)
 
-	jobArgs := jobEnqueueArgs{}
+	jobArgs := models.JobEnqueueArgs{}
 	err := json.Unmarshal(j.Args, &jobArgs)
 	if err != nil {
 		return err

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -371,7 +371,7 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 	assert.Nil(s.T(), err)
 	assert.False(s.T(), complete)
 
-	jobArgs := jobEnqueueArgs{
+	jobArgs := models.JobEnqueueArgs{
 		ID:             int(j.ID),
 		ACOID:          j.ACOID.String(),
 		BeneficiaryIDs: []string{"10000", "11000"},
@@ -401,7 +401,7 @@ func (s *MainTestSuite) TestProcessJob_InvalidArgs() {
 }
 
 func (s *MainTestSuite) TestProcessJob_InvalidJobID() {
-	qjArgs, _ := json.Marshal(jobEnqueueArgs{
+	qjArgs, _ := json.Marshal(models.JobEnqueueArgs{
 		ID:             99999999,
 		ACOID:          "00000000-0000-0000-0000-000000000000",
 		BeneficiaryIDs: []string{},
@@ -428,7 +428,7 @@ func (s *MainTestSuite) TestProcessJob_NoBBClient() {
 	}
 	db.Save(&j)
 
-	qjArgs, _ := json.Marshal(jobEnqueueArgs{
+	qjArgs, _ := json.Marshal(models.JobEnqueueArgs{
 		ID:             int(j.ID),
 		ACOID:          j.ACOID.String(),
 		BeneficiaryIDs: []string{},
@@ -486,7 +486,7 @@ func (s *MainTestSuite) TestQueueJobWithNoParent() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			qjArgs, _ := json.Marshal(jobEnqueueArgs{
+			qjArgs, _ := json.Marshal(models.JobEnqueueArgs{
 				ID:             99999999, // JobID is not found in the db
 				ACOID:          "00000000-0000-0000-0000-000000000000",
 				BeneficiaryIDs: []string{},


### PR DESCRIPTION
### Fixes [BCDA-3589](https://jira.cms.gov/browse/BCDA-3589)

There were two definitions of JobEnqueueArgs, in bcda/models.go and bcdaworker/main.go. These definitions were equivalent.

Since we were using JSON serialization AND the field name/types are equivalent, we do not need to worry about any data migration from the old definitions.

### Change Details

1. Allow models.go JobEnqueueArgs definition to be exported and used in other packages (including bcdaworker).
2. Remove the struct definition from the bcdaworker code.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

CI and unit tests are sufficient. Since the definition is not changed, we do not need to perform any data migration.
