### PR TITLE
BCDA-3970 - Fix race condition uncovered in bluebutton.go

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -315,17 +315,6 @@ func (bbc *BlueButtonClient) getRawData(u *url.URL) (string, error) {
 	return result, nil
 }
 
-func (bbc *BlueButtonClient) getRequest(path string, params url.Values) (*http.Request, error) {
-	req, err := http.NewRequest("GET", bbc.bbServer+bbc.bbBasePath+path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.URL.RawQuery = params.Encode()
-
-	return req, nil
-}
-
 func (bbc *BlueButtonClient) getURL(path string, params url.Values) (*url.URL, error) {
 	u, err := url.Parse(fmt.Sprintf("%s%s/%s/", bbc.bbServer, bbc.bbBasePath, path))
 	if err != nil {

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -139,7 +139,13 @@ func (bbc *BlueButtonClient) GetPatient(patientID, jobID, cmsID, since string, t
 	params := GetDefaultParams()
 	params.Set("_id", patientID)
 	updateParamWithLastUpdated(&params, since, transactionTime)
-	return bbc.getBundleData("/Patient/", params, jobID, cmsID, header)
+
+	u, err := bbc.getURL("Patient", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return bbc.getBundleData(u, jobID, cmsID, header)
 }
 
 func (bbc *BlueButtonClient) GetPatientByIdentifierHash(hashedIdentifier string) (string, error) {
@@ -147,14 +153,26 @@ func (bbc *BlueButtonClient) GetPatientByIdentifierHash(hashedIdentifier string)
 
 	// FHIR spec requires a FULLY qualified namespace so this is in fact the argument, not a URL
 	params.Set("identifier", fmt.Sprintf("https://bluebutton.cms.gov/resources/identifier/%s|%v", "mbi-hash", hashedIdentifier))
-	return bbc.getRawData("/Patient/", params, "", "")
+
+	u, err := bbc.getURL("Patient", params)
+	if err != nil {
+		return "", err
+	}
+
+	return bbc.getRawData(u)
 }
 
 func (bbc *BlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
 	params := GetDefaultParams()
 	params.Set("beneficiary", beneficiaryID)
 	updateParamWithLastUpdated(&params, since, transactionTime)
-	return bbc.getBundleData("/Coverage/", params, jobID, cmsID, nil)
+
+	u, err := bbc.getURL("Coverage", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return bbc.getBundleData(u, jobID, cmsID, nil)
 }
 
 func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime, serviceDate time.Time) (*models.Bundle, error) {
@@ -170,28 +188,28 @@ func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, si
 		params.Set("service-date", fmt.Sprintf("le%s", serviceDate.Format(svcDateFmt)))
 	}
 	updateParamWithLastUpdated(&params, since, transactionTime)
-	return bbc.getBundleData("/ExplanationOfBenefit/", params, jobID, cmsID, nil)
-}
 
-func (bbc *BlueButtonClient) GetMetadata() (string, error) {
-	return bbc.getRawData("/metadata/", GetDefaultParams(), "", "")
-}
-
-func (bbc *BlueButtonClient) getBundleData(path string, params url.Values, jobID, cmsID string, headers http.Header) (*models.Bundle, error) {
-	req, err := bbc.getRequest(path, params)
+	u, err := bbc.getURL("ExplanationOfBenefit", params)
 	if err != nil {
 		return nil, err
 	}
 
-	for key, values := range headers {
-		for _, value := range values {
-			req.Header.Add(key, value)
-		}
+	return bbc.getBundleData(u, jobID, cmsID, nil)
+}
+
+func (bbc *BlueButtonClient) GetMetadata() (string, error) {
+	u, err := bbc.getURL("metadata", GetDefaultParams())
+	if err != nil {
+		return "", err
 	}
 
+	return bbc.getRawData(u)
+}
+
+func (bbc *BlueButtonClient) getBundleData(u *url.URL, jobID, cmsID string, headers http.Header) (*models.Bundle, error) {
 	var b *models.Bundle
 	for ok := true; ok; {
-		result, nextReq, err := bbc.tryBundleRequest(req, jobID, cmsID)
+		result, nextURL, err := bbc.tryBundleRequest(u, jobID, cmsID, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -202,24 +220,21 @@ func (bbc *BlueButtonClient) getBundleData(path string, params url.Values, jobID
 			b.Entries = append(b.Entries, result.Entries...)
 		}
 
-		req = nextReq
-		ok = nextReq != nil
+		u = nextURL
+		ok = nextURL != nil
 	}
 
 	return b, nil
 }
 
-func (bbc *BlueButtonClient) tryBundleRequest(req *http.Request, jobID, cmsID string) (*models.Bundle, *http.Request, error) {
+func (bbc *BlueButtonClient) tryBundleRequest(u *url.URL, jobID, cmsID string, headers http.Header) (*models.Bundle, *url.URL, error) {
 	m := monitoring.GetMonitor()
-	txn := m.Start(req.URL.Path, nil, nil)
+	txn := m.Start(u.Path, nil, nil)
 	defer m.End(txn)
-
-	queryID := uuid.NewRandom()
-	addRequestHeaders(req, queryID, jobID, cmsID)
 
 	var (
 		result  *models.Bundle
-		nextReq *http.Request
+		nextURL *url.URL
 		err     error
 	)
 
@@ -228,7 +243,22 @@ func (bbc *BlueButtonClient) tryBundleRequest(req *http.Request, jobID, cmsID st
 	b := backoff.WithMaxRetries(eb, bbc.maxTries)
 
 	err = backoff.RetryNotify(func() error {
-		result, nextReq, err = bbc.client.DoBundleRequest(req)
+		req, err := http.NewRequest("GET", u.String(), nil)
+		if err != nil {
+			logger.Error(err)
+			return err
+		}
+
+		for key, values := range headers {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+
+		queryID := uuid.NewRandom()
+		addRequestHeaders(req, queryID, jobID, cmsID)
+
+		result, nextURL, err = bbc.client.DoBundleRequest(req)
 		if err != nil {
 			logger.Error(err)
 		}
@@ -236,29 +266,21 @@ func (bbc *BlueButtonClient) tryBundleRequest(req *http.Request, jobID, cmsID st
 	},
 		b,
 		func(err error, d time.Duration) {
-			logger.Infof("Blue Button request %s failed %s. Retry in %s ms...", queryID, err.Error(), d.String())
+			logger.Infof("Blue Button request failed %s. Retry in %s", err.Error(), d.String())
 		},
 	)
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("blue button request %s failed %d time(s) %s", queryID, bbc.maxTries, err.Error())
+		return nil, nil, fmt.Errorf("blue button request failed %d time(s) %s", bbc.maxTries, err.Error())
 	}
 
-	return result, nextReq, nil
+	return result, nextURL, nil
 }
 
-func (bbc *BlueButtonClient) getRawData(path string, params url.Values, jobID, cmsID string) (string, error) {
+func (bbc *BlueButtonClient) getRawData(u *url.URL) (string, error) {
 	m := monitoring.GetMonitor()
-	txn := m.Start(path, nil, nil)
+	txn := m.Start(u.Path, nil, nil)
 	defer m.End(txn)
-
-	req, err := bbc.getRequest(path, params)
-	if err != nil {
-		return "", err
-	}
-
-	queryID := uuid.NewRandom()
-	addRequestHeaders(req, queryID, jobID, cmsID)
 
 	eb := backoff.NewExponentialBackOff()
 	eb.InitialInterval = bbc.retryInterval
@@ -266,7 +288,14 @@ func (bbc *BlueButtonClient) getRawData(path string, params url.Values, jobID, c
 
 	var result string
 
-	err = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
+		req, err := http.NewRequest("GET", u.String(), nil)
+		if err != nil {
+			logger.Error(err)
+			return err
+		}
+		addRequestHeaders(req, uuid.NewRandom(), "", "")
+
 		result, err = bbc.client.DoRaw(req)
 		if err != nil {
 			logger.Error(err)
@@ -275,12 +304,12 @@ func (bbc *BlueButtonClient) getRawData(path string, params url.Values, jobID, c
 	},
 		b,
 		func(err error, d time.Duration) {
-			logger.Infof("Blue Button request %s retry in %s", queryID, d.String())
+			logger.Infof("Blue Button request failed %s. Retry in %s", err, d.String())
 		},
 	)
 
 	if err != nil {
-		return "", fmt.Errorf("blue button request %s failed %d time(s)", queryID, bbc.maxTries)
+		return "", fmt.Errorf("blue button request failed %d time(s) %s", bbc.maxTries, err.Error())
 	}
 
 	return result, nil
@@ -295,6 +324,16 @@ func (bbc *BlueButtonClient) getRequest(path string, params url.Values) (*http.R
 	req.URL.RawQuery = params.Encode()
 
 	return req, nil
+}
+
+func (bbc *BlueButtonClient) getURL(path string, params url.Values) (*url.URL, error) {
+	u, err := url.Parse(fmt.Sprintf("%s%s/%s/", bbc.bbServer, bbc.bbBasePath, path))
+	if err != nil {
+		return nil, err
+	}
+	u.RawQuery = params.Encode()
+
+	return u, nil
 }
 
 func addRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) {

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -206,7 +206,7 @@ func (s *BBRequestTestSuite) TestGetPatient() {
 
 func (s *BBRequestTestSuite) TestGetPatient_500() {
 	p, err := s.bbClient.GetPatient("012345", "543210", "A0000", "", now)
-	assert.Regexp(s.T(), `blue button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), p)
 }
 func (s *BBRequestTestSuite) TestGetCoverage() {
@@ -218,7 +218,7 @@ func (s *BBRequestTestSuite) TestGetCoverage() {
 
 func (s *BBRequestTestSuite) TestGetCoverage_500() {
 	c, err := s.bbClient.GetCoverage("012345", "543210", "A0000", since, now)
-	assert.Regexp(s.T(), `blue button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), c)
 }
 
@@ -231,7 +231,7 @@ func (s *BBRequestTestSuite) TestGetExplanationOfBenefit() {
 
 func (s *BBRequestTestSuite) TestGetExplanationOfBenefit_500() {
 	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now, time.Time{})
-	assert.Regexp(s.T(), `blue button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), e)
 }
 
@@ -244,7 +244,7 @@ func (s *BBRequestTestSuite) TestGetMetadata() {
 
 func (s *BBRequestTestSuite) TestGetMetadata_500() {
 	p, err := s.bbClient.GetMetadata()
-	assert.Regexp(s.T(), `blue button request .+ failed \d+ time\(s\)`, err.Error())
+	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get response`, err.Error())
 	assert.Equal(s.T(), "", p)
 }
 

--- a/bcda/client/fhir/client_test.go
+++ b/bcda/client/fhir/client_test.go
@@ -78,8 +78,9 @@ func TestMultipleRequestBundle(t *testing.T) {
 
 		// The partial files do not know the correct port, so we'll update the request
 		// to point to the test server
-		next.URL.Host = testHost
-		req = next
+		next.Host = testHost
+		req, err = http.NewRequest("GET", next.String(), nil)
+		assert.NoError(t, err)
 	}
 
 	assert.Equal(t, 3, r.numRequestsReceived)


### PR DESCRIPTION
### Fixes [BCDA-3970](https://jira.cms.gov/browse/BCDA-3970)

We encountered the following race condition:

```
=== FAIL: bcda/api/v1 TestAPITestSuite/TestBulkConcurrentRequestTime (2.54s)
==================
WARNING: DATA RACE
Write at 0x00c000360a80 by goroutine 36:
  github.com/CMSgov/bcda-app/bcda/client/fhir.(*singleClient).DoBundleRequest()
      /go/src/github.com/CMSgov/bcda-app/bcda/client/fhir/client.go:45 +0xfe
  github.com/CMSgov/bcda-app/bcda/client.(*BlueButtonClient).tryBundleRequest.func1()
      /go/src/github.com/CMSgov/bcda-app/bcda/client/bluebutton.go:231 +0xa7
  github.com/CMSgov/bcda-app/vendor/github.com/cenkalti/backoff.RetryNotifyWithTimer()
      /go/src/github.com/CMSgov/bcda-app/vendor/github.com/cenkalti/backoff/retry.go:52 +0x2db
  github.com/CMSgov/bcda-app/vendor/github.com/cenkalti/backoff.RetryNotify()
      /go/src/github.com/CMSgov/bcda-app/vendor/github.com/cenkalti/backoff/retry.go:31 +0x466
  github.com/CMSgov/bcda-app/bcda/client.(*BlueButtonClient).tryBundleRequest()
      /go/src/github.com/CMSgov/bcda-app/bcda/client/bluebutton.go:230 +0x370
  github.com/CMSgov/bcda-app/bcda/client.(*BlueButtonClient).getBundleData()
      /go/src/github.com/CMSgov/bcda-app/bcda/client/bluebutton.go:194 +0x473
  github.com/CMSgov/bcda-app/bcda/client.(*BlueButtonClient).GetPatient()
      /go/src/github.com/CMSgov/bcda-app/bcda/client/bluebutton.go:142 +0x4de
  github.com/CMSgov/bcda-app/bcda/api.(*Handler).bulkRequest()
      /go/src/github.com/CMSgov/bcda-app/bcda/api/requests.go:236 +0xc29
  github.com/CMSgov/bcda-app/bcda/api.(*Handler).BulkPatientRequest()
      /go/src/github.com/CMSgov/bcda-app/bcda/api/requests.go:90 +0xd9
  github.com/CMSgov/bcda-app/bcda/api/v1.BulkPatientRequest()
      /go/src/github.com/CMSgov/bcda-app/bcda/api/v1/api.go:55 +0x84
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2042 +0x1181
  github.com/CMSgov/bcda-app/bcda/api/v1.bulkConcurrentRequestTimeHelper()
      /go/src/github.com/CMSgov/bcda-app/bcda/api/v1/api_test.go:473 +0x113a
  github.com/CMSgov/bcda-app/bcda/api/v1.(*APITestSuite).TestBulkConcurrentRequestTime()
      /go/src/github.com/CMSgov/bcda-app/bcda/api/v1/api_test.go:179 +0x51
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:540 +0x3d
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:336 +0xd8
  github.com/CMSgov/bcda-app/vendor/github.com/stretchr/testify/suite.Run.func2()
      /go/src/github.com/CMSgov/bcda-app/vendor/github.com/stretchr/testify/suite/suite.go:102 +0x2ee
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1108 +0x202

Previous read at 0x00c000360a80 by goroutine 103:
  net/url.(*URL).RequestURI()
      /usr/local/go/src/net/url/url.go:1101 +0x13b
  net/http.(*Request).write()
      /usr/local/go/src/net/http/request.go:570 +0x1b2
  net/http.(*persistConn).writeLoop()
      /usr/local/go/src/net/http/transport.go:2343 +0x349

Goroutine 36 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1159 +0x796
  github.com/CMSgov/bcda-app/vendor/github.com/stretchr/testify/suite.runTests()
      /go/src/github.com/CMSgov/bcda-app/vendor/github.com/stretchr/testify/suite/suite.go:121 +0xe3
  github.com/CMSgov/bcda-app/vendor/github.com/stretchr/testify/suite.Run()
      /go/src/github.com/CMSgov/bcda-app/vendor/github.com/stretchr/testify/suite/suite.go:108 +0x674
  github.com/CMSgov/bcda-app/bcda/api/v1.TestAPITestSuite()
      /go/src/github.com/CMSgov/bcda-app/bcda/api/v1/api_test.go:1072 +0x5e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1108 +0x202

Goroutine 103 (finished) created at:
  net/http.(*Transport).dialConn()
      /usr/local/go/src/net/http/transport.go:1709 +0xc30
  net/http.(*Transport).dialConnFor()
      /usr/local/go/src/net/http/transport.go:1421 +0x151
==================
    testing.go:1023: race detected during execution of test
    --- FAIL: TestAPITestSuite/TestBulkConcurrentRequestTime (2.54s)

=== FAIL: bcda/api/v1 TestAPITestSuite (28.08s)
    testing.go:1023: race detected during execution of test

DONE 536 tests, 2 failures in 347.035s
make: *** [Makefile:66: unit-test] Error 1
script returned exit code 2
```

This was caused by re-using the *http.Request struct across multiple HTTP requests. We used to re-use the HTTP request in our retry loop.

### Change Details

1. Create new request object within the RetryNotify. This change resolves the uncovered race condition.
2. Update our fhir client to return a *url.URL struct. This allows us to easily create new *http.Request structs.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation
CI Passes.