### PR TITLE
BCDA-3681 - Add IP option when registering system

### DIFF
--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -17,7 +17,7 @@ type AlphaAuthPlugin struct{}
 // validates that AlphaAuthPlugin implements the interface
 var _ Provider = AlphaAuthPlugin{}
 
-func (p AlphaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Credentials, error) {
+func (p AlphaAuthPlugin) RegisterSystem(localID, publicKey, groupID string, ips ...string) (Credentials, error) {
 	regEvent := event{op: "RegisterSystem", trackingID: localID}
 	operationStarted(regEvent)
 	if localID == "" {
@@ -69,11 +69,6 @@ func (p AlphaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Cre
 	regEvent.clientID = aco.ClientID
 	operationSucceeded(regEvent)
 	return Credentials{ClientName: aco.Name, ClientID: localID, ClientSecret: s}, nil
-}
-
-// RegisterSystemWithIPs wraps RegisterSystem since Alpha has no notion of binding IP addresses with the system
-func (p AlphaAuthPlugin) RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error) {
-	return p.RegisterSystem(localID, publicKey, groupID)
 }
 
 func generateClientSecret() (string, error) {

--- a/bcda/auth/alpha.go
+++ b/bcda/auth/alpha.go
@@ -14,6 +14,9 @@ import (
 
 type AlphaAuthPlugin struct{}
 
+// validates that AlphaAuthPlugin implements the interface
+var _ Provider = AlphaAuthPlugin{}
+
 func (p AlphaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Credentials, error) {
 	regEvent := event{op: "RegisterSystem", trackingID: localID}
 	operationStarted(regEvent)
@@ -66,6 +69,11 @@ func (p AlphaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Cre
 	regEvent.clientID = aco.ClientID
 	operationSucceeded(regEvent)
 	return Credentials{ClientName: aco.Name, ClientID: localID, ClientSecret: s}, nil
+}
+
+// RegisterSystemWithIPs wraps RegisterSystem since Alpha has no notion of binding IP addresses with the system
+func (p AlphaAuthPlugin) RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error) {
+	return p.RegisterSystem(localID, publicKey, groupID)
 }
 
 func generateClientSecret() (string, error) {

--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -150,13 +150,14 @@ func (c *SSASClient) DeleteGroup(id int) error {
 }
 
 // CreateSystem POSTs to the SSAS /system endpoint to create a system.
-func (c *SSASClient) CreateSystem(clientName, groupID, scope, publicKey, trackingID string) ([]byte, error) {
+func (c *SSASClient) CreateSystem(clientName, groupID, scope, publicKey, trackingID string, ips []string) ([]byte, error) {
 	type system struct {
-		ClientName string `json:"client_name"`
-		GroupID    string `json:"group_id"`
-		Scope      string `json:"scope"`
-		PublicKey  string `json:"public_key"`
-		TrackingID string `json:"tracking_id"`
+		ClientName string   `json:"client_name"`
+		GroupID    string   `json:"group_id"`
+		Scope      string   `json:"scope"`
+		PublicKey  string   `json:"public_key"`
+		TrackingID string   `json:"tracking_id"`
+		IPs        []string `json:"ips,omitempty"`
 	}
 
 	sys := system{
@@ -165,6 +166,7 @@ func (c *SSASClient) CreateSystem(clientName, groupID, scope, publicKey, trackin
 		Scope:      scope,
 		PublicKey:  publicKey,
 		TrackingID: trackingID,
+		IPs:        ips,
 	}
 
 	bb, err := json.Marshal(sys)

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -148,7 +148,7 @@ func (s *SSASClientTestSuite) TestCreateSystem() {
 		s.FailNow("Failed to create SSAS client", err.Error())
 	}
 
-	resp, err := client.CreateSystem("fake-name", "fake-group", "fake-scope", "fake-key", "fake-tracking")
+	resp, err := client.CreateSystem("fake-name", "fake-group", "fake-scope", "fake-key", "fake-tracking", nil)
 	assert.Nil(s.T(), err)
 	creds := auth.Credentials{}
 	err = json.Unmarshal(resp, &creds)

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -41,7 +41,7 @@ func NewOktaAuthPlugin(backend OktaBackend) OktaAuthPlugin {
 	return OktaAuthPlugin{backend}
 }
 
-func (o OktaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Credentials, error) {
+func (o OktaAuthPlugin) RegisterSystem(localID, publicKey, groupID string, ips ...string) (Credentials, error) {
 	if localID == "" {
 		return Credentials{}, errors.New("you must provide a localID")
 	}
@@ -53,11 +53,6 @@ func (o OktaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Cred
 		ClientSecret: secret,
 		ClientName:   name,
 	}, err
-}
-
-// RegisterSystemWithIPs wraps RegisterSystem since Okta has no notion of binding IP addresses with the system
-func (o OktaAuthPlugin) RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error) {
-	return o.RegisterSystem(localID, publicKey, groupID)
 }
 
 func (o OktaAuthPlugin) UpdateSystem(params []byte) ([]byte, error) {

--- a/bcda/auth/okta.go
+++ b/bcda/auth/okta.go
@@ -33,6 +33,9 @@ type OktaAuthPlugin struct {
 	backend OktaBackend // interface, not a concrete type, so no *
 }
 
+// validates that OktaAuthPlugin implements the interface
+var _ Provider = OktaAuthPlugin{}
+
 // Create a new plugin using the provided backend. Having the backend passed in facilitates testing with Mockta.
 func NewOktaAuthPlugin(backend OktaBackend) OktaAuthPlugin {
 	return OktaAuthPlugin{backend}
@@ -50,6 +53,11 @@ func (o OktaAuthPlugin) RegisterSystem(localID, publicKey, groupID string) (Cred
 		ClientSecret: secret,
 		ClientName:   name,
 	}, err
+}
+
+// RegisterSystemWithIPs wraps RegisterSystem since Okta has no notion of binding IP addresses with the system
+func (o OktaAuthPlugin) RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error) {
+	return o.RegisterSystem(localID, publicKey, groupID)
 }
 
 func (o OktaAuthPlugin) UpdateSystem(params []byte) ([]byte, error) {

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -84,6 +84,10 @@ type Provider interface {
 	// RegisterSystem adds a software client for the ACO identified by localID.
 	RegisterSystem(localID, publicKey, groupID string) (Credentials, error)
 
+	// RegisterSystem is an extension of RegisterSystem. It exposes the capability of association
+	// a set of IP Addresses with the given system.
+	RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error)
+
 	// UpdateSystem changes data associated with the registered software client identified by clientID
 	UpdateSystem(params []byte) ([]byte, error)
 

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -82,11 +82,7 @@ type Credentials struct {
 // Provider defines operations performed through an authentication provider.
 type Provider interface {
 	// RegisterSystem adds a software client for the ACO identified by localID.
-	RegisterSystem(localID, publicKey, groupID string) (Credentials, error)
-
-	// RegisterSystem is an extension of RegisterSystem. It exposes the capability of association
-	// a set of IP Addresses with the given system.
-	RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error)
+	RegisterSystem(localID, publicKey, groupID string, ips ...string) (Credentials, error)
 
 	// UpdateSystem changes data associated with the registered software client identified by clientID
 	UpdateSystem(params []byte) ([]byte, error)

--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -22,14 +22,8 @@ type SSASPlugin struct {
 // validates that SSASPlugin implements the interface
 var _ Provider = SSASPlugin{}
 
-// RegisterSystemWithIPs adds a software client for the ACO identified by localID. It does not
-// associate any IPs with the created client.
-func (s SSASPlugin) RegisterSystem(localID, publicKey, groupID string) (Credentials, error) {
-	return s.RegisterSystemWithIPs(localID, publicKey, groupID, nil)
-}
-
 // RegisterSystemWithIPs adds a software client for the ACO identified by localID.
-func (s SSASPlugin) RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error) {
+func (s SSASPlugin) RegisterSystem(localID, publicKey, groupID string, ips ...string) (Credentials, error) {
 	creds := Credentials{}
 	aco, err := GetACOByUUID(localID)
 	if err != nil {

--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -19,8 +19,17 @@ type SSASPlugin struct {
 	client *client.SSASClient
 }
 
-// RegisterSystem adds a software client for the ACO identified by localID.
+// validates that SSASPlugin implements the interface
+var _ Provider = SSASPlugin{}
+
+// RegisterSystemWithIPs adds a software client for the ACO identified by localID. It does not
+// associate any IPs with the created client.
 func (s SSASPlugin) RegisterSystem(localID, publicKey, groupID string) (Credentials, error) {
+	return s.RegisterSystemWithIPs(localID, publicKey, groupID, nil)
+}
+
+// RegisterSystemWithIPs adds a software client for the ACO identified by localID.
+func (s SSASPlugin) RegisterSystemWithIPs(localID, publicKey, groupID string, ips []string) (Credentials, error) {
 	creds := Credentials{}
 	aco, err := GetACOByUUID(localID)
 	if err != nil {
@@ -34,6 +43,7 @@ func (s SSASPlugin) RegisterSystem(localID, publicKey, groupID string) (Credenti
 		"bcda-api",
 		publicKey,
 		trackingID,
+		ips,
 	)
 	if err != nil {
 		return creds, errors.Wrap(err, "failed to create system")

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -136,12 +136,7 @@ func (s *SSASPluginTestSuite) TestRegisterSystem() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			ips, response, tester = tt.ips, tt.ssasResp, t
-			var (
-				creds Credentials
-				err   error
-			)
-			creds, err = s.p.RegisterSystem(testACOUUID, "", "", tt.ips...)
-
+			creds, err := s.p.RegisterSystem(testACOUUID, "", "", tt.ips...)
 			if tt.expErrMsg != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to unmarshal response json")

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -129,7 +129,7 @@ func (s *SSASPluginTestSuite) TestRegisterSystem() {
 		expErrMsg string
 	}{
 		{"Successful response", nil, validResp, ""},
-		{"Successful response with IPs", []string{"1.2.3.4", "1.2.3.5"}, validResp, ""},
+		{"Successful response with IPs", []string{testUtils.GetRandomIPV4Address(s.T()), testUtils.GetRandomIPV4Address(s.T())}, validResp, ""},
 		{"Invalid JSON response", nil, `"this is": "invalid"`, "failed to unmarshal response json"},
 	}
 

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -140,12 +140,7 @@ func (s *SSASPluginTestSuite) TestRegisterSystem() {
 				creds Credentials
 				err   error
 			)
-
-			if len(tt.ips) == 0 {
-				creds, err = s.p.RegisterSystem(testACOUUID, "", "")
-			} else {
-				creds, err = s.p.RegisterSystemWithIPs(testACOUUID, "", "", tt.ips)
-			}
+			creds, err = s.p.RegisterSystem(testACOUUID, "", "", tt.ips...)
 
 			if tt.expErrMsg != "" {
 				assert.Error(t, err)
@@ -159,29 +154,6 @@ func (s *SSASPluginTestSuite) TestRegisterSystem() {
 			assert.Equal(t, "fake-client-id", creds.ClientID)
 		})
 	}
-}
-
-func (s *SSASPluginTestSuite) TestRegisterSystem_InvalidJSON() {
-	router := chi.NewRouter()
-	router.Post("/system", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(201)
-		fmt.Fprintf(w, `"this is": "invalid"`)
-	})
-	server := httptest.NewServer(router)
-
-	os.Setenv("SSAS_URL", server.URL)
-	os.Setenv("SSAS_PUBLIC_URL", server.URL)
-	os.Setenv("SSAS_USE_TLS", "false")
-
-	c, err := client.NewSSASClient()
-	if err != nil {
-		log.Fatalf("no client for SSAS; %s", err.Error())
-	}
-	s.p = SSASPlugin{client: c}
-
-	creds, err := s.p.RegisterSystem(testACOUUID, "", "")
-	assert.Contains(s.T(), err.Error(), "failed to unmarshal response json")
-	assert.Empty(s.T(), creds.SystemID)
 }
 
 func (s *SSASPluginTestSuite) TestUpdateSystem() {}

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -79,11 +81,33 @@ func (s *SSASPluginTestSuite) TearDownTest() {
 }
 
 func (s *SSASPluginTestSuite) TestRegisterSystem() {
+	// These variables will allow us to swap out expectations without
+	// reinstantiating the server
+	var (
+		response string
+		ips      []string
+		tester   *testing.T
+	)
+
 	// TODO: Mock client instead of server
 	router := chi.NewRouter()
 	router.Post("/system", func(w http.ResponseWriter, r *http.Request) {
+		reqBody, err := ioutil.ReadAll(r.Body)
+		assert.NoError(tester, err)
+		var obj map[string]interface{}
+		assert.NoError(tester, json.Unmarshal(reqBody, &obj))
+		if obj["ips"] == nil {
+			assert.Equal(tester, 0, len(ips), "ips should be empty since request contained no ips field")
+		} else {
+			var ipsReceived []string
+			for _, ip := range obj["ips"].([]interface{}) {
+				ipsReceived = append(ipsReceived, ip.(string))
+			}
+			assert.Equal(tester, ipsReceived, ips)
+		}
+
 		w.WriteHeader(201)
-		fmt.Fprintf(w, `{ "system_id": "1", "client_id": "fake-client-id", "client_secret": "fake-secret", "client_name": "fake-name" }`)
+		fmt.Fprint(w, response)
 	})
 	server := httptest.NewServer(router)
 
@@ -97,10 +121,44 @@ func (s *SSASPluginTestSuite) TestRegisterSystem() {
 	}
 	s.p = SSASPlugin{client: c}
 
-	creds, err := s.p.RegisterSystem(testACOUUID, "", "")
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "1", creds.SystemID)
-	assert.Equal(s.T(), "fake-client-id", creds.ClientID)
+	validResp := `{ "system_id": "1", "client_id": "fake-client-id", "client_secret": "fake-secret", "client_name": "fake-name" }`
+	tests := []struct {
+		name      string
+		ips       []string
+		ssasResp  string
+		expErrMsg string
+	}{
+		{"Successful response", nil, validResp, ""},
+		{"Successful response with IPs", []string{"1.2.3.4", "1.2.3.5"}, validResp, ""},
+		{"Invalid JSON response", nil, `"this is": "invalid"`, "failed to unmarshal response json"},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			ips, response, tester = tt.ips, tt.ssasResp, t
+			var (
+				creds Credentials
+				err   error
+			)
+
+			if len(tt.ips) == 0 {
+				creds, err = s.p.RegisterSystem(testACOUUID, "", "")
+			} else {
+				creds, err = s.p.RegisterSystemWithIPs(testACOUUID, "", "", tt.ips)
+			}
+
+			if tt.expErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to unmarshal response json")
+				assert.Empty(t, creds.SystemID)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, "1", creds.SystemID)
+			assert.Equal(t, "fake-client-id", creds.ClientID)
+		})
+	}
 }
 
 func (s *SSASPluginTestSuite) TestRegisterSystem_InvalidJSON() {

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -250,6 +250,7 @@ func setUpApp() *cli.App {
 				},
 				cli.StringSliceFlag{
 					Name:  "ips",
+					Usage: "Set of IPs associated with the ACO",
 					Value: &ips,
 				},
 			},

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -490,13 +490,7 @@ func generateClientCredentials(acoCMSID string, ips []string) (string, error) {
 	}
 
 	// The public key is optional for SSAS, and not used by the ACO API
-	var creds auth.Credentials
-	if len(ips) == 0 {
-		creds, err = auth.GetProvider().RegisterSystem(aco.UUID.String(), "", aco.GroupID)
-	} else {
-		creds, err = auth.GetProvider().RegisterSystemWithIPs(aco.UUID.String(), "", aco.GroupID, ips)
-	}
-
+	creds, err := auth.GetProvider().RegisterSystem(aco.UUID.String(), "", aco.GroupID, ips...)
 	if err != nil {
 		return "", errors.Wrapf(err, "could not register system for %s", acoCMSID)
 	}

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/api"
@@ -45,8 +46,7 @@ func setUpApp() *cli.App {
 	app.Name = Name
 	app.Usage = Usage
 	app.Version = constants.Version
-	var acoName, acoCMSID, acoID, accessToken, threshold, acoSize, filePath, dirToDelete, environment, groupID, groupName string
-	var ips cli.StringSlice
+	var acoName, acoCMSID, acoID, accessToken, threshold, acoSize, filePath, dirToDelete, environment, groupID, groupName, ips string
 	app.Commands = []cli.Command{
 		{
 			Name:  "start-api",
@@ -248,17 +248,21 @@ func setUpApp() *cli.App {
 					Usage:       "CMS ID of ACO",
 					Destination: &acoCMSID,
 				},
-				cli.StringSliceFlag{
-					Name:  "ips",
-					Usage: "Set of IPs associated with the ACO",
-					Value: &ips,
+				cli.StringFlag{
+					Name:        "ips",
+					Usage:       "Comma separated list of IPs associated with the ACO",
+					Destination: &ips,
 				},
 			},
 			Action: func(c *cli.Context) error {
 				if acoCMSID == "" {
 					return errors.New("ACO CMS ID (--cms-id) is required")
 				}
-				msg, err := generateClientCredentials(acoCMSID, ips)
+				var ipAddr []string
+				if len(ips) > 0 {
+					ipAddr = strings.Split(ips, ",")
+				}
+				msg, err := generateClientCredentials(acoCMSID, ipAddr)
 				if err != nil {
 					return err
 				}

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -159,7 +159,8 @@ func (s *CLITestSuite) TestGenerateClientCredentials() {
 	defer database.Close(db)
 
 	cmsID := "A8880"
-	for _, ips := range [][]string{nil, []string{"1.2.3.4,5.6.7.8"}, []string{"1.2.3.4"}, []string{}} {
+	for _, ips := range [][]string{nil, []string{testUtils.GetRandomIPV4Address(s.T()), testUtils.GetRandomIPV4Address(s.T())},
+		[]string{testUtils.GetRandomIPV4Address(s.T())}, []string{}} {
 		s.SetupTest()
 		// Clear out alpha_secret so we're able to re-generate credentials for the same ACO
 		assert.NoError(db.Model(&models.ACO{}).Where("cms_id = ?", cmsID).Update("alpha_secret", "").Error)

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -158,7 +158,7 @@ func (s *CLITestSuite) TestGenerateClientCredentials() {
 	s.testApp.Writer = buf
 	assert := assert.New(s.T())
 
-	args := []string{"bcda", "generate-client-credentials", "--cms-id", "A8880"}
+	args := []string{"bcda", "generate-client-credentials", "--cms-id", "A8880", "--ips", "1.2.3.4,5.6.7.8"}
 	err := s.testApp.Run(args)
 	assert.Nil(err)
 	assert.Regexp(regexp.MustCompile(".+\n.+\n.+"), buf.String())

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -168,7 +168,6 @@ func (s *CLITestSuite) TestGenerateClientCredentials() {
 		buf := new(bytes.Buffer)
 		s.testApp.Writer = buf
 
-		fmt.Println(ips)
 		args := []string{"bcda", "generate-client-credentials", "--cms-id", cmsID, "--ips", strings.Join(ips, ",")}
 		err := s.testApp.Run(args)
 		assert.Nil(err)

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -140,3 +140,13 @@ func CopyToTemporaryDirectory(t *testing.T, src string) (string, func()) {
 
 	return newPath, cleanup
 }
+
+// GetRandomIPV4Address returns a random IPV4 address using rand.Read() to generate the values.
+func GetRandomIPV4Address(t *testing.T) string {
+	data := make([]byte, 4)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	return fmt.Sprintf("%d.%d.%d.%d", data[0], data[1], data[2], data[3])
+}


### PR DESCRIPTION
### Part of [BCDA-3681](https://jira.cms.gov/browse/BCDA-3681)

We want to add the ability to associate a set of IP addresses when registering a new system.
Right now, this IP association is only valid for SSAS auth providers.

### Change Details

1. Update our Provider#RegisterSystem method to accept a list of IP address. Using a variadic input for IPs to allow users to exclude the IP arguments when calling RegisterSystem.

The following snippets are all valid:
```
cred, err := RegisterSystem("id", "key", "groupID")
cred, err := RegisterSystem("id", "key", "groupID", "1.2.3.4", "5.6.7.8")
cred, err := RegisterSystem("id", "key", "groupID", []string{"10.11.12.13"}...)
```

2. Update our cli command for generating system credentials to accept list of IP addresses.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Added test cases to verify that we're passing the IP address argument correctly when making the associated SSAS call.
2. Will have an associated change in bcda-ops where we can verify that the IP address are being added when the caller makes the generate-creds call.

Successfully validate 2. See: https://github.com/CMSgov/bcda-ops/pull/577 for more details.