### PR TITLE
BCDA-3722 - Update bcdaworker to leverage ServiceDate parameter

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -133,8 +133,6 @@ func NewBlueButtonClient(config BlueButtonConfig) (*BlueButtonClient, error) {
 	return &BlueButtonClient{client, maxTries, retryInterval, config.BBServer, config.BBBasePath}, nil
 }
 
-type BeneDataFunc func(string, string, string, string, time.Time) (*models.Bundle, error)
-
 func (bbc *BlueButtonClient) GetPatient(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
 	params := GetDefaultParams()
 	params.Set("_id", patientID)
@@ -164,8 +162,10 @@ func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, si
 	params := GetDefaultParams()
 	params.Set("patient", patientID)
 	params.Set("excludeSAMHSA", "true")
+	// If service date is supplied, it represents the latest date (inclusive) that claims should occur.
+	// That's why the le (less than or equal to) operator is used.
 	if !serviceDate.IsZero() {
-		params.Set("service-date", serviceDate.Format(svcDateFmt))
+		params.Set("service-date", fmt.Sprintf("le%s", serviceDate.Format(svcDateFmt)))
 	}
 	updateParamWithLastUpdated(&params, since, transactionTime)
 	return bbc.getBundleData("/ExplanationOfBenefit/", params, jobID, cmsID)

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -49,7 +49,7 @@ func NewConfig(basePath string) BlueButtonConfig {
 }
 
 type APIClient interface {
-	GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error)
+	GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime, serviceDate time.Time) (*models.Bundle, error)
 	GetPatient(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error)
 	GetCoverage(beneficiaryID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error)
 	GetPatientByIdentifierHash(hashedIdentifier string) (string, error)
@@ -157,10 +157,16 @@ func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID, since stri
 	return bbc.getBundleData("/Coverage/", params, jobID, cmsID)
 }
 
-func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
+func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime, serviceDate time.Time) (*models.Bundle, error) {
+	// ServiceDate only uses yyyy-mm-dd
+	const svcDateFmt = "2006-01-02"
+
 	params := GetDefaultParams()
 	params.Set("patient", patientID)
 	params.Set("excludeSAMHSA", "true")
+	if !serviceDate.IsZero() {
+		params.Set("service-date", serviceDate.Format(svcDateFmt))
+	}
 	updateParamWithLastUpdated(&params, since, transactionTime)
 	return bbc.getBundleData("/ExplanationOfBenefit/", params, jobID, cmsID)
 }

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -220,14 +220,14 @@ func (s *BBRequestTestSuite) TestGetCoverage_500() {
 }
 
 func (s *BBRequestTestSuite) TestGetExplanationOfBenefit() {
-	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now)
+	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now, time.Time{})
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 33, len(e.Entries))
 	assert.Equal(s.T(), "carrier-10525061996", e.Entries[3]["resource"].(map[string]interface{})["id"])
 }
 
 func (s *BBRequestTestSuite) TestGetExplanationOfBenefit_500() {
-	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now)
+	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now, time.Time{})
 	assert.Regexp(s.T(), `blue button request .+ failed \d+ time\(s\)`, err.Error())
 	assert.Nil(s.T(), e)
 }
@@ -289,7 +289,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		{
 			"GetExplanationOfBenefit",
 			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, since, now)
+				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, since, now, time.Time{})
 			},
 			func(t *testing.T, payload interface{}) {
 				result, ok := payload.(*models.Bundle)
@@ -305,7 +305,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		{
 			"GetExplanationOfBenefitNoSince",
 			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, "", now)
+				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, "", now, time.Time{})
 			},
 			func(t *testing.T, payload interface{}) {
 				result, ok := payload.(*models.Bundle)

--- a/bcda/testUtils/client.go
+++ b/bcda/testUtils/client.go
@@ -19,7 +19,7 @@ type BlueButtonClient struct {
 }
 
 func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime, serviceDate time.Time) (*models.Bundle, error) {
-	args := bbc.Called(patientID)
+	args := bbc.Called(patientID, jobID, cmsID, since, transactionTime, serviceDate)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -32,12 +32,12 @@ func (bbc *BlueButtonClient) GetPatientByIdentifierHash(hashedIdentifier string)
 }
 
 func (bbc *BlueButtonClient) GetPatient(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
-	args := bbc.Called(patientID)
+	args := bbc.Called(patientID, jobID, cmsID, since, transactionTime)
 	return args.Get(0).(*models.Bundle), args.Error(1)
 }
 
 func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
