### PR TITLE
BCCDA-3751 - Log "Accept-Encoding" header to gzip adoption

### DIFF
--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -59,6 +59,7 @@ func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 	logFields["remote_addr"] = r.RemoteAddr
 	logFields["forwarded_for"] = r.Header.Get("X-Forwarded-For")
 	logFields["user_agent"] = r.UserAgent()
+	logFields["accept_encoding"] = r.Header.Get("Accept-Encoding")
 
 	logFields["uri"] = fmt.Sprintf("%s://%s%s", scheme, r.Host, Redact(r.RequestURI))
 


### PR DESCRIPTION
### Fixes [BCDA-3751](https://jira.cms.gov/browse/BCDA-3751)

Log Accept-Encoding header value when logging request parameters. This will allow us to track the adoption of gzip-encoded file requests.

### Change Details

1. Update our StructuredLogger to emit the value of "Accept-Encoding" hdaer.
<!-- Add detailed discussion of changes here: -->

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Adding tests to verify that the header is logged as expected.
2. Deploy to dev to verify Splunk metrics are updated as expected.


