### PR TITLE
BCDA-3720 - Update CCLF ingest to support runout files

### DIFF
--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -238,7 +238,7 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer im
 	rc, err := rawFile.Open()
 	if err != nil {
 		fmt.Printf("Could not read file %s for CCLF%d in archive %s.\n", cclfFile.Name, fileMetadata.cclfNum, fileMetadata.filePath)
-		err = fmt.Errorf("could not read file %s for CCLF%d in archive %s", cclfFile.Name, fileMetadata.cclfNum, fileMetadata.filePath)
+		err = errors.Wrapf(err, "could not read file %s for CCLF%d in archive %s", cclfFile.Name, fileMetadata.cclfNum, fileMetadata.filePath)
 		log.Error(err)
 		return err
 	}

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -34,6 +34,7 @@ type cclfFileMetadata struct {
 	imported     bool
 	deliveryDate time.Time
 	fileID       uint
+	fileType     models.CCLFFileType
 }
 
 type cclfFileValidator struct {
@@ -199,6 +200,7 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer im
 		Timestamp:       fileMetadata.timestamp,
 		PerformanceYear: fileMetadata.perfYear,
 		ImportStatus:    constants.ImportInprog,
+		Type:            fileMetadata.fileType,
 	}
 
 	db := database.GetGORMDbConnection()
@@ -228,7 +230,7 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer im
 
 	if rawFile == nil {
 		fmt.Printf("File %s not found in archive %s.\n", fileMetadata.name, fileMetadata.filePath)
-		err = errors.Wrapf(err, "file %s not found in archive %s", fileMetadata.name, fileMetadata.filePath)
+		err = fmt.Errorf("file %s not found in archive %s", fileMetadata.name, fileMetadata.filePath)
 		log.Error(err)
 		return err
 	}
