### PR TITLE
BCDA-3739: Validate OpenAPI Schema Generation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ docker-build:
 
 docker-bootstrap:
 	$(MAKE) docker-build
+	docker-compose up --exit-code-from openapi openapi
 	docker-compose up -d
 	sleep 40
 	$(MAKE) load-fixtures

--- a/ops/swagger_to_openapi.sh
+++ b/ops/swagger_to_openapi.sh
@@ -9,4 +9,7 @@ java -jar -DswaggerUrl=swagger.yaml /swagger-converter/jetty-runner.jar /swagger
 sleep 30
 curl -X POST -d "@swaggerui/swagger.json" localhost:8080/api/convert -H "Content-Type: application/json" -o temp.json
 cat temp.json | jq > swaggerui/openapi.json
-grep "Beneficiary Claims Data API" swaggerui/openapi.json
+
+# Remove openapi.json file if it is invalid
+# Note that build_and_package.sh script validates that openapi.json exists; so RPM packaging will fail if there is an invalid openapi.json
+grep "Beneficiary Claims Data API" swaggerui/openapi.json || rm swaggerui/openapi.json

--- a/ops/swagger_to_openapi.sh
+++ b/ops/swagger_to_openapi.sh
@@ -9,7 +9,4 @@ java -jar -DswaggerUrl=swagger.yaml /swagger-converter/jetty-runner.jar /swagger
 sleep 30
 curl -X POST -d "@swaggerui/swagger.json" localhost:8080/api/convert -H "Content-Type: application/json" -o temp.json
 cat temp.json | jq > swaggerui/openapi.json
-
-# Remove openapi.json file if it is invalid
-# Note that build_and_package.sh script validates that openapi.json exists; so RPM packaging will fail if there is an invalid openapi.json
-grep "Beneficiary Claims Data API" swaggerui/openapi.json || rm swaggerui/openapi.json
+grep "Beneficiary Claims Data API" swaggerui/openapi.json || exit 1

--- a/ops/swagger_to_openapi.sh
+++ b/ops/swagger_to_openapi.sh
@@ -9,3 +9,4 @@ java -jar -DswaggerUrl=swagger.yaml /swagger-converter/jetty-runner.jar /swagger
 sleep 30
 curl -X POST -d "@swaggerui/swagger.json" localhost:8080/api/convert -H "Content-Type: application/json" -o temp.json
 cat temp.json | jq > swaggerui/openapi.json
+grep "Beneficiary Claims Data API" swaggerui/openapi.json


### PR DESCRIPTION
### Fixes [BCDA-3739](https://jira.cms.gov/browse/BCDA-3739)

We recently encountered an [issue](https://github.com/CMSgov/bcda-static-site/issues/79) where the OpenAPI schema was not generated properly.  We should fail the build/package if the OpenAPI schema is invalid.

### Change Details

- Added a simple validation step to ensure OpenAPI schema was generated correctly at build time

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Performed a negative test locally, and the build was halted.

### Feedback Requested

Please review.
