### PR TITLE
Fix issue with parsing _since parameter 

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -205,8 +205,7 @@ func bulkRequest(resourceTypes []string, w http.ResponseWriter, r *http.Request,
 	var since time.Time
 	// Decode the _since parameter (if it exists) so it can be persisted in job args
 	if params, ok := r.URL.Query()["_since"]; ok {
-		decodedSince, _ := url.QueryUnescape(params[0])
-		since, err = time.Parse(time.RFC3339Nano, decodedSince)
+		since, err = time.Parse(time.RFC3339Nano, params[0])
 		if err != nil {
 			log.Error(err)
 			oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.Processing, "")

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -126,13 +126,13 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 }
 
 func (s *APITestSuite) TestBulkPatientRequest() {
+	bulkPatientRequestHelper("Patient", "", s)
+	s.TearDownTest()
+	s.SetupTest()
+	bulkPatientRequestHelper("Group/all", "", s)
+	s.TearDownTest()
+	s.SetupTest()
 	for _, since := range []string{"2020-02-13T08:00:00.000-05:00", "2020-02-13T08:00:00.000+05:00"} {
-		bulkPatientRequestHelper("Patient", "", s)
-		s.TearDownTest()
-		s.SetupTest()
-		bulkPatientRequestHelper("Group/all", "", s)
-		s.TearDownTest()
-		s.SetupTest()
 		bulkPatientRequestHelper("Patient", since, s)
 		s.TearDownTest()
 		s.SetupTest()

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -126,17 +126,18 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 }
 
 func (s *APITestSuite) TestBulkPatientRequest() {
-	since := "2020-02-13T08:00:00.000-05:00"
-	bulkPatientRequestHelper("Patient", "", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkPatientRequestHelper("Group/all", "", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkPatientRequestHelper("Patient", since, s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkPatientRequestHelper("Group/all", since, s)
+	for _, since := range []string{"2020-02-13T08:00:00.000-05:00", "2020-02-13T08:00:00.000+05:00"} {
+		bulkPatientRequestHelper("Patient", "", s)
+		s.TearDownTest()
+		s.SetupTest()
+		bulkPatientRequestHelper("Group/all", "", s)
+		s.TearDownTest()
+		s.SetupTest()
+		bulkPatientRequestHelper("Patient", since, s)
+		s.TearDownTest()
+		s.SetupTest()
+		bulkPatientRequestHelper("Group/all", since, s)
+	}
 }
 
 func (s *APITestSuite) TestBulkPatientRequestInvalidSinceFormat() {

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -126,17 +126,13 @@ func (s *APITestSuite) TestBulkEOBRequestNoQueue() {
 }
 
 func (s *APITestSuite) TestBulkPatientRequest() {
-	bulkPatientRequestHelper("Patient", "", s)
-	s.TearDownTest()
-	s.SetupTest()
-	bulkPatientRequestHelper("Group/all", "", s)
-	s.TearDownTest()
-	s.SetupTest()
-	for _, since := range []string{"2020-02-13T08:00:00.000-05:00", "2020-02-13T08:00:00.000+05:00"} {
+	for _, since := range []string{"", "2020-02-13T08:00:00.000-05:00", "2020-02-13T08:00:00.000+05:00"} {
 		bulkPatientRequestHelper("Patient", since, s)
 		s.TearDownTest()
 		s.SetupTest()
 		bulkPatientRequestHelper("Group/all", since, s)
+		s.TearDownTest()
+		s.SetupTest()
 	}
 }
 


### PR DESCRIPTION
### Discovered by [BCDA-3721](https://jira.cms.gov/browse/BCDA-3721)

**tl:dr; We've been incorrectly returning errors when parsing _since parameters with a positive timezone offset**
 
With this [PR](https://github.com/CMSgov/bcda-app/pull/568) we pushed our validation of the `_since` parameter to occur in both patient and /group/all endpoints. It used to only occur on the /group/all endpoint.

After we merged the PR, we started to see failures in the FHIR scan. It was traced to this section of code:
```
decodedSince, _ := url.QueryUnescape(params[0])			
since, err = time.Parse(time.RFC3339Nano, decodedSince)
```
By using `url.QueryUnescape(...)`, we were incorrectly removing the `+` character from our timezone information.

Example:
```
t := '2020-09-26T15:05:31+04:00'
tNegative := '2020-09-26T15:05:31-04:00'
t1, _ := url.QueryUnescape(t) // t1 = 2020-09-26T15:05:31 04:00
t2, _ := url.QueryUnescape(tNegative) // t2 = 2020-09-26T15:05:31-04:00
```

Since the FHIR scan was using the positive timezone for Patient endpoint, it started to fail. Before this [PR](https://github.com/CMSgov/bcda-app/pull/568) was merged, we were not parsing the time value for patient endpoints.

We do not have to use QueryUnescape to clean the _since parameter. It's already done automatically when using url.Query() (see: https://golang.org/src/net/url/url.go?s=30710:30738#L927).

### Change Details

1. Do not "clean" _since parameter field before parsing it to a time.Time struct.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Added unit test to verify behavior
2. Successfully ran [FHIR scan](https://bcda-ci.adhocteam.us/job/BCDA%20-%20FHIR%20Scan/134/) with this PR.

