### PR TITLE
BCDA-3582 - expect a 404 error if v2 endpoints are disabled

### DIFF
--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "db43685f-537c-44b8-b35b-54e67e71e11d",
+		"_postman_id": "c262bae4-4b78-4efa-a98d-ae2097916b2d",
 		"name": "Beneficiary Claims Data API Tests, Sequential",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -11,7 +11,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "ad63b716-3407-4006-9e75-64f2a50a8e40",
+						"id": "e1aca00f-2d0d-4a40-af84-ddca0a3d4ea8",
 						"exec": [
 							"pm.test(\"Response contains version\", function() {",
 							"    pm.expect(pm.response.json()).to.have.property(\"version\");",
@@ -44,7 +44,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "cf32d8c9-5dea-4e61-b656-334ac2d1e233",
+						"id": "7ad153eb-6b5d-41fe-9067-849d0e868400",
 						"exec": [
 							"pm.test(\"Response time is less than 200 ms\", function() {",
 							"    pm.expect(pm.response.responseTime).to.be.below(200);",
@@ -145,7 +145,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "21248982-329c-4980-9c08-f53f73ab98b3",
+						"id": "3d9ce781-4e5e-4042-91ac-ea1c4bb1e92e",
 						"exec": [
 							"pm.test(\"Response contains database status\", function() {",
 							"    pm.expect(pm.response.json()).to.have.property(\"database\");",
@@ -177,7 +177,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "6c95f79e-c7de-4e64-9baf-db77f12e9e64",
+						"id": "b2b406db-fd6f-4144-b49a-fcd1271ef6a1",
 						"exec": [
 							"pm.test(\"Status code is 401\", function() {",
 							"    pm.response.to.have.status(401);",
@@ -243,7 +243,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "2737091f-d971-4dc1-85a2-0083654b89a9",
+						"id": "57d9f83d-6bac-4daa-bd44-6fd41eb9b129",
 						"exec": [
 							"pm.test(\"Status code is 401\", function() {",
 							"    pm.response.to.have.status(401);",
@@ -308,7 +308,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "98e3c47f-e962-4b19-8ca9-052aff6bbb20",
+						"id": "748a2b4d-e4e4-4a92-b980-ada55f1ea4f6",
 						"exec": [
 							"pm.test(\"Status code is 401\", function() {",
 							"    pm.response.to.have.status(401);",
@@ -373,7 +373,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "065e1f80-a88f-4cff-a821-313c4dfe3142",
+						"id": "0428f43c-69ca-409c-a722-ed0f19b1f3b3",
 						"exec": [
 							"pm.test(\"Status code is 401\", function() {",
 							"    pm.response.to.have.status(401);",
@@ -429,7 +429,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "5ebf033f-781a-48d8-86fd-87ba3c65f778",
+						"id": "35274aca-3bad-46fd-9efd-cbdc598746c3",
 						"exec": [
 							"pm.test(\"Status code is 401\", function() {",
 							"    pm.response.to.have.status(401);",
@@ -471,7 +471,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "cbe9f997-6868-4484-8c0c-bb1d8e45a968",
+						"id": "2b6295dc-c9ab-4646-b1ee-4997f6d635a2",
 						"exec": [
 							"var env = pm.environment.get(\"env\");",
 							"pm.environment.set(\"clientId\", pm.globals.get(\"clientId\"));",
@@ -546,7 +546,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "7935c03d-2792-4df1-96f6-86b37b16ebdc",
+						"id": "4d8e7bac-f8ca-4445-b52c-0eee58dd857d",
 						"exec": [
 							"pm.test(\"Status code is 202\", function() {",
 							"    pm.response.to.have.status(202);",
@@ -614,7 +614,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "2e864853-8291-4894-81ef-477934a972fa",
+						"id": "097845d4-c463-4716-9e22-114662cbd7b0",
 						"exec": [
 							"pm.test(\"Status code is 202\", function() {",
 							"    pm.response.to.have.status(202);",
@@ -682,8 +682,17 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "08a99c52-1136-4249-a6ad-dfa088acd289",
+						"id": "b5dfe937-cdb2-4a09-a955-24b4700e99d2",
 						"exec": [
+							"var v2Disabled = pm.globals.get(\"v2Disabled\") == \"true\"",
+							"",
+							"if (v2Disabled) {",
+							"    pm.test(\"Status code is 404\", function() {",
+							"        pm.response.to.have.status(404);",
+							"    });",
+							"    return;",
+							"}",
+							"",
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
 							"});",
@@ -758,7 +767,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "aa788d60-8e40-4df2-9230-c173483b22b2",
+						"id": "c0c88838-95b1-4043-aa51-b0fa92ab2431",
 						"exec": [
 							"pm.test(\"Status code is 202\", function() {",
 							"    pm.response.to.have.status(202);",
@@ -826,8 +835,17 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "4709c84e-961e-47a2-a23f-0f8532cff68d",
+						"id": "22648c0a-3b2f-4a09-943e-8fbd9db98e48",
 						"exec": [
+							"var v2Disabled = pm.globals.get(\"v2Disabled\") == \"true\"",
+							"",
+							"if (v2Disabled) {",
+							"    pm.test(\"Status code is 404\", function() {",
+							"        pm.response.to.have.status(404);",
+							"    });",
+							"    return;",
+							"}",
+							"",
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
 							"});",
@@ -902,8 +920,17 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "cb3525b2-6f51-432a-8dc6-85c08c74fca3",
+						"id": "d3bc9a5c-dc75-41b1-a745-6c7eb15de213",
 						"exec": [
+							"var v2Disabled = pm.globals.get(\"v2Disabled\") == \"true\"",
+							"",
+							"if (v2Disabled) {",
+							"    pm.test(\"Status code is 404\", function() {",
+							"        pm.response.to.have.status(404);",
+							"    });",
+							"    return;",
+							"}",
+							"",
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
 							"});",
@@ -972,7 +999,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "d7b2d57d-fb2b-4781-93c0-c3ae6134d34f",
+						"id": "02fe915e-0f66-4abd-8099-82db59c3b4d0",
 						"exec": [
 							"pm.test(\"Status code is 202 or 200\", function() {",
 							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
@@ -1018,7 +1045,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "2a07159b-13db-454d-bbfe-d2383fc863ec",
+						"id": "a8e3ff19-f1a8-430d-ab53-10c59ab39ded",
 						"exec": [
 							"const retryDelay = 5000;",
 							"const maxRetries = 10;",
@@ -1101,7 +1128,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "fb909a1d-a267-4cc0-83f4-d4ecb2bcae01",
+						"id": "62021b11-873b-4791-998f-cebde558021a",
 						"exec": [
 							"pm.test(\"Status code is 200\", function() {",
 							"    pm.response.to.have.status(200);",
@@ -1143,7 +1170,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "f34cd3b5-0983-48ee-86a3-4d6059209cd2",
+						"id": "5b64355a-2667-42a2-8ae9-b7ad6020356f",
 						"exec": [
 							"pm.test(\"Status code is 202 or 200\", function() {",
 							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
@@ -1189,7 +1216,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "1a844bf4-5d09-4d8a-b601-8a9aaf390648",
+						"id": "2af45c38-0689-4788-a349-ed695135042e",
 						"exec": [
 							"const retryDelay = 5000;",
 							"const maxRetries = 10;",
@@ -1272,7 +1299,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "88db4208-46c8-4c37-881d-10110c270450",
+						"id": "440a1c9c-ad96-4b3c-b802-2872e91a6c01",
 						"exec": [
 							"pm.test(\"Status code is 200\", function() {",
 							"    pm.response.to.have.status(200);",
@@ -1314,7 +1341,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "bd4efbcf-03a2-47fd-b033-c9c840acebe1",
+						"id": "e04f3bc9-11a0-42eb-a17b-611466acd735",
 						"exec": [
 							"pm.test(\"Status code is 202 or 200\", function() {",
 							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
@@ -1360,7 +1387,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "eb587463-5310-4615-b001-df40a1448483",
+						"id": "b689a189-aec0-4462-92be-ff047f80a433",
 						"exec": [
 							"const retryDelay = 5000;",
 							"const maxRetries = 10;",
@@ -1443,7 +1470,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "1f6eecb5-134f-411a-8897-c18b892bb909",
+						"id": "3f580e70-1b1c-4931-8192-a93b5eedc805",
 						"exec": [
 							"pm.test(\"Status code is 200\", function() {",
 							"    pm.response.to.have.status(200);",
@@ -1485,7 +1512,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "7e0e5505-e379-43c9-8d6b-e8569e21a08c",
+						"id": "c77637dc-0920-4e9a-84e3-c5c4bfd30f90",
 						"exec": [
 							"pm.test(\"Status code is 202\", function() {",
 							"    pm.response.to.have.status(202);",
@@ -1503,7 +1530,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "da4ac209-ca87-4e0f-b823-01e40c11aa19",
+						"id": "5ac0f0b0-299c-47e5-9676-6b72c60670a5",
 						"exec": [
 							"let timestamp = new Date().toJSON();",
 							"pm.environment.set('now', timestamp);"
@@ -1568,7 +1595,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "5c34fc63-f25a-4ffa-a0b7-04d3847ff3e1",
+						"id": "dfa1e243-587c-4d04-b235-a3932513c363",
 						"exec": [
 							"pm.test(\"Status code is 202 or 200\", function() {",
 							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
@@ -1614,7 +1641,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "2d2c8e70-6ec8-4cca-900f-634876c76d04",
+						"id": "7c2e87c1-ab3b-4ae9-9dea-453908426c1e",
 						"exec": [
 							"const retryDelay = 5000;",
 							"const maxRetries = 10;",
@@ -1697,7 +1724,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "6b933f11-e1f1-4f56-a08b-2299f7f459e1",
+						"id": "7fd1fe61-3ab1-43be-afca-ac9950499633",
 						"exec": [
 							"pm.test(\"Status code is 200\", function() {",
 							"    pm.response.to.have.status(200);",
@@ -1739,7 +1766,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "13fb9a6b-b123-47dc-9efa-4575133d9cdc",
+						"id": "ac1cc9db-8da7-470b-b8c1-f7099e80cba9",
 						"exec": [
 							"pm.test(\"Status code is 202\", function() {",
 							"    pm.response.to.have.status(202);",
@@ -1808,7 +1835,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "fed50408-6e12-472e-af26-91c5b3adf6b8",
+						"id": "faaaa1fd-a74c-41b9-9659-2416692eec7a",
 						"exec": [
 							"pm.test(\"Status code is 202 or 200\", function() {",
 							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
@@ -1863,7 +1890,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "cb75c696-749e-4240-9bea-47afaedcafeb",
+						"id": "3336b61c-c969-463f-93c3-66813ed19ec3",
 						"exec": [
 							"const retryDelay = 5000;",
 							"const maxRetries = 10;",
@@ -1946,7 +1973,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "b6dc4367-f725-4397-9ba1-5ade0a49f7b2",
+						"id": "84145c1b-02f4-4bc8-a34a-b0378944c993",
 						"exec": [
 							"pm.test(\"Status code is 200\", function() {",
 							"    pm.response.to.have.status(200);",
@@ -1990,7 +2017,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "bb96c9d3-14c6-4a78-993c-643b75f25f04",
+						"id": "e76f26f4-a642-4aba-84dd-4dd90409e0c2",
 						"exec": [
 							"pm.test(\"Status code is 202\", function() {",
 							"    pm.response.to.have.status(202);",
@@ -2063,7 +2090,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "931f74a6-9b24-4f0a-bea9-ab466295d46c",
+						"id": "754e8d35-8e6e-4196-86f4-d7366bfef12d",
 						"exec": [
 							"pm.test(\"Status code is 202 or 200\", function() {",
 							"     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
@@ -2121,7 +2148,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "d1c0c9bd-526b-423c-9d65-4122ae236ada",
+						"id": "c0a6ae41-0eac-4990-8c25-34c882f14a14",
 						"exec": [
 							"const retryDelay = 5000;",
 							"const maxRetries = 10;",
@@ -2204,7 +2231,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "24f5f59f-3383-442a-ad92-0f057b606309",
+						"id": "e6c36a7c-7621-4203-9e4e-38dd4664a414",
 						"exec": [
 							"pm.test(\"Status code is 200\", function() {",
 							"    pm.response.to.have.status(200);",
@@ -2249,7 +2276,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "58b41ccd-4e9f-4ac0-b654-24dfe0eba48c",
+						"id": "648630b5-52ad-42de-abca-b5c70d4957bc",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2325,7 +2352,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "a6405fe6-cb76-405b-aa5b-203783d22aeb",
+						"id": "64f5f622-4144-4c1d-b508-cd1219098566",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2401,7 +2428,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "1194fa6c-cc8d-43dc-a888-03685039dac2",
+						"id": "d581eaca-c9ae-4ad0-bb62-63364cec9427",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2478,7 +2505,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "9cefcc0e-cf56-4306-96a5-0c21642e574e",
+						"id": "7b487259-16fa-47b8-a25f-dc1350f39aa4",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2555,7 +2582,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "32de5b7b-76dd-43f8-84db-8d53bf971449",
+						"id": "02f37336-3d70-44b1-a998-753656562f07",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2632,7 +2659,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "aae3e6db-2659-46b1-82db-b13dc6ccccaf",
+						"id": "cecbc3d2-ad08-4b7f-b12b-0a8d22c7e9cc",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2708,7 +2735,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "143f154f-0b03-4302-806e-772a7584f26e",
+						"id": "c48040ca-ba40-4714-8603-ea880115df38",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2785,7 +2812,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "3e2beb21-78b7-473e-a5ce-0f4181714a07",
+						"id": "cb59346a-1194-49dd-9335-8c920658d611",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",
@@ -2861,7 +2888,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "937d20d8-0b5a-4a2d-98db-50c25dec6e06",
+						"id": "8cf9ee19-c0bc-4aa7-a7f9-3324f751c167",
 						"exec": [
 							"pm.test(\"Status code is 400\", function() {",
 							"    pm.response.to.have.status(400);",


### PR DESCRIPTION
### Fixes issue introduced by [BCDA-3582](https://jira.cms.gov/browse/BCDA-3582)

If we have the v2 endpoints disabled, we should expect to see a 404 not found error.

### Change Details

Introduce new global variable `v2Disabled` that will alter the expected response code.

Decided to introduce a new variable instead of leveraging the env variable. bcda-api is not aware of what environments have v2 enabled or disabled. By introducing a new variable, we can keep that information at the ops/deployment side.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation

1. Ran [smoke test in prod environment](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/2545/) and verified postman tests pass with the expectation of the 404 error.
2. Ran [smoke tests in dev environment](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/2546/) and verified postman tests pass with the expectation of the 400 error.
