### PR TITLE
BCDA-3692 - Fix cms_id types to account for varying length IDs

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -70,12 +70,20 @@ func InitializeGormModels() *gorm.DB {
 	db.Model(&CCLFBeneficiary{}).AddForeignKey("file_id", "cclf_files(id)", "RESTRICT", "RESTRICT")
 
 	if err := db.Exec("ALTER TABLE cclf_files DROP CONSTRAINT IF EXISTS cclf_files_name_key").Error; err != nil {
-		log.Fatalf("Falied to remove name constraint on cclf_files table %s", err.Error())
+		log.Fatalf("Failed to remove name constraint on cclf_files table %s", err.Error())
 	}
 
 	if err := db.Model(&CCLFFile{}).AddUniqueIndex("idx_cclf_files_name_aco_cms_id_key",
 		"name", "aco_cms_id").Error; err != nil {
 		log.Fatalf("Failed to create unique index on cclf_files table %s", err.Error())
+	}
+
+	if err := db.Exec("ALTER TABLE cclf_files ALTER COLUMN aco_cms_id SET DATA TYPE varchar(5)").Error; err != nil {
+		log.Fatalf("Failed to update aco_cms_id column to varchar(5) %s", err.Error())
+	}
+
+	if err := db.Exec("ALTER TABLE acos ALTER COLUMN cms_id SET DATA TYPE varchar(5)").Error; err != nil {
+		log.Fatalf("Failed to update cms_id column from acos table to varchar(5) %s", err.Error())
 	}
 
 	return db
@@ -307,7 +315,7 @@ type JobKey struct {
 type ACO struct {
 	gorm.Model
 	UUID        uuid.UUID `gorm:"primary_key;type:char(36)" json:"uuid"`
-	CMSID       *string   `gorm:"type:char(5);unique" json:"cms_id"`
+	CMSID       *string   `gorm:"type:varchar(5);unique" json:"cms_id"`
 	Name        string    `json:"name"`
 	ClientID    string    `json:"client_id"`
 	GroupID     string    `json:"group_id"`

--- a/db/api.sql
+++ b/db/api.sql
@@ -1,6 +1,6 @@
 create table acos (
   uuid uuid not null primary key,
-  cms_id char(5) unique null,
+  cms_id character varying(5) unique null,
   name text not null,
   created_at timestamp with time zone not null default now(),
   updated_at timestamp with time zone not null default now(),
@@ -21,7 +21,7 @@ create table cclf_files (
     id serial primary key,
     cclf_num integer not null,
     name varchar not null,
-    aco_cms_id char(5),
+    aco_cms_id character varying(5),
     "timestamp" timestamp with time zone not null,
     performance_year integer not null,
     import_status varchar,


### PR DESCRIPTION
### Fix found by [BCDA-3692](https://jira.cms.gov/browse/BCDA-3692)

With the addition of NGACOs, we have a CMS ID that is less than 5 characters (V***). As a result, we need to change our a schemas that expected a 5 character ID.

The new data type should accept UP TO 5 characters but SHOULD NOT pad the ID with extra spaces.

### Change Details

1. Update our automigrate process to alter the acos#cms_id column to varchar(5).
2. Update our automigrate process to alter the cclf_files#aco_cms_id column to varchar(5).
3. Adding tests to verify behavior of new columns.


### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

1. CI Passes
2. Run smoke tests on dev with new ACO types and confirm everything is working as expected.