### PR TITLE
BCDA-3551 - Update performance tests commands to use clientID/clientSecret

### DIFF
--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -17,8 +17,11 @@ import (
 
 // might add a with metrics bool option
 var (
-	appClientID, appClientSecret, workerClientID, workerClientSecret, apiHost, proto, resourceType, reportFilePath, endpoint string
-	freq, duration                                                                                                           int
+	appClientID, appClientSecret, workerClientID,
+	workerClientSecret, apiHost, proto,
+	resourceType, reportFilePath, endpoint string
+
+	freq, duration int
 )
 
 func init() {

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -158,7 +158,7 @@ func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rat
 }
 
 func writeResults(filename string, buf bytes.Buffer) {
-	re := regexp.MustCompile("[^a-zA-Z0-9\\.\\-]")
+	re := regexp.MustCompile(`[^a-zA-Z0-9\\.\\-]`)
 	clean := re.ReplaceAllString(filename, "-")
 	data := buf.Bytes()
 	if len(data) > 0 {
@@ -205,7 +205,7 @@ func validateMetrics(metrics vegeta.Metrics) error {
 	}
 
 	if metrics.Success < 1.0 {
-		fmt.Errorf("Expected success rate of 1.0, received %f",
+		return fmt.Errorf("Expected success rate of 1.0, received %f",
 			metrics.Success)
 	}
 

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -87,6 +87,7 @@ func makeTarget(accessToken string) vegeta.Targeter {
 		"Prefer":        {"respond-async"},
 		"Accept":        {"application/fhir+json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+		"User-Agent":    {"bcda-performance-test"},
 	}
 
 	targeter := vegeta.NewStaticTargeter(vegeta.Target{

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -119,7 +119,7 @@ func runAPITest(target vegeta.Targeter) *plot.Plot {
 			log.Fatal(err.Error())
 		}
 	}()
-	plotAttack(p, metrics, target, rate, d)
+	plotAttack(p, &metrics, target, rate, d)
 
 	return p
 }
@@ -141,13 +141,13 @@ func runWorkerTest(target vegeta.Targeter) *plot.Plot {
 			log.Fatal(err.Error())
 		}
 	}()
-	plotAttack(p, metrics, target, rate, d)
+	plotAttack(p, &metrics, target, rate, d)
 
 	return p
 }
 
 // need to make rate into some sort of pretty string format
-func plotAttack(p *plot.Plot, m vegeta.Metrics, t vegeta.Targeter, r vegeta.Rate, du time.Duration) {
+func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rate, du time.Duration) {
 	attacker := vegeta.NewAttacker()
 	for results := range attacker.Attack(t, r, du, fmt.Sprintf("%dps:", r.Freq)) {
 		if err := p.Add(results); err != nil {

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -23,8 +23,8 @@ var (
 func init() {
 	flag.StringVar(&appClientID, "appClientID", "", "client id for retrieving an access token for api performance testing")
 	flag.StringVar(&appClientSecret, "appClientSecret", "", "client secret for retrieving an access token for api performance testing")
-	flag.StringVar(&workerClientID, "appClientID", "", "client id for retrieving an access token for worker performance testing")
-	flag.StringVar(&workerClientSecret, "appClientSecret", "", "client secret for retrieving an access token for worker performance testing")
+	flag.StringVar(&workerClientID, "workerClientID", "", "client id for retrieving an access token for worker performance testing")
+	flag.StringVar(&workerClientSecret, "workerClientSecret", "", "client secret for retrieving an access token for worker performance testing")
 	flag.StringVar(&apiHost, "host", "localhost:3000", "host to send requests to")
 	flag.IntVar(&duration, "duration", 60, "seconds: the total time to run the test")
 	flag.IntVar(&freq, "freq", 10, "the number of requests per second")

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -196,7 +196,6 @@ func getAccessToken(clientID, clientSecret string) string {
 }
 
 func validateMetrics(metrics vegeta.Metrics) error {
-	fmt.Printf("%+v\n", metrics)
 	if metrics.Requests == 0 {
 		return nil
 	}

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"regexp"
 	"time"
 
 	vegeta "github.com/tsenart/vegeta/lib"
@@ -136,9 +137,11 @@ func plotAttack(p *plot.Plot, t vegeta.Targeter, r vegeta.Rate, du time.Duration
 }
 
 func writeResults(filename string, buf bytes.Buffer) {
+	re := regexp.MustCompile("[^a-zA-Z0-9\\.\\-]")
+	clean := re.ReplaceAllString(filename, "-")
 	data := buf.Bytes()
 	if len(data) > 0 {
-		fn := fmt.Sprintf("%s/%s.html", reportFilePath, filename)
+		fn := fmt.Sprintf("%s/%s.html", reportFilePath, clean)
 		fmt.Printf("Writing results: %s\n", fn)
 		err := ioutil.WriteFile(fn, data, 0600)
 		if err != nil {

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -196,6 +196,7 @@ func getAccessToken(clientID, clientSecret string) string {
 }
 
 func validateMetrics(metrics vegeta.Metrics) error {
+	fmt.Printf("%+v\n", metrics)
 	if metrics.Requests == 0 {
 		return nil
 	}


### PR DESCRIPTION
### Fixes [BCDA-3551](https://jira.cms.gov/browse/BCDA-3551)

Performance tests were silently failing with authentication issues. Need to update auth mechanism and have failures to notify developers when issues arise with the test process.

### Change Details
1. Update CLI to accept clientID and clientSecret. These are used to retrieve a token.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Ran positive test with successful requests being made to BCDA backend.
2. Ran negative test to verify performance test fails when it receives non 2xx response codes.
