### PR TITLE
BCDA-3753 - Detect repetition of query param charcter (?) in request

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -342,6 +342,15 @@ func ValidateRequest(r *http.Request) ([]string, *fhirmodels.OperationOutcome) {
 		return nil, oo
 	}
 
+	// Check and see if the user has a duplicated the query parameter symbol (?)
+	// e.g. /api/v1/Patient/$export?_type=ExplanationOfBenefit&?_since=2020-09-13T08:00:00.000-05:00
+	for key := range r.URL.Query() {
+		if strings.HasPrefix(key, "?") {
+			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.FormatErr, "Invalid parameter: query parameters cannot start with ?")
+			return nil, oo
+		}
+	}
+
 	return resourceTypes, nil
 }
 


### PR DESCRIPTION
### Fixes [BCDA-3753](https://jira.cms.gov/browse/BCDA-3753)

User had specified a query parameter that started with the `?` character, which caused the specified `_since` parameter to not be used.

Ex:

```
https://api.bcda.cms.gov/api/v1/Patient/$export?_type=ExplanationOfBenefit&?_since=2020-09-13T08:00:00.000-05:00
```

Considered using a whitelist of approved query parameters (`_since`, `_type`, etc.), but that seems to go against [experimental query parameters](https://hl7.org/fhir/uv/bulkdata/export/index.html#experimental-query-parameters) defined in the bulk FHIR spec..

### Change Details

1. Update ValidateRequest to check that no query parameters start with `?`

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
CI Passes
