### PR TITLE
BCDA-3582 - Update BCDA to support querying v1/v2 BFD endpoints

### DIFF
--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -183,17 +183,15 @@ func (s *RequestsTestSuite) TestInvalidRequests() {
 		s.T().Run(fmt.Sprintf("%s-group", tt.name), func(t *testing.T) {
 			rr := httptest.NewRecorder()
 			h.BulkGroupRequest(rr, req)
-			body, err := ioutil.ReadAll(rr.Body)
-			assert.NoError(t, err)
-			assert.Contains(t, string(body), tt.errMsg)
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.errMsg)
 		})
 
 		s.T().Run(fmt.Sprintf("%s-patient", tt.name), func(t *testing.T) {
 			rr := httptest.NewRecorder()
 			h.BulkGroupRequest(rr, req)
-			body, err := ioutil.ReadAll(rr.Body)
-			assert.NoError(t, err)
-			assert.Contains(t, string(body), tt.errMsg)
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.errMsg)
 		})
 	}
 }

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -25,6 +25,12 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 )
 
+var h *api.Handler
+
+func init() {
+	h = api.NewHandler([]string{"Patient", "Coverage", "ExplanationOfBenefit"}, "/v1/fhir")
+}
+
 /*
 	swagger:route GET /api/v1/Patient/$export bulkData bulkPatientRequest
 
@@ -46,7 +52,7 @@ import (
 		500: errorResponse
 */
 func BulkPatientRequest(w http.ResponseWriter, r *http.Request) {
-	api.BulkPatientRequest(w, r)
+	h.BulkPatientRequest(w, r)
 }
 
 /*
@@ -70,7 +76,7 @@ func BulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 		500: errorResponse
 */
 func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
