### PR TITLE
BCDA-3920 - Update 429 check to only use in-progress/pending jobs

### DIFF
--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -247,7 +247,7 @@ func (s *RequestsTestSuite) TestBulkRequestWithOldJobPaths() {
 	var aco models.ACO
 	s.NoError(s.db.First(&aco, "uuid = ?", s.acoID).Error)
 
-	// Create jobs that are completed but have an unsupported path
+	// Create jobs that githave an unsupported path
 	s.NoError(s.db.Create(&models.Job{ACOID: s.acoID, RequestURL: "https://api.bcda.cms.gov/api/v1/Coverage/$export", Status: "Failed"}).Error)
 	s.NoError(s.db.Create(&models.Job{ACOID: s.acoID, RequestURL: "https://api.bcda.cms.gov/api/v1/ExplanationOfBenefit/$export", Status: "Expired"}).Error)
 	s.NoError(s.db.Create(&models.Job{ACOID: s.acoID, RequestURL: "https://api.bcda.cms.gov/api/v1/SomeCoolUnsupportedResource/$export", Status: "Completed"}).Error)


### PR DESCRIPTION
### Fixes [BCDA-3920](https://jira.cms.gov/browse/BCDA-3920)

With this [PR](https://github.com/CMSgov/bcda-app/pull/570), we started to parse the job's requestURL to determine if we are servicing a V1 or V2 request.

We had expected that all jobs were of type Group or Patient. However, there are older jobs for other resources (ex: Coverage). This caused our regex to fail and prevented smoke tests from passing in the prod environment.

### Change Details

Only return in progress OR pending jobs from the database when applying our 429 check. Completed, Failed, Expired, etc. should not be used. This matches our business logic in the check429 function. We only consider in progress and pending jobs.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Added new unit test to verify the functionality.