### PR TITLE
BCDA-3692 - Add CEC/NGACO requests to smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ SSAS_ADMIN_CLIENT_SECRET := $(shell docker-compose run --rm ssas sh -c 'main --r
 #    export ACO_CMS_ID=A9999; make postman env=local
 # or
 #    ACO_CMS_ID=A9999 make postman env=local
-#
-# TODO: as part of BCDA-3692, generate credentials for E9994 and V994
 ACO_CMS_ID ?= A9994
 clientTemp := $(shell docker-compose run --rm api sh -c 'tmp/bcda reset-client-credentials --cms-id $(ACO_CMS_ID)'|tail -n2)
 CLIENT_ID ?= $(shell echo $(clientTemp) |awk '{print $$1}')

--- a/test/smoke_test/bulk_data_requests_lite.sh
+++ b/test/smoke_test/bulk_data_requests_lite.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# This script is intended to be run from within the Docker "smoke_test" container
+#
+set -e
+echo "Running Patient All"
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient &
+echo "Running Group All"
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/all &
+wait

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+CMS_IDs=("A9996" "E9996" "V996")
 set -e
-function cleanup {
-	# TODO: as part of BCDA-3692, clean up the data for E9996 and V996
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM jobs WHERE aco_id IN (SELECT uuid FROM acos where cms_id = '"'"A9996"'"')"'
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM acos WHERE cms_id = '"'"'A9996'"'"'"'
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM encryption_keys WHERE system_id IN (SELECT id FROM systems WHERE group_id = '"'"'smoke-test-group'"'"')"'
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM secrets WHERE system_id IN (SELECT id FROM systems WHERE group_id = '"'"'smoke-test-group'"'"')"'
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM systems WHERE group_id = '"'"'smoke-test-group'"'"'"'
-        docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM groups WHERE group_id = '"'"'smoke-test-group'"'"'"'
+function cleanup() {
+        for CMS_ID in "${CMS_IDs[@]}"
+        do 
+                docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM encryption_keys WHERE system_id IN (SELECT id FROM systems WHERE group_id = '"'"${CMS_ID}"'"')"'
+                docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM secrets WHERE system_id IN (SELECT id FROM systems WHERE group_id = '"'"${CMS_ID}"'"')"'
+                docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM systems WHERE group_id = '"'"${CMS_ID}"'"'"'
+                docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM groups WHERE group_id = '"'"${CMS_ID}"'"'"'
+                docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM jobs WHERE aco_id IN (SELECT uuid FROM acos where cms_id = '"'"${CMS_ID}"'"')"'
+                docker-compose exec db sh -c 'psql "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -c "DELETE FROM acos WHERE cms_id = '"'"${CMS_ID}"'"'"'
+        done
 }
 trap cleanup EXIT
 
@@ -18,16 +21,23 @@ SSAS_URL="http://ssas:3004" SSAS_PUBLIC_URL="http://ssas:3003" BCDA_AUTH_PROVIDE
 echo "waiting for API to rebuild with SSAS as auth provider"
 sleep 30
 
-#  TODO: as part of BCDA-3692, generate credentials for E9996 and V996
-ACO_ID=$(docker-compose exec api sh -c 'tmp/bcda create-aco --name "Smoke Test ACO" --cms-id A9996' | tail -n1 | tr -d '\r')
-SAVE_KEY_RESULT=$(docker-compose exec api sh -c 'tmp/bcda save-public-key --cms-id A9996 --key-file "../shared_files/ATO_public.pem"' | tail -n1)
-GROUP_ID=$(docker-compose exec api sh -c 'tmp/bcda create-group --id "smoke-test-group" --name "Smoke Test Group" --aco-id A9996' | tail -n1 | tr -d '\r')
-CREDS=($(docker-compose exec api sh -c 'tmp/bcda generate-client-credentials --cms-id A9996' | tail -n2 | tr -d '\r'))
-CLIENT_ID=${CREDS[0]}
-CLIENT_SECRET=${CREDS[1]}
+for CMS_ID in "${CMS_IDs[@]}"
+do
+        ACO_ID=$(docker-compose exec -e CMS_ID=${CMS_ID} api sh -c 'tmp/bcda create-aco --name "Smoke Test ACO" --cms-id ${CMS_ID}' | tail -n1 | tr -d '\r')
+        SAVE_KEY_RESULT=$(docker-compose exec -e CMS_ID=${CMS_ID} api sh -c 'tmp/bcda save-public-key --cms-id ${CMS_ID} --key-file "../shared_files/ATO_public.pem"' | tail -n1)
+        GROUP_ID=$(docker-compose exec -e CMS_ID=${CMS_ID} api sh -c 'tmp/bcda create-group --id ${CMS_ID} --name "Smoke Test Group" --aco-id ${CMS_ID}' | tail -n1 | tr -d '\r')
+        CREDS=($(docker-compose exec -e CMS_ID=${CMS_ID} api sh -c 'tmp/bcda generate-client-credentials --cms-id ${CMS_ID}' | tail -n2 | tr -d '\r'))
+        CLIENT_ID=${CREDS[0]}
+        CLIENT_SECRET=${CREDS[1]}
 
-# TODO: as part of BCDA-3692, run a single test for E9996 and V996
-CLIENT_ID=$CLIENT_ID CLIENT_SECRET=$CLIENT_SECRET docker-compose -f docker-compose.test.yml run --rm -w /go/src/github.com/CMSgov/bcda-app/test/smoke_test tests sh bulk_data_requests.sh
+        testFile=bulk_data_requests_lite.sh
+        if [ ${CMS_ID} = "A9996" ]; then
+                testFile=bulk_data_requests.sh
+        fi
+        CLIENT_ID=${CLIENT_ID} CLIENT_SECRET=${CLIENT_SECRET} docker-compose -f docker-compose.test.yml run --rm -w /go/src/github.com/CMSgov/bcda-app/test/smoke_test tests sh ${testFile} &
+done
+
+wait
 docker-compose stop api ssas
 
 echo "waiting for API to rebuild with alpha as auth provider"


### PR DESCRIPTION
### Fixes [BCDA-3692](https://jira.cms.gov/browse/BCDA-3692)

### Change Details

1. Add requests for CEC ACO (`E9996`) and NGACO (`V996`) for our smoke tests.
2. Introduced a lighter version of our requests (`bulk_data_requests_lite.sh`) for usage in the new ACO types.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
CI passes