-	api.BulkGroupRequest(w, r)
+	h.BulkGroupRequest(w, r)
 }
 
 /*

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -96,14 +96,6 @@ func (s *APITestSuite) TestBulkEOBRequest() {
 	bulkEOBRequestHelper("Group/all", since, s)
 }
 
-func (s *APITestSuite) TestBulkEOBRequestInvalidSinceFormat() {
-	since := "invalidDate"
-	bulkEOBRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkEOBRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
 func (s *APITestSuite) TestBulkEOBRequestNoBeneficiariesInACO() {
 	bulkEOBRequestNoBeneficiariesInACOHelper("Patient", s)
 	s.TearDownTest()
@@ -132,14 +124,6 @@ func (s *APITestSuite) TestBulkPatientRequest() {
 	bulkPatientRequestHelper("Group/all", since, s)
 }
 
-func (s *APITestSuite) TestBulkPatientRequestInvalidSinceFormat() {
-	since := "invalidDate"
-	bulkPatientRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkPatientRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
 func (s *APITestSuite) TestBulkCoverageRequest() {
 	requestParams := RequestParams{}
 	bulkCoverageRequestHelper("Patient", requestParams, s)
@@ -153,86 +137,6 @@ func (s *APITestSuite) TestBulkCoverageRequest() {
 	s.TearDownTest()
 	s.SetupTest()
 	bulkCoverageRequestHelper("Group/all", requestParams, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormat() {
-	since := "invalidDate"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatEscapeCharacterFormat() {
-	since := "2020-03-01T00%3A%2000%3A00.000-00%3A00"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatMissingTimeZone() {
-	since := "2020-02-13T08:00:00.000"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatInvalidTime() {
-	since := "2020-02-13T33:00:00.000-05:00"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatInvalidDate() {
-	since := "2020-20-13T08:00:00.000-05:00"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatOnlyDate() {
-	since := "2020-03-01"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatOnlyInvalidDate() {
-	since := "2020-04-0"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatOnlyJunkDataAfterDate() {
-	since := "2020-02-13T08:00:00.000-05:00dfghj"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFormatOnlyJunkDataBeforeDate() {
-	since := "erty2020-02-13T08:00:00.000-05:00"
-	bulkCoverageRequestInvalidSinceFormatHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceFormatHelper("Group/all", since, s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidSinceFutureDate() {
-	futureDate := time.Now().AddDate(0, 0, 1).Format(time.RFC3339Nano)
-	bulkCoverageRequestInvalidSinceDateHelper("Patient", futureDate, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidSinceDateHelper("Group/all", futureDate, s)
 }
 
 func (s *APITestSuite) TestBulkCoverageRequestValidOutputFormatNDJSON() {
@@ -267,34 +171,6 @@ func (s *APITestSuite) TestBulkCoverageRequestValidMultipleParameters() {
 	bulkCoverageRequestHelper("Group/all", requestParams, s)
 }
 
-func (s *APITestSuite) TestBulkCoverageRequestInvalidOutputFormatTextHTML() {
-	bulkCoverageRequestInvalidOutputHelper("Patient", "text/html", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidOutputHelper("Group/all", "text/html", s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidOutputFormatXML() {
-	bulkCoverageRequestInvalidOutputHelper("Patient", "application/xml", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidOutputHelper("Group/all", "application/xml", s)
-}
-
-func (s *APITestSuite) TestBulkCoverageRequestInvalidOutputFormatCustom() {
-	bulkCoverageRequestInvalidOutputHelper("Patient", "x-custom", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkCoverageRequestInvalidOutputHelper("Group/all", "x-custom", s)
-}
-
-func (s *APITestSuite) TestBulkRequestInvalidType() {
-	bulkRequestInvalidTypeHelper("Patient", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkRequestInvalidTypeHelper("Group/all", s)
-}
-
 func (s *APITestSuite) TestBulkConcurrentRequest() {
 	bulkConcurrentRequestHelper("Patient", s)
 	s.TearDownTest()
@@ -307,13 +183,6 @@ func (s *APITestSuite) TestBulkConcurrentRequestTime() {
 	s.TearDownTest()
 	s.SetupTest()
 	bulkConcurrentRequestTimeHelper("Group/all", s)
-}
-
-func (s *APITestSuite) TestValidateRequest() {
-	validateRequestHelper("Patient", s)
-	s.TearDownTest()
-	s.SetupTest()
-	validateRequestHelper("Group/all", s)
 }
 
 func (s *APITestSuite) TestBulkPatientRequestBBClientFailure() {
@@ -339,31 +208,6 @@ func bulkEOBRequestHelper(endpoint, since string, s *APITestSuite) {
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 
 	s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{})
-}
-
-func bulkEOBRequestInvalidSinceFormatHelper(endpoint, since string, s *APITestSuite) {
-	acoID := acoUnderTest
-	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
-	assert.Nil(s.T(), err)
-
-	requestParams := RequestParams{resourceType: "ExplanationOfBenefit", since: since}
-	_, handlerFunc, req := bulkRequestHelper(endpoint, requestParams)
-	ad := s.makeContextValues(acoID)
-	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-
-	handler := http.HandlerFunc(handlerFunc)
-	handler.ServeHTTP(s.rr, req)
-
-	var respOO fhirmodels.OperationOutcome
-	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)
-	if err != nil {
-		s.T().Error(err)
-	}
-
-	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), "Invalid date format supplied in _since parameter.  Date must be in FHIR Instant format.", respOO.Issue[0].Details.Coding[0].Display)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
 }
 
 func bulkEOBRequestNoBeneficiariesInACOHelper(endpoint string, s *APITestSuite) {
@@ -425,31 +269,6 @@ func bulkPatientRequestHelper(endpoint, since string, s *APITestSuite) {
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 }
 
-func bulkPatientRequestInvalidSinceFormatHelper(endpoint, since string, s *APITestSuite) {
-	acoID := acoUnderTest
-	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
-	assert.Nil(s.T(), err)
-
-	requestParams := RequestParams{resourceType: "Patient", since: since}
-	_, handlerFunc, req := bulkRequestHelper(endpoint, requestParams)
-	ad := s.makeContextValues(acoID)
-	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-
-	handler := http.HandlerFunc(handlerFunc)
-	handler.ServeHTTP(s.rr, req)
-
-	var respOO fhirmodels.OperationOutcome
-	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)
-	if err != nil {
-		s.T().Error(err)
-	}
-
-	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), "Invalid date format supplied in _since parameter.  Date must be in FHIR Instant format.", respOO.Issue[0].Details.Coding[0].Display)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
-}
-
 func bulkCoverageRequestHelper(endpoint string, requestParams RequestParams, s *APITestSuite) {
 	acoID := acoUnderTest
 
@@ -462,86 +281,11 @@ func bulkCoverageRequestHelper(endpoint string, requestParams RequestParams, s *
 
 	ad := s.makeContextValues(acoID)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-	
+
 	handler := http.HandlerFunc(handlerFunc)
 	handler.ServeHTTP(s.rr, req)
 
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
-}
-
-func bulkCoverageRequestInvalidSinceFormatHelper(endpoint, since string, s *APITestSuite) {
-	acoID := acoUnderTest
-	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
-	assert.Nil(s.T(), err)
-
-	requestParams := RequestParams{resourceType: "Coverage", since: since}
-	_, handlerFunc, req := bulkRequestHelper(endpoint, requestParams)
-	ad := s.makeContextValues(acoID)
-	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-
-	handler := http.HandlerFunc(handlerFunc)
-	handler.ServeHTTP(s.rr, req)
-
-	var respOO fhirmodels.OperationOutcome
-	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)
-	if err != nil {
-		s.T().Error(err)
-	}
-
-	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), "Invalid date format supplied in _since parameter.  Date must be in FHIR Instant format.", respOO.Issue[0].Details.Coding[0].Display)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
-}
-
-func bulkCoverageRequestInvalidSinceDateHelper(endpoint, since string, s *APITestSuite) {
-	acoID := acoUnderTest
-	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
-	assert.Nil(s.T(), err)
-
-	requestParams := RequestParams{resourceType: "Coverage", since: since}
-	_, handlerFunc, req := bulkRequestHelper(endpoint, requestParams)
-	ad := s.makeContextValues(acoID)
-	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-
-	handler := http.HandlerFunc(handlerFunc)
-	handler.ServeHTTP(s.rr, req)
-
-	var respOO fhirmodels.OperationOutcome
-	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)
-	if err != nil {
-		s.T().Error(err)
-	}
-
-	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), "Invalid date format supplied in _since parameter. Date must be a date that has already passed", respOO.Issue[0].Details.Coding[0].Display)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
-}
-
-func bulkCoverageRequestInvalidOutputHelper(endpoint, outputFormat string, s *APITestSuite) {
-	acoID := acoUnderTest
-	err := s.db.Unscoped().Where("aco_id = ?", acoID).Delete(models.Job{}).Error
-	assert.Nil(s.T(), err)
-
-	requestParams := RequestParams{resourceType: "Coverage", outputFormat: outputFormat}
-	_, handlerFunc, req := bulkRequestHelper(endpoint, requestParams)
-	ad := s.makeContextValues(acoID)
-	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-
-	handler := http.HandlerFunc(handlerFunc)
-	handler.ServeHTTP(s.rr, req)
-
-	var respOO fhirmodels.OperationOutcome
-	err = json.Unmarshal(s.rr.Body.Bytes(), &respOO)
-	if err != nil {
-		s.T().Error(err)
-	}
-
-	assert.Equal(s.T(), responseutils.Error, respOO.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, respOO.Issue[0].Code)
-	assert.Equal(s.T(), "_outputFormat parameter must be application/fhir+ndjson, application/ndjson, or ndjson", respOO.Issue[0].Details.Coding[0].Display)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
 }
 
 func bulkPatientRequestBBClientFailureHelper(endpoint string, s *APITestSuite) {
@@ -573,13 +317,6 @@ func bulkPatientRequestBBClientFailureHelper(endpoint string, s *APITestSuite) {
 	assert.Equal(s.T(), http.StatusInternalServerError, s.rr.Code)
 
 	assert.Equal(s.T(), http.StatusInternalServerError, s.rr.Code)
-}
-
-func bulkRequestInvalidTypeHelper(endpoint string, s *APITestSuite) {
-	requestParams := RequestParams{resourceType: "Foo"}
-	_, handlerFunc, req := bulkRequestHelper(endpoint, requestParams)
-	handlerFunc(s.rr, req)
-	assert.Equal(s.T(), http.StatusBadRequest, s.rr.Code)
 }
 
 func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
@@ -739,94 +476,6 @@ func bulkConcurrentRequestTimeHelper(endpoint string, s *APITestSuite) {
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
 	os.Unsetenv("DEPLOYMENT_TARGET")
-}
-
-func validateRequestHelper(endpoint string, s *APITestSuite) {
-	requestUrl, _ := url.Parse("/api/v1/Patient/$export")
-	q := requestUrl.Query()
-	q.Set("_elements", "blah,blah,blah")
-	requestUrl.RawQuery = q.Encode()
-	req := httptest.NewRequest("GET", requestUrl.String(), nil)
-	rctx := chi.NewRouteContext()
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	resourceTypes, err := api.ValidateRequest(req)
-	assert.Nil(s.T(), resourceTypes)
-	assert.Equal(s.T(), responseutils.Error, err.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, err.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Code)
-	assert.Equal(s.T(), "Invalid parameter: this server does not support the _elements parameter.", err.Issue[0].Details.Coding[0].Display)
-
-	requestParams := RequestParams{}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 3, len(resourceTypes))
-	for _, t := range resourceTypes {
-		if t != "ExplanationOfBenefit" && t != "Patient" && t != "Coverage" {
-			assert.Fail(s.T(), "Invalid Resource type found")
-		}
-	}
-
-	requestParams = RequestParams{resourceType: "ExplanationOfBenefit,Patient"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 2, len(resourceTypes))
-	for _, t := range resourceTypes {
-		if t != "ExplanationOfBenefit" && t != "Patient" {
-			assert.Fail(s.T(), "Invalid Resource type found")
-		}
-	}
-
-	requestParams = RequestParams{resourceType: "Coverage,Patient"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 2, len(resourceTypes))
-	for _, t := range resourceTypes {
-		if t != "Coverage" && t != "Patient" {
-			assert.Fail(s.T(), "Invalid Resource type found")
-		}
-	}
-
-	requestParams = RequestParams{resourceType: "ExplanationOfBenefit"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 1, len(resourceTypes))
-	assert.Contains(s.T(), resourceTypes, "ExplanationOfBenefit")
-
-	requestParams = RequestParams{resourceType: "Patient"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 1, len(resourceTypes))
-	assert.Contains(s.T(), resourceTypes, "Patient")
-
-	requestParams = RequestParams{resourceType: "Coverage"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 1, len(resourceTypes))
-	assert.Contains(s.T(), resourceTypes, "Coverage")
-
-	requestParams = RequestParams{resourceType: "Practitioner"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), resourceTypes)
-	assert.Equal(s.T(), responseutils.Error, err.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, err.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Code)
-	assert.Equal(s.T(), "Invalid resource type", err.Issue[0].Details.Coding[0].Display)
-
-	requestParams = RequestParams{resourceType: "Patient,Patient"}
-	_, _, req = bulkRequestHelper(endpoint, requestParams)
-	resourceTypes, err = api.ValidateRequest(req)
-	assert.Nil(s.T(), resourceTypes)
-	assert.Equal(s.T(), responseutils.Error, err.Issue[0].Severity)
-	assert.Equal(s.T(), responseutils.Exception, err.Issue[0].Code)
-	assert.Equal(s.T(), responseutils.RequestErr, err.Issue[0].Details.Coding[0].Code)
-	assert.Equal(s.T(), "Repeated resource type", err.Issue[0].Details.Coding[0].Display)
 }
 
 func bulkRequestHelper(endpoint string, testRequestParams RequestParams) (string, func(http.ResponseWriter, *http.Request), *http.Request) {

--- a/bcda/api/v2/api.go
+++ b/bcda/api/v2/api.go
@@ -18,7 +18,9 @@ import (
 var h *api.Handler
 
 func init() {
-	h = api.NewHandler([]string{"Patient", "Coverage"}, "/v2/fhir")
+	// TODO (BCDA-3582) - Since v2 APIs are not available (as of 2020-10-21), we're still
+	// routing requests to the v1 BFD endpoints
+	h = api.NewHandler([]string{"Patient", "Coverage"}, "/v1/fhir")
 }
 
 /*

--- a/bcda/api/v2/api.go
+++ b/bcda/api/v2/api.go
@@ -15,6 +15,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var h *api.Handler
+
+func init() {
+	h = api.NewHandler([]string{"Patient", "Coverage"}, "/v2/fhir")
+}
+
 /*
 	swagger:route GET /api/v2/Patient/$export bulkDataV2 BulkPatientRequest
 
@@ -36,7 +42,7 @@ import (
 		500: errorResponse
 */
 func BulkPatientRequest(w http.ResponseWriter, r *http.Request) {
-	api.BulkPatientRequest(w, r)
+	h.BulkPatientRequest(w, r)
 }
 
 /*
@@ -60,7 +66,7 @@ func BulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 		500: errorResponse
 */
 func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
