### PR TITLE
BCDA-3685 - Add registration support for NGACO/CEC ACO type

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -422,7 +422,7 @@ func createGroup(id, name, acoID string) (string, error) {
 
 	var aco models.ACO
 
-	if match, err := regexp.MatchString("A\\d{4}", acoID); err == nil && match {
+	if match, err := models.IsSupportedACO(acoID); err == nil && match {
 		aco, err = auth.GetACOByCMSID(acoID)
 		if err != nil {
 			return "", err
@@ -433,7 +433,7 @@ func createGroup(id, name, acoID string) (string, error) {
 			return "", err
 		}
 	} else {
-		return "", errors.New("ACO ID (--aco-id) must be a CMS ID (A####) or UUID")
+		return "", errors.New("ACO ID (--aco-id) must be a supported CMS ID or UUID")
 	}
 
 	ssas, err := authclient.NewSSASClient()
@@ -475,8 +475,11 @@ func createACO(name, cmsID string) (string, error) {
 
 	var cmsIDPt *string
 	if cmsID != "" {
-		acoIDFmt := regexp.MustCompile(`^A\d{4}$`)
-		if !acoIDFmt.MatchString(cmsID) {
+		match, err := models.IsSupportedACO(cmsID)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to check if ACO is supported")
+		}
+		if !match {
 			return "", errors.New("ACO CMS ID (--cms-id) is invalid")
 		}
 		cmsIDPt = &cmsID

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -540,7 +540,7 @@ func (s *CLITestSuite) TestCreateGroup_InvalidACOID() {
 	// Invalid format
 	args := []string{"bcda", "create-group", "--id", "invalid-aco-id-group", "--name", "Invalid ACO ID Group", "--aco-id", "1234"}
 	err := s.testApp.Run(args)
-	assert.EqualError(s.T(), err, "ACO ID (--aco-id) must be a CMS ID (A####) or UUID")
+	assert.EqualError(s.T(), err, "ACO ID (--aco-id) must be a supported CMS ID or UUID")
 	assert.Empty(s.T(), buf.String())
 	buf.Reset()
 

--- a/bcda/models/service.go
+++ b/bcda/models/service.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/constants"
@@ -169,4 +170,17 @@ func (s *service) getBenes(cclfFileID uint) ([]*CCLFBeneficiary, error) {
 	}
 
 	return benes, nil
+}
+
+// IsSupportedACO determines if the particular ACO is supported by checking
+// its CMS_ID against the supported formats.
+func IsSupportedACO(cmsID string) (bool, error) {
+	const (
+		ssp     = `^A\d{4}$`
+		ngaco   = `^V\d{3}$`
+		cec     = `^E\d{4}$`
+		pattern = `(` + ssp + `)|(` + ngaco + `)|(` + cec + `)`
+	)
+
+	return regexp.MatchString(pattern, cmsID)
 }

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -16,6 +16,39 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+func TestSupportedACOs(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmsID       string
+		isSupported bool
+	}{
+		{"SSP too short", "A999", false},
+		{"SSP too long", "A99999", false},
+		{"SSP invalid characters", "A999A", false},
+		{"valid SSP", "A9999", true},
+
+		{"NGACO too short", "V99", false},
+		{"NGACO too long", "V9999", false},
+		{"NGACO invalid characters", "V99V", false},
+		{"valid NGACO", "V999", true},
+
+		{"CEC too short", "E999", false},
+		{"CEC too long", "E99999", false},
+		{"CEC invalid characters", "E999E", false},
+		{"valid CEC", "E9999", true},
+
+		{"Unregisted ACO", "Z1234", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(sub *testing.T) {
+			match, err := IsSupportedACO(tt.cmsID)
+			assert.NoError(sub, err)
+			assert.Equal(sub, tt.isSupported, match)
+		})
+	}
+}
+
 type ServiceTestSuite struct {
 	suite.Suite
 }


### PR DESCRIPTION
### Fixes [BCDA-3685](https://jira.cms.gov/browse/BCDA-3685)

Need to add support to onboard NGACOs (CMS_ID: VXXX) and CEC ACOs (CMS_ID:EXXXX).

Since we're using ACO_ID (UUID generated when an ACO is created in our system) for the majority of our lookups, only minimal changes are needed to add support for these new ACOs.

**NOTE:** This PR **does not** add support for the CCLF files associated with NGACO and CEC ACOs. That work will be completed in later PR.

### Change Details

1. Add IsSupportedACO method that contains the expected patterns for CEC, NGACO, and SSP ACOs.
2. Consolidate all ACO format checks to utilize the new method. This was only needed in the bcda-cli.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

CI Passes

### Feedback Requested

1. Double check that we only need to make changes to the bcda CLI.
2. Review PR.