-	args := bbc.Called(beneficiaryID)
+	args := bbc.Called(beneficiaryID, jobID, cmsID, since, transactionTime)
 	return args.Get(0).(*models.Bundle), args.Error(1)
 }
 

--- a/bcda/testUtils/client.go
+++ b/bcda/testUtils/client.go
@@ -32,12 +32,12 @@ func (bbc *BlueButtonClient) GetPatientByIdentifierHash(hashedIdentifier string)
 }
 
 func (bbc *BlueButtonClient) GetPatient(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
-	args := bbc.Called(patientID, jobID, cmsID)
+	args := bbc.Called(patientID)
 	return args.Get(0).(*models.Bundle), args.Error(1)
 }
 
 func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
-	args := bbc.Called(beneficiaryID, jobID, cmsID)
+	args := bbc.Called(beneficiaryID)
 	return args.Get(0).(*models.Bundle), args.Error(1)
 }
 

--- a/bcda/testUtils/client.go
+++ b/bcda/testUtils/client.go
@@ -18,7 +18,7 @@ type BlueButtonClient struct {
 	MBI  *string
 }
 
-func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
+func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime, serviceDate time.Time) (*models.Bundle, error) {
 	args := bbc.Called(patientID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -21,10 +21,6 @@ func PrintSeparator() {
 }
 
 func CreateStaging(jobID int) {
-	err := os.Setenv("FHIR_STAGING_DIR", "data/test")
-	if err != nil {
-		log.Panic(err)
-	}
 	testdir := fmt.Sprintf("%s/%d", os.Getenv("FHIR_STAGING_DIR"), jobID)
 
 	if _, err := os.Stat(testdir); os.IsNotExist(err) {

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -20,12 +20,12 @@ func PrintSeparator() {
 	fmt.Println("**********************************************************************************")
 }
 
-func CreateStaging(jobID string) {
+func CreateStaging(jobID int) {
 	err := os.Setenv("FHIR_STAGING_DIR", "data/test")
 	if err != nil {
 		log.Panic(err)
 	}
-	testdir := fmt.Sprintf("%s/%s", os.Getenv("FHIR_STAGING_DIR"), jobID)
+	testdir := fmt.Sprintf("%s/%d", os.Getenv("FHIR_STAGING_DIR"), jobID)
 
 	if _, err := os.Stat(testdir); os.IsNotExist(err) {
 		err = os.MkdirAll(testdir, os.ModePerm)

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -20,17 +20,6 @@ func PrintSeparator() {
 	fmt.Println("**********************************************************************************")
 }
 
-func CreateStaging(jobID int) {
-	testdir := fmt.Sprintf("%s/%d", os.Getenv("FHIR_STAGING_DIR"), jobID)
-
-	if _, err := os.Stat(testdir); os.IsNotExist(err) {
-		err = os.MkdirAll(testdir, os.ModePerm)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-}
-
 func RandomHexID() string {
 	b, err := someRandomBytes(4)
 	if err != nil {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -142,7 +142,7 @@ func processJob(j *que.Job) error {
 		return err
 	}
 
-	fileUUID, err := writeBBDataToFile(ctx, bb, db, jobArgs.ACOID, *aco.CMSID, jobArgs.BeneficiaryIDs, jobID, jobArgs.ResourceType, jobArgs.Since, jobArgs.TransactionTime)
+	fileUUID, err := writeBBDataToFile(ctx, bb, db, *aco.CMSID, jobArgs)
 	fileName := fileUUID + ".ndjson"
 
 	// This is only run AFTER completion of all the collection
@@ -181,7 +181,8 @@ func createDir(path string) error {
 	return nil
 }
 
-func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, acoID string, acoCMSID string, cclfBeneficiaryIDs []string, jobID, t, since string, transactionTime time.Time) (fileUUID string, error error) {
+// func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, acoID string, acoCMSID string, cclfBeneficiaryIDs []string, jobID, t, since string, transactionTime time.Time) (fileUUID string, error error) {
+func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, cmsID string, jobArgs models.JobEnqueueArgs) (fileUUID string, err error) {
 	segment := getSegment(ctx, "writeBBDataToFile")
 	defer func() {
 		if err := segment.End(); err != nil {
@@ -189,28 +190,27 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, ac
 		}
 	}()
 
-	if bb == nil {
-		err := errors.New("Blue Button client is required")
-		log.Error(err)
-		return "", err
-	}
-
-	bbFunc := bbFuncByType(bb, t)
-	if bbFunc == nil {
-		err := fmt.Errorf("Invalid resource type requested: %s", t)
-		log.Error(err)
-		return "", err
-	}
-
-	if !utils.IsUUID(acoID) {
-		err := errors.New("Invalid ACO ID")
-		log.Error(err)
-		return "", err
+	var bbFunc func(bbID string) (*fhirmodels.Bundle, error)
+	switch jobArgs.ResourceType {
+	case "Coverage":
+		bbFunc = func(bbID string) (*fhirmodels.Bundle, error) {
+			return bb.GetCoverage(bbID, strconv.Itoa(jobArgs.ID), cmsID, jobArgs.Since, jobArgs.TransactionTime)
+		}
+	case "ExplanationOfBenefit":
+		bbFunc = func(bbID string) (*fhirmodels.Bundle, error) {
+			return bb.GetExplanationOfBenefit(bbID, strconv.Itoa(jobArgs.ID), cmsID, jobArgs.Since, jobArgs.TransactionTime, jobArgs.ServiceDate)
+		}
+	case "Patient":
+		bbFunc = func(bbID string) (*fhirmodels.Bundle, error) {
+			return bb.GetCoverage(bbID, strconv.Itoa(jobArgs.ID), cmsID, jobArgs.Since, jobArgs.TransactionTime)
+		}
+	default:
+		return "", fmt.Errorf("unsupported resource type %s", jobArgs.ResourceType)
 	}
 
 	dataDir := os.Getenv("FHIR_STAGING_DIR")
-	fileUUID = uuid.NewRandom().String()
-	f, err := os.Create(fmt.Sprintf("%s/%s/%s.ndjson", dataDir, jobID, fileUUID))
+	fileUUID = uuid.New()
+	f, err := os.Create(fmt.Sprintf("%s/%d/%s.ndjson", dataDir, jobArgs.ID, fileUUID))
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -220,21 +220,23 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, ac
 
 	w := bufio.NewWriter(f)
 	errorCount := 0
-	totalBeneIDs := float64(len(cclfBeneficiaryIDs))
+	totalBeneIDs := float64(len(jobArgs.BeneficiaryIDs))
 	failThreshold := getFailureThreshold()
 	failed := false
 
-	for _, cclfBeneficiaryID := range cclfBeneficiaryIDs {
-		blueButtonID, err := beneBBID(cclfBeneficiaryID, bb, db)
+	for _, beneID := range jobArgs.BeneficiaryIDs {
+		blueButtonID, err := beneBBID(beneID, bb, db)
 
 		if err != nil {
-			handleBBError(ctx, err, &errorCount, fileUUID, fmt.Sprintf("Error retrieving BlueButton ID for cclfBeneficiary %s", cclfBeneficiaryID), jobID)
+			handleBBError(ctx, err, &errorCount, fileUUID, fmt.Sprintf("Error retrieving BlueButton ID for cclfBeneficiary %s", beneID), jobArgs.ID)
 		} else {
-			b, err := bbFunc(blueButtonID, jobID, acoCMSID, since, transactionTime)
+			b, err := bbFunc(blueButtonID)
 			if err != nil {
-				handleBBError(ctx, err, &errorCount, fileUUID, fmt.Sprintf("Error retrieving %s for beneficiary %s in ACO %s", t, blueButtonID, acoID), jobID)
+				handleBBError(ctx, err, &errorCount, fileUUID,
+					fmt.Sprintf("Error retrieving %s for beneficiary %s in ACO %s", jobArgs.ResourceType, blueButtonID, jobArgs.ACOID),
+					jobArgs.ID)
 			} else {
-				fhirBundleToResourceNDJSON(ctx, w, b, t, cclfBeneficiaryID, acoCMSID, jobID, fileUUID)
+				fhirBundleToResourceNDJSON(ctx, w, b, jobArgs.ResourceType, beneID, cmsID, fileUUID, jobArgs.ID)
 			}
 		}
 		failPct := (float64(errorCount) / totalBeneIDs) * 100
@@ -244,8 +246,7 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, ac
 		}
 	}
 
-	err = w.Flush()
-	if err != nil {
+	if err = w.Flush(); err != nil {
 		return "", err
 	}
 
@@ -254,14 +255,6 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, ac
 	}
 
 	return fileUUID, nil
-}
-
-func bbFuncByType(bb client.APIClient, t string) client.BeneDataFunc {
-	return map[string]client.BeneDataFunc{
-		"ExplanationOfBenefit": bb.GetExplanationOfBenefit,
-		"Patient":              bb.GetPatient,
-		"Coverage":             bb.GetCoverage,
-	}[t]
 }
 
 // beneBBID returns the beneficiary's Blue Button ID. The ID value is retrieved from BB and saved.
@@ -282,7 +275,7 @@ func beneBBID(cclfBeneID string, bb client.APIClient, db *gorm.DB) (string, erro
 	return bbID, nil
 }
 
-func handleBBError(ctx context.Context, err error, errorCount *int, fileUUID, msg, jobID string) {
+func handleBBError(ctx context.Context, err error, errorCount *int, fileUUID, msg string, jobID int) {
 	log.Error(err)
 	(*errorCount)++
 	appendErrorToFile(ctx, fileUUID, responseutils.Exception, responseutils.BbErr, msg, jobID)
@@ -301,7 +294,7 @@ func getFailureThreshold() float64 {
 	return float64(exportFailPct)
 }
 
-func appendErrorToFile(ctx context.Context, fileUUID, code, detailsCode, detailsDisplay string, jobID string) {
+func appendErrorToFile(ctx context.Context, fileUUID, code, detailsCode, detailsDisplay string, jobID int) {
 	segment := getSegment(ctx, "appendErrorToFile")
 	defer func() {
 		if err := segment.End(); err != nil {
@@ -312,7 +305,7 @@ func appendErrorToFile(ctx context.Context, fileUUID, code, detailsCode, details
 	oo := responseutils.CreateOpOutcome(responseutils.Error, code, detailsCode, detailsDisplay)
 
 	dataDir := os.Getenv("FHIR_STAGING_DIR")
-	fileName := fmt.Sprintf("%s/%s/%s-error.ndjson", dataDir, jobID, fileUUID)
+	fileName := fmt.Sprintf("%s/%d/%s-error.ndjson", dataDir, jobID, fileUUID)
 	/* #nosec -- opening file defined by variable */
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 
@@ -332,7 +325,7 @@ func appendErrorToFile(ctx context.Context, fileUUID, code, detailsCode, details
 	}
 }
 
-func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, jobID, fileUUID string) {
+func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, fileUUID string, jobID int) {
 	segment := getSegment(ctx, "fhirBundleToResourceNDJSON")
 	defer func() {
 		if err := segment.End(); err != nil {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -202,7 +202,7 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, cm
 		}
 	case "Patient":
 		bbFunc = func(bbID string) (*fhirmodels.Bundle, error) {
-			return bb.GetCoverage(bbID, strconv.Itoa(jobArgs.ID), cmsID, jobArgs.Since, jobArgs.TransactionTime)
+			return bb.GetPatient(bbID, strconv.Itoa(jobArgs.ID), cmsID, jobArgs.Since, jobArgs.TransactionTime)
 		}
 	default:
 		return "", fmt.Errorf("unsupported resource type %s", jobArgs.ResourceType)


### PR DESCRIPTION
### Fixes [BCDA-3722](https://jira.cms.gov/browse/BCDA-3722)

Updates bcdaworker to use the serviceDate filter when querying from BFD.

### Change Details

1. Update bcdaworker and bb client to use the JobEnqueueArgs#ServiceDate parameter. When the field is set, we will query BFD with `service-date=le<SERVICE_DATE>`. See [RFC](https://github.com/CMSgov/beneficiary-fhir-data/blob/master/rfcs/0007-service-date-filter.md) for more details.
2. Consolidate bcda worker test setup into SetupSuite()/SetupTest()

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [x] new data stored or transmitted

This PR will leverage service-date query parameter.

- [x] security checklist is completed for this change

[Security checklist](https://confluence.cms.gov/display/BCDA/20-10-16%3A+Service+Date+Filter+Implementation+Security+Checklist) for service-date filter implementation.

- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. CI Passes. Added unit tests to verify the service date parameter is passed in as expected.

We have a follow up [ticket](https://jira.cms.gov/browse/BCDA-3870) to implement smoke tests that will verify this behavior. 