-	api.BulkGroupRequest(w, r)
+	h.BulkGroupRequest(w, r)
 }
 
 /*

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -141,7 +141,12 @@ func (s *APITestSuite) TestResourceTypes() {
 			s.T().Run(fmt.Sprintf("%s-%d", tt.name, idx), func(t *testing.T) {
 				rr := httptest.NewRecorder()
 
-				u, err := url.Parse("/api/v2")
+				ep := "Group"
+				if idx == 1 {
+					ep = "Patient"
+				}
+
+				u, err := url.Parse(fmt.Sprintf("/api/v2/%s/$export", ep))
 				assert.NoError(t, err)
 
 				q := u.Query()

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -70,3 +70,5 @@ func TestMetadataResponse(t *testing.T) {
 	assert.Equal(t, ts.URL, subExtension["valueUri"])
 
 }
+
+f

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -1,37 +1,89 @@
 package v2_test
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	v2 "github.com/CMSgov/bcda-app/bcda/api/v2"
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/constants"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/go-chi/chi"
+	"github.com/jinzhu/gorm"
+	"github.com/pborman/uuid"
 	"github.com/samply/golang-fhir-models/fhir-models/fhir"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestMetadataResponse(t *testing.T) {
+const (
+	acoUnderTest = constants.LargeACOUUID // Should use a different ACO compared to v1 tests
+)
+
+type APITestSuite struct {
+	suite.Suite
+	db *gorm.DB
+
+	cleanup func()
+}
+
+func (s *APITestSuite) SetupSuite() {
+	origDate := os.Getenv("CCLF_REF_DATE")
+	os.Setenv("CCLF_REF_DATE", time.Now().Format("060102 15:01:01"))
+	os.Setenv("BB_REQUEST_RETRY_INTERVAL_MS", "10")
+	origBBCert := os.Getenv("BB_CLIENT_CERT_FILE")
+	os.Setenv("BB_CLIENT_CERT_FILE", "../../../shared_files/decrypted/bfd-dev-test-cert.pem")
+	origBBKey := os.Getenv("BB_CLIENT_KEY_FILE")
+	os.Setenv("BB_CLIENT_KEY_FILE", "../../../shared_files/decrypted/bfd-dev-test-key.pem")
+
+	s.cleanup = func() {
+		os.Setenv("CCLF_REF_DATE", origDate)
+		os.Setenv("BB_CLIENT_CERT_FILE", origBBCert)
+		os.Setenv("BB_CLIENT_KEY_FILE", origBBKey)
+	}
+
+	s.db = database.GetGORMDbConnection()
+}
+
+func (s *APITestSuite) TearDownSuite() {
+	s.cleanup()
+	s.db.Close()
+}
+
+func TestAPITestSuite(t *testing.T) {
+	suite.Run(t, new(APITestSuite))
+}
+
+func (s *APITestSuite) TestMetadataResponse() {
 	ts := httptest.NewServer(http.HandlerFunc(v2.Metadata))
 	defer ts.Close()
 
 	res, err := http.Get(ts.URL)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
-	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(s.T(), "application/json", res.Header.Get("Content-Type"))
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 
 	resp, err := ioutil.ReadAll(res.Body)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 
 	cs, err := fhir.UnmarshalCapabilityStatement(resp)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 
 	// Expecting an R4 response so we'll evaluate some fields to reflect that
-	assert.Equal(t, fhir.FHIRVersion4_0_1, cs.FhirVersion)
-	assert.Equal(t, 1, len(cs.Rest))
-	assert.Equal(t, 2, len(cs.Rest[0].Resource))
+	assert.Equal(s.T(), fhir.FHIRVersion4_0_1, cs.FhirVersion)
+	assert.Equal(s.T(), 1, len(cs.Rest))
+	assert.Equal(s.T(), 2, len(cs.Rest[0].Resource))
 	resourceData := []struct {
 		rt           fhir.ResourceType
 		opName       string
@@ -49,10 +101,10 @@ func TestMetadataResponse(t *testing.T) {
 				break
 			}
 		}
-		assert.NotNil(t, rr)
-		assert.Equal(t, 1, len(rr.Operation))
-		assert.Equal(t, rd.opName, rr.Operation[0].Name)
-		assert.Equal(t, rd.opDefinition, rr.Operation[0].Definition)
+		assert.NotNil(s.T(), rr)
+		assert.Equal(s.T(), 1, len(rr.Operation))
+		assert.Equal(s.T(), rd.opName, rr.Operation[0].Name)
+		assert.Equal(s.T(), rd.opDefinition, rr.Operation[0].Definition)
 	}
 
 	// Need to validate our security.extensions manually since the extension
@@ -60,15 +112,62 @@ func TestMetadataResponse(t *testing.T) {
 	// See: https://github.com/samply/golang-fhir-models/issues/1
 	var obj map[string]interface{}
 	err = json.Unmarshal(resp, &obj)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 
 	targetExtension := obj["rest"].([]interface{})[0].(map[string]interface{})["security"].(map[string]interface{})["extension"].([]interface{})[0].(map[string]interface{})
 	subExtension := targetExtension["extension"].([]interface{})[0].(map[string]interface{})
 
-	assert.Equal(t, "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris", targetExtension["url"])
-	assert.Equal(t, "token", subExtension["url"])
-	assert.Equal(t, ts.URL, subExtension["valueUri"])
+	assert.Equal(s.T(), "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris", targetExtension["url"])
+	assert.Equal(s.T(), "token", subExtension["url"])
+	assert.Equal(s.T(), ts.URL, subExtension["valueUri"])
 
 }
 
-f
+func (s *APITestSuite) TestResourceTypes() {
+	tests := []struct {
+		name          string
+		resourceTypes []string
+		statusCode    int
+	}{
+		{"Supported type - Patient", []string{"Patient"}, http.StatusAccepted},
+		{"Supported type - Coverage", []string{"Coverage"}, http.StatusAccepted},
+		{"Supported type - Patient,Coverage", []string{"Patient", "Coverage"}, http.StatusAccepted},
+		{"Unsupported type - EOB", []string{"ExplanationOfBenefit"}, http.StatusBadRequest},
+		{"Unsupported type - default", nil, http.StatusBadRequest},
+	}
+
+	for idx, handler := range []http.HandlerFunc{v2.BulkGroupRequest, v2.BulkPatientRequest} {
+		for _, tt := range tests {
+			s.T().Run(fmt.Sprintf("%s-%d", tt.name, idx), func(t *testing.T) {
+				rr := httptest.NewRecorder()
+
+				u, err := url.Parse("/api/v2")
+				assert.NoError(t, err)
+
+				q := u.Query()
+				if len(tt.resourceTypes) > 0 {
+					q.Add("_type", strings.Join(tt.resourceTypes, ","))
+
+				}
+				u.RawQuery = q.Encode()
+				req := httptest.NewRequest("GET", u.String(), nil)
+				rctx := chi.NewRouteContext()
+				rctx.URLParams.Add("groupId", "all")
+				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+				ad := s.getAuthData()
+				req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+
+				handler(rr, req)
+				assert.Equal(t, tt.statusCode, rr.Code)
+				fmt.Println(rr.Body.String())
+			})
+		}
+	}
+}
+
+func (s *APITestSuite) getAuthData() (data auth.AuthData) {
+	var aco models.ACO
+	s.db.First(&aco, "uuid = ?", acoUnderTest)
+	return auth.AuthData{ACOID: acoUnderTest, CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
+}

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -80,12 +80,12 @@ func (s *BBTestSuite) TestNewBlueButtonClientNoCertFile() {
 	assert := assert.New(s.T())
 
 	os.Unsetenv("BB_CLIENT_CERT_FILE")
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: open : no such file or directory")
 
 	os.Setenv("BB_CLIENT_CERT_FILE", "foo.pem")
-	bbc, err = client.NewBlueButtonClient(client.NewConfig())
+	bbc, err = client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: open foo.pem: no such file or directory")
 }
@@ -97,12 +97,12 @@ func (s *BBTestSuite) TestNewBlueButtonClientInvalidCertFile() {
 	assert := assert.New(s.T())
 
 	os.Setenv("BB_CLIENT_CERT_FILE", "../static/emptyFile.pem")
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: tls: failed to find any PEM data in certificate input")
 
 	os.Setenv("BB_CLIENT_CERT_FILE", "../static/badPublic.pem")
-	bbc, err = client.NewBlueButtonClient(client.NewConfig())
+	bbc, err = client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: tls: failed to find any PEM data in certificate input")
 }
@@ -114,12 +114,12 @@ func (s *BBTestSuite) TestNewBlueButtonClientNoKeyFile() {
 	assert := assert.New(s.T())
 
 	os.Unsetenv("BB_CLIENT_KEY_FILE")
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: open : no such file or directory")
 
 	os.Setenv("BB_CLIENT_KEY_FILE", "foo.pem")
-	bbc, err = client.NewBlueButtonClient(client.NewConfig())
+	bbc, err = client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: open foo.pem: no such file or directory")
 }
@@ -131,12 +131,12 @@ func (s *BBTestSuite) TestNewBlueButtonClientInvalidKeyFile() {
 	assert := assert.New(s.T())
 
 	os.Setenv("BB_CLIENT_KEY_FILE", "../static/emptyFile.pem")
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: tls: failed to find any PEM data in key input")
 
 	os.Setenv("BB_CLIENT_KEY_FILE", "../static/badPublic.pem")
-	bbc, err = client.NewBlueButtonClient(client.NewConfig())
+	bbc, err = client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not load Blue Button keypair: tls: failed to find any PEM data in key input")
 }
@@ -153,12 +153,12 @@ func (s *BBTestSuite) TestNewBlueButtonClientNoCAFile() {
 
 	os.Unsetenv("BB_CLIENT_CA_FILE")
 	os.Unsetenv("BB_CHECK_CERT")
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not read CA file: read .: is a directory")
 
 	os.Setenv("BB_CLIENT_CA_FILE", "foo.pem")
-	bbc, err = client.NewBlueButtonClient(client.NewConfig())
+	bbc, err = client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not read CA file: open foo.pem: no such file or directory")
 }
@@ -175,12 +175,12 @@ func (s *BBTestSuite) TestNewBlueButtonClientInvalidCAFile() {
 
 	os.Setenv("BB_CLIENT_CA_FILE", "../static/emptyFile.pem")
 	os.Unsetenv("BB_CHECK_CERT")
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not append CA certificate(s)")
 
 	os.Setenv("BB_CLIENT_CA_FILE", "../static/badPublic.pem")
-	bbc, err = client.NewBlueButtonClient(client.NewConfig())
+	bbc, err = client.NewBlueButtonClient(client.NewConfig(""))
 	assert.Nil(bbc)
 	assert.EqualError(err, "could not append CA certificate(s)")
 }

--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -30,7 +30,7 @@ func IsDatabaseOK() bool {
 }
 
 func IsBlueButtonOK() bool {
-	bbc, err := client.NewBlueButtonClient(client.NewConfig())
+	bbc, err := client.NewBlueButtonClient(client.NewConfig("/v1/fhir"))
 	if err != nil {
 		log.Error("Health check: Blue Button client error: ", err.Error())
 		return false

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -338,4 +338,5 @@ type JobEnqueueArgs struct {
 	Since           string
 	TransactionTime time.Time
 	ServiceDate     time.Time
+	BBBasePath      string
 }

--- a/bcda/models/service.go
+++ b/bcda/models/service.go
@@ -40,7 +40,7 @@ const (
 	cclf8FileNum = int(8)
 )
 
-func NewService(r Repository, cutoffDuration time.Duration, lookbackDays int, runoutCutoffDuration time.Duration) Service {
+func NewService(r Repository, cutoffDuration time.Duration, lookbackDays int, runoutCutoffDuration time.Duration, basePath string) Service {
 	return &service{
 		repository:        r,
 		logger:            log.StandardLogger(),
@@ -51,9 +51,10 @@ func NewService(r Repository, cutoffDuration time.Duration, lookbackDays int, ru
 		},
 		rp: runoutParameters{
 			// Runouts apply to claims data for the previous year.
-			claimThruDate: time.Date(time.Now().Year()-1, time.December, 31, 23, 59, 59, 999999, time.UTC),
+			claimThruDate:  time.Date(time.Now().Year()-1, time.December, 31, 23, 59, 59, 999999, time.UTC),
 			cutoffDuration: runoutCutoffDuration,
 		},
+		bbBasePath: basePath,
 	}
 }
 
@@ -65,6 +66,7 @@ type service struct {
 	stdCutoffDuration time.Duration
 	sp                suppressionParameters
 	rp                runoutParameters
+	bbBasePath        string
 }
 
 type suppressionParameters struct {
@@ -150,6 +152,7 @@ func (s *service) createQueueJobs(job *Job, CMSID string, resourceTypes []string
 					ResourceType:    rt,
 					Since:           sinceArg,
 					TransactionTime: job.TransactionTime,
+					BBBasePath:      s.bbBasePath,
 				}
 
 				if reqType == Runout {

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -453,6 +453,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 		}
 	}
 
+	basePath := "/v2/fhir"
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			repository := &MockRepository{}
@@ -461,7 +462,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			repository.On("GetCCLFBeneficiaries", mock.Anything, mock.Anything).Return(tt.expBenes, nil)
 			// use benes1 as the "old" benes. Allows us to verify the since parameter is populated as expected
 			repository.On("GetCCLFBeneficiaryMBIs", mock.Anything).Return(benes1MBI, nil)
-			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, "")
+			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, basePath)
 			queJobs, err := serviceInstance.GetQueJobs(tt.acoID, &Job{ACOID: uuid.NewUUID()}, tt.resourceTypes, tt.expSince, tt.reqType)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID
@@ -511,6 +512,8 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 				for _, beneID := range args.BeneficiaryIDs {
 					subMap[beneID] = struct{}{}
 				}
+
+				assert.Equal(t, basePath, args.BBBasePath)
 			}
 
 			for _, resourceType := range tt.resourceTypes {

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -284,7 +284,7 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 			}
 			repository.On("GetSuppressedMBIs", lookbackDays).Return([]string{suppressedMBI}, nil)
 
-			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff).(*service)
+			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff, "").(*service)
 			newBenes, oldBenes, err := serviceInstance.getNewAndExistingBeneficiaries("cmsID", since)
 
 			if tt.expectedErr != nil {
@@ -381,7 +381,7 @@ func (s *ServiceTestSuite) TestGetBeneficiaries() {
 				repository.On("GetCCLFBeneficiaries", tt.cclfFile.ID, []string{suppressedMBI}).Return(benes, nil)
 			}
 
-			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff).(*service)
+			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff, "").(*service)
 			benes, err := serviceInstance.getBeneficiaries("cmsID", tt.fileType)
 
 			if tt.expectedErr != nil {
@@ -461,7 +461,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			repository.On("GetCCLFBeneficiaries", mock.Anything, mock.Anything).Return(tt.expBenes, nil)
 			// use benes1 as the "old" benes. Allows us to verify the since parameter is populated as expected
 			repository.On("GetCCLFBeneficiaryMBIs", mock.Anything).Return(benes1MBI, nil)
-			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff)
+			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, "")
 			queJobs, err := serviceInstance.GetQueJobs(tt.acoID, &Job{ACOID: uuid.NewUUID()}, tt.resourceTypes, tt.expSince, tt.reqType)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -58,7 +58,7 @@ func createWorkerDirs() {
 }
 
 func processJob(j *que.Job) error {
-	// TODO (PUT_JIRA_TICKET_HERE) -- once we have jobs
+	// TODO (BCDA-3895) -- once we have jobs
 	// populated with the basePath, we do not need this fallback.
 	const blueButtonBasePath = "/v1/fhir"
 
@@ -114,7 +114,7 @@ func processJob(j *que.Job) error {
 		return errors.Wrap(err, "could not update job status in database")
 	}
 
-	// TODO (PUT_JIRA_TICKET_HERE) - Remove this fallback once we can guarantee
+	// TODO (BCDA-3895) - Remove this fallback once we can guarantee
 	// that all jobs are created with the expected path
 	basePath := jobArgs.BBBasePath
 	if len(basePath) == 0 {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -58,6 +58,10 @@ func createWorkerDirs() {
 }
 
 func processJob(j *que.Job) error {
+	// TODO (PUT_JIRA_TICKET_HERE) -- once we have jobs
+	// populated with the basePath, we do not need this fallback.
+	const blueButtonBasePath = "/v1/fhir"
+
 	m := monitoring.GetMonitor()
 	txn := m.Start("processJob", nil, nil)
 	ctx := newrelic.NewContext(context.Background(), txn)
@@ -110,7 +114,14 @@ func processJob(j *que.Job) error {
 		return errors.Wrap(err, "could not update job status in database")
 	}
 
-	bb, err := client.NewBlueButtonClient(client.NewConfig())
+	// TODO (PUT_JIRA_TICKET_HERE) - Remove this fallback once we can guarantee
+	// that all jobs are created with the expected path
+	basePath := jobArgs.BBBasePath
+	if len(basePath) == 0 {
+		basePath = blueButtonBasePath
+	}
+
+	bb, err := client.NewBlueButtonClient(client.NewConfig(basePath))
 	if err != nil {
 		err = errors.Wrap(err, "could not create Blue Button client")
 		log.Error(err)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -377,6 +377,7 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 	defer database.Close(db)
 
 	// Verifies that we can handle an empty and specified basePath
+	// TODO (BCDA-3895) - we should confirm that the job fails when we supply an empty basePath
 	for _, basePath := range []string{"", "/v1/fhir"} {
 		j := models.Job{
 			ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -2390,7 +2390,7 @@
 							"",
 							"",
 							"pm.test(\"Issue details text is Invalid Resource Type\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid resource type\")",
+							"    pm.expect(respJson.issue[0].details.text).to.include(\"Invalid resource type\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -2470,7 +2470,7 @@
 							"});",
 							"",
 							"pm.test(\"Issue details text is Invalid Resource Type\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.eql(\"Invalid resource type\")",
+							"    pm.expect(respJson.issue[0].details.text).to.include(\"Invalid resource type\")",
 							"});"
 						],
 						"type": "text/javascript"


### PR DESCRIPTION
### Fixes [BCDA-3582](https://jira.cms.gov/browse/BCDA-3582)

We need to have a mechanism where callers can retrieve data from BFD v1 endpoints (STU3) and v2 endpoints (R4).

### Change Details
1. Update our JobEnqueueArgs to accept a basePath parameter. This parameter will be used to allow our worker to make v1/v2 BFD calls.
2. Update v1/v2 APIs to contain a list of supported resourceTypes. This information is passed into requests.go.
3. Update requests.go to contain a handler struct to capture resourceTypes and basePath parameters. v1 and v2 API will instantiate the handler with the expected parameters.
4. Refactor validation tests into request_test.go (from v1/api_test.go)

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted

This PR **does not** call BFD v2 endpoints since they are not yet available. We will have follow up PR that switches the basePath. As such, no new data is stored/transmitted.

- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
CI passes
