### PR TITLE
BCDA-3765 - Add aco_cms_id to cclf_file schema constraint

### DIFF
--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -634,7 +634,7 @@ func (s *CLITestSuite) TestImportCCLFDirectory() {
 	defer database.Close(db)
 
 	var existngCCLFFiles []models.CCLFFile
-	db.Where("aco_cms_id = ?", "A0001").Find(&existngCCLFFiles)
+	db.Where("aco_cms_id in (?, ?, ?)", "A0001", "A9989", "A9988").Find(&existngCCLFFiles)
 	for _, cclfFile := range existngCCLFFiles {
 		err := cclfFile.Delete()
 		assert.Nil(err)

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -69,6 +69,15 @@ func InitializeGormModels() *gorm.DB {
 
 	db.Model(&CCLFBeneficiary{}).AddForeignKey("file_id", "cclf_files(id)", "RESTRICT", "RESTRICT")
 
+	if err := db.Exec("ALTER TABLE cclf_files DROP CONSTRAINT IF EXISTS cclf_files_name_key").Error; err != nil {
+		log.Fatalf("Falied to remove name constraint on cclf_files table %s", err.Error())
+	}
+
+	if err := db.Model(&CCLFFile{}).AddUniqueIndex("idx_cclf_files_name_aco_cms_id_key",
+		"name", "aco_cms_id").Error; err != nil {
+		log.Fatalf("Failed to create unique index on cclf_files table %s", err.Error())
+	}
+
 	return db
 }
 
@@ -405,8 +414,8 @@ func CreateACO(name string, cmsID *string) (uuid.UUID, error) {
 type CCLFFile struct {
 	gorm.Model
 	CCLFNum         int       `gorm:"not null"`
-	Name            string    `gorm:"not null;unique"`
-	ACOCMSID        string    `gorm:"column:aco_cms_id"`
+	Name            string    `gorm:"not null;UNIQUE_INDEX:idx_cclf_files_name_aco_cms_id_key"`
+	ACOCMSID        string    `gorm:"column:aco_cms_id;UNIQUE_INDEX:idx_cclf_files_name_aco_cms_id_key"`
 	Timestamp       time.Time `gorm:"not null"`
 	PerformanceYear int       `gorm:"not null"`
 	ImportStatus    string    `gorm:"column:import_status"`

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"log"
 	random "math/rand"
 	"net/http"
@@ -776,9 +775,9 @@ func (s *ModelsTestSuite) TestDuplicateCCLFFileNames() {
 		acoIDs   []string
 		errMsg   string
 	}{
-		{"Different ACO ID", fmt.Sprintf("SOME_CCLF_FILE_NAME_%s", time.Now().String()), []string{"ACO1", "ACO2"},
+		{"Different ACO ID", uuid.New(), []string{"ACO1", "ACO2"},
 			""},
-		{"Duplicate ACO ID", fmt.Sprintf("SOME_CCLF_FILE_NAME_DUPLICATE_ACO_%s", time.Now().String()), []string{"ACO3", "ACO3"},
+		{"Duplicate ACO ID", uuid.New(), []string{"ACO3", "ACO3"},
 			`pq: duplicate key value violates unique constraint "idx_cclf_files_name_aco_cms_id_key"`},
 	}
 
@@ -794,7 +793,11 @@ func (s *ModelsTestSuite) TestDuplicateCCLFFileNames() {
 				}
 				if err1 := s.db.Create(cclfFile).Error; err1 != nil {
 					err = err1
+					continue
 				}
+				defer func() {
+					assert.Empty(t, cclfFile.Delete())
+				}()
 			}
 			if tt.errMsg != "" {
 				assert.EqualError(t, err, tt.errMsg)

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -784,6 +784,7 @@ func (s *ModelsTestSuite) TestDuplicateCCLFFileNames() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			var err error
+			var expectedFileCount int
 			for _, acoID := range tt.acoIDs {
 				cclfFile := &CCLFFile{
 					Name:            tt.fileName,
@@ -795,15 +796,22 @@ func (s *ModelsTestSuite) TestDuplicateCCLFFileNames() {
 					err = err1
 					continue
 				}
+				expectedFileCount++
 				defer func() {
 					assert.Empty(t, cclfFile.Delete())
 				}()
 			}
+
 			if tt.errMsg != "" {
 				assert.EqualError(t, err, tt.errMsg)
 			} else {
 				assert.NoError(t, err)
 			}
+
+			var count int
+			s.db.Model(&CCLFFile{}).Where("name = ?", tt.fileName).Count(&count)
+			assert.True(t, expectedFileCount > 0)
+			assert.Equal(t, expectedFileCount, count)
 		})
 	}
 }

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -66,7 +66,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFile() {
 	cmsID := "A00234"
 	jobID := "1"
 	stagingDir := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
-	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012309"}
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: uuid.New()}
 	db.Create(&cclfFile)
 	defer db.Delete(&cclfFile)
 	os.RemoveAll(stagingDir)
@@ -153,7 +153,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold() 
 
 	db := database.GetGORMDbConnection()
 	defer db.Close()
-	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012309"}
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: uuid.New()}
 	db.Create(&cclfFile)
 	defer db.Delete(&cclfFile)
 
@@ -207,7 +207,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFileWithErrorsAboveFailureThreshold() 
 	var cclfBeneficiaryIDs []string
 	db := database.GetGORMDbConnection()
 	defer db.Close()
-	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012309"}
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: uuid.New()}
 	db.Create(&cclfFile)
 	defer db.Delete(&cclfFile)
 
@@ -256,7 +256,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {
 	cmsID := "A00234"
 	jobID := "1"
 	stagingDir := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
-	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: "T.A12345.ACO.ZC8Y19.D191120.T1012312"}
+	cclfFile := models.CCLFFile{CCLFNum: 8, ACOCMSID: "12345", Timestamp: time.Now(), PerformanceYear: 19, Name: uuid.New()}
 	db.Create(&cclfFile)
 	defer db.Delete(&cclfFile)
 


### PR DESCRIPTION
### Fixes [BCDA-3765](https://jira.cms.gov/browse/BCDA-3765)

When ingesting CCLF files associated with CEC ACOs, we encountered a duplicate file name error in our Postgres instance. Since the CEC files do not contain their CMS_ID in the name, we need to expand our unique constraint to include file name (name) and CMS ID (aco_cms_id)

This does not affect SSP ACOs (or NGACOs) since they already contain CMS ID in the file name.

### Change Details

1. Update our models#InitializeGormModels function to remove the old constraint (on file name only) and add new constraint for fileName + cmsID.
2. Fixing tests that violated the unique constraint. Before this PR, our test db **did not** include the file name constraint. Since we're explicitly adding the unique index in our initialization set, we need to clean up/use unique names.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. CI Tests pass.
2. Run migration on lower envs (dev/test) to ensure migration works as expected. Will do this after getting approval for the PR (but before landing the PR).