@@ -236,7 +238,7 @@ func importCCLF(ctx context.Context, fileMetadata *cclfFileMetadata, importer im
 	rc, err := rawFile.Open()
 	if err != nil {
 		fmt.Printf("Could not read file %s for CCLF%d in archive %s.\n", cclfFile.Name, fileMetadata.cclfNum, fileMetadata.filePath)
-		err = errors.Wrapf(err, "could not read file %s for CCLF%d in archive %s", cclfFile.Name, fileMetadata.cclfNum, fileMetadata.filePath)
+		err = fmt.Errorf("could not read file %s for CCLF%d in archive %s", cclfFile.Name, fileMetadata.cclfNum, fileMetadata.filePath)
 		log.Error(err)
 		return err
 	}

--- a/bcda/cclf/fileprocessor.go
+++ b/bcda/cclf/fileprocessor.go
@@ -114,7 +114,7 @@ func (p *processor) handleArchiveError(path string, info os.FileInfo, cause erro
 
 func getCMSID(name string) (string, error) {
 	// CCLF foldername convention with BCD identifier: P.BCD.<ACO_ID>.ZCY**.Dyymmdd.Thhmmsst
-	exp := regexp.MustCompile(`(?:T|P)\.BCD\.(.*)\.ZCY\d{2}\.D\d{6}\.T\d{7}`)
+	exp := regexp.MustCompile(`(?:T|P)\.BCD\.(.*)\.ZC(?:Y|R)\d{2}\.D\d{6}\.T\d{7}`)
 	parts := exp.FindStringSubmatch(name)
 	if len(parts) != 2 {
 		err := fmt.Errorf("invalid name ('%s') for CCLF archive, parts: %v", name, parts)
@@ -128,10 +128,10 @@ func getCMSID(name string) (string, error) {
 
 func getCCLFFileMetadata(cmsID, fileName string) (cclfFileMetadata, error) {
 	var metadata cclfFileMetadata
-	// CCLF filename convention for SSP with BCD identifier: P.BCD.A****.ZC[0|8][Y]**.Dyymmdd.Thhmmsst
-	// CCLF filename convention for NGACO:  P.V***.ACO.ZC1.Dyymmdd.Thhmmsst
-	// CCLF file name convetion for CEC: P.CEC.ZC1.Dyymmdd.Thhmmsst
-	filenameRegexp := regexp.MustCompile(`(T|P)(?:\.BCD)?\.(.*?)(?:\.ACO)?\.ZC(?:(R))?(0|8)Y(\d{2})\.(D\d{6}\.T\d{6})\d`)
+	// CCLF filename convention for SSP with BCD identifier: P.BCD.A****.ZC[0|8][Y|R]**.Dyymmdd.Thhmmsst
+	// CCLF filename convention for NGACO:  P.V***.ACO.ZC[0|8][Y|R].Dyymmdd.Thhmmsst
+	// CCLF file name convetion for CEC: P.CEC.ZC[0|8][Y|R].Dyymmdd.Thhmmsst
+	filenameRegexp := regexp.MustCompile(`(T|P)(?:\.BCD)?\.(.*?)(?:\.ACO)?\.ZC(0|8)(Y|R)(\d{2})\.(D\d{6}\.T\d{6})\d`)
 	parts := filenameRegexp.FindStringSubmatch(fileName)
 
 	if len(parts) != 7 {
@@ -140,7 +140,7 @@ func getCCLFFileMetadata(cmsID, fileName string) (cclfFileMetadata, error) {
 		return metadata, err
 	}
 
-	cclfNum, err := strconv.Atoi(parts[4])
+	cclfNum, err := strconv.Atoi(parts[3])
 	if err != nil {
 		err = errors.Wrapf(err, "failed to parse CCLF number from file: %s", fileName)
 		fmt.Println(err.Error())
@@ -182,13 +182,17 @@ func getCCLFFileMetadata(cmsID, fileName string) (cclfFileMetadata, error) {
 		return metadata, err
 	}
 
-	if parts[1] == "T" {
+	switch parts[1] {
+	case "T":
 		metadata.env = "test"
-	} else if parts[1] == "P" {
+	case "P":
 		metadata.env = "production"
 	}
 
-	if parts[3] == "R" {
+	switch parts[4] {
+	case "Y":
+		metadata.fileType = models.FileTypeDefault
+	case "R":
 		metadata.fileType = models.FileTypeRunout
 	}
 

--- a/bcda/cclf/fileprocessor.go
+++ b/bcda/cclf/fileprocessor.go
@@ -114,7 +114,7 @@ func (p *processor) handleArchiveError(path string, info os.FileInfo, cause erro
 
 func getCMSID(name string) (string, error) {
 	// CCLF foldername convention with BCD identifier: P.BCD.<ACO_ID>.ZC[Y|R]**.Dyymmdd.Thhmmsst
-	exp := regexp.MustCompile(`(?:T|P)\.BCD\.(.*)\.ZC(?:Y|R)\d{2}\.D\d{6}\.T\d{7}`)
+	exp := regexp.MustCompile(`(?:T|P)\.BCD\.(.*)\.ZC[Y|R]\d{2}\.D\d{6}\.T\d{7}`)
 	parts := exp.FindStringSubmatch(name)
 	if len(parts) != 2 {
 		err := fmt.Errorf("invalid name ('%s') for CCLF archive, parts: %v", name, parts)

--- a/bcda/cclf/fileprocessor.go
+++ b/bcda/cclf/fileprocessor.go
@@ -113,7 +113,7 @@ func (p *processor) handleArchiveError(path string, info os.FileInfo, cause erro
 }
 
 func getCMSID(name string) (string, error) {
-	// CCLF foldername convention with BCD identifier: P.BCD.<ACO_ID>.ZCY**.Dyymmdd.Thhmmsst
+	// CCLF foldername convention with BCD identifier: P.BCD.<ACO_ID>.ZC[Y|R]**.Dyymmdd.Thhmmsst
 	exp := regexp.MustCompile(`(?:T|P)\.BCD\.(.*)\.ZC(?:Y|R)\d{2}\.D\d{6}\.T\d{7}`)
 	parts := exp.FindStringSubmatch(name)
 	if len(parts) != 2 {

--- a/bcda/cclf/fileprocessor_test.go
+++ b/bcda/cclf/fileprocessor_test.go
@@ -5,11 +5,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -184,7 +186,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 
 	// Timestamp that'll satisfy the time window requirement
 	validTime := startUTC.Add(-24 * time.Hour)
-	sspProdFile, sspTestFile := gen(sspProd, validTime), gen(sspTest, validTime)
+	sspProdFile, sspTestFile, sspRunoutFile := gen(sspProd, validTime), gen(sspTest, validTime),
+		strings.Replace(gen(sspProd, validTime), "ZC8", "ZCR8", 1)
 	cecProdFile, cecTestFile := gen(cecProd, validTime), gen(cecTest, validTime)
 	ngacoProdFile, ngacoTestFile := gen(ngacoProd, validTime), gen(ngacoTest, validTime)
 
@@ -207,6 +210,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 				acoID:     sspID,
 				timestamp: validTime,
 				perfYear:  20,
+				fileType:  models.FileTypeDefault,
 			},
 		},
 		{"Test SSP file", sspID, sspTestFile, "",
@@ -217,6 +221,19 @@ func TestGetCCLFMetadata(t *testing.T) {
 				acoID:     sspID,
 				timestamp: validTime,
 				perfYear:  20,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{
+			"Runout SSP file", sspID, sspRunoutFile, "",
+			cclfFileMetadata{
+				env:       "production",
+				name:      sspRunoutFile,
+				cclfNum:   8,
+				acoID:     sspID,
+				timestamp: validTime,
+				perfYear:  20,
+				fileType:  models.FileTypeRunout,
 			},
 		},
 		{"Production CEC file", cecID, cecProdFile, "",
@@ -227,6 +244,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 				acoID:     cecID,
 				timestamp: validTime,
 				perfYear:  20,
+				fileType:  models.FileTypeDefault,
 			},
 		},
 		{"Test CEC file", cecID, cecTestFile, "",
@@ -237,6 +255,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 				acoID:     cecID,
 				timestamp: validTime,
 				perfYear:  20,
+				fileType:  models.FileTypeDefault,
 			},
 		},
 		{"Production NGACO file", ngacoID, ngacoProdFile, "",
@@ -247,6 +266,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 				acoID:     ngacoID,
 				timestamp: validTime,
 				perfYear:  20,
+				fileType:  models.FileTypeDefault,
 			},
 		},
 		{"Test NGACO file", ngacoID, ngacoTestFile, "",
@@ -257,6 +277,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 				acoID:     ngacoID,
 				timestamp: validTime,
 				perfYear:  20,
+				fileType:  models.FileTypeDefault,
 			},
 		},
 	}

--- a/bcda/cclf/fileprocessor_test.go
+++ b/bcda/cclf/fileprocessor_test.go
@@ -146,6 +146,7 @@ func TestGetCMSID(t *testing.T) {
 		cmsID    string
 	}{
 		{"validSSPPath", "path/T.BCD.A0001.ZCY18.D181120.T1000000", false, "A0001"},
+		{"validSSPRunoutPath", "path/T.BCD.A0002.ZCR18.D181120.T1000000", false, "A0002"},
 		{"validNGACOPath", "path/T.BCD.V299.ZCY19.D191005.T0209260", false, "V299"},
 		{"validCECPath", "path/T.BCD.E9999.ZCY19.D191005.T0209260", false, "E9999"},
 		{"missingBCD", "path/T.A0001.ACO.ZC8Y18.D18NOV20.T1000009", true, ""},
@@ -187,7 +188,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 	// Timestamp that'll satisfy the time window requirement
 	validTime := startUTC.Add(-24 * time.Hour)
 	sspProdFile, sspTestFile, sspRunoutFile := gen(sspProd, validTime), gen(sspTest, validTime),
-		strings.Replace(gen(sspProd, validTime), "ZC8", "ZCR8", 1)
+		strings.Replace(gen(sspProd, validTime), "ZC8Y", "ZC8R", 1)
 	cecProdFile, cecTestFile := gen(cecProd, validTime), gen(cecTest, validTime)
 	ngacoProdFile, ngacoTestFile := gen(ngacoProd, validTime), gen(ngacoTest, validTime)
 

--- a/bcda/cclf/fileprocessor_test.go
+++ b/bcda/cclf/fileprocessor_test.go
@@ -149,7 +149,9 @@ func TestGetCMSID(t *testing.T) {
 		{"validSSPRunoutPath", "path/T.BCD.A0002.ZCR18.D181120.T1000000", false, "A0002"},
 		{"validNGACOPath", "path/T.BCD.V299.ZCY19.D191005.T0209260", false, "V299"},
 		{"validCECPath", "path/T.BCD.E9999.ZCY19.D191005.T0209260", false, "E9999"},
-		{"missingBCD", "path/T.A0001.ACO.ZC8Y18.D18NOV20.T1000009", true, ""},
+		{"missingBCD", "path/T.A0001.ACO.ZCY18.D18NOV20.T1000009", true, ""},
+		{"not ZCY or ZCR", "path/T.BCD.A0001.ZC18.D181120.T1000000", true, ""},
+		{"missing ZCY and ZCR", "path/T.BCD.A0001.ZCA18.D181120.T1000000", true, ""},
 		{"empty", "", true, ""},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Fixes [BCDA-3720](https://jira.cms.gov/browse/BCDA-3720)

Runout files have a slightly different format versus regular CCLF files. For the ZIP file, we can expect `ZCR` instead of `ZCY`. For individual CCLF files, we can expect `ZC0R,ZC8R` instead of `ZC0Y,ZC8Y`

### Change Details

1. Update regex found in fileprocessor.go to support the new expectations from runout files.
2. Update our metadata to include filetype. If we have `R`, we assume runout. If we have `Y`, we assume a regular CCLF file.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
With this change, we will be able to ingest runout CCLF files. The data stored will be exactly the same as regular CCLF files.
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
CI passes - new tests written to validate that we can process runout files as expected.

