### PR TITLE
bcda-3895 Feature: Remove bfd v1 fhir fallback basepath for job args

### DIFF
--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -376,7 +376,6 @@ func (s *MainTestSuite) TestProcessJobEOB() {
 		Type: "ProcessJob",
 		Args: args,
 	}
-	fmt.Println("About to queue up the job")
 	err = processJob(job)
 	assert.Nil(s.T(), err)
 	_, err = j.CheckCompletedAndCleanup(s.db)
@@ -413,7 +412,6 @@ func (s *MainTestSuite) TestProcessJob_EmptyBasePath() {
 		Type: "ProcessJob",
 		Args: args,
 	}
-	fmt.Println("About to queue up the job")
 	err = processJob(job)
 	assert.EqualError(s.T(), err, "empty BBBasePath: Must be set")
 }

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -351,45 +351,71 @@ func (s *MainTestSuite) TestAppendErrorToFile() {
 }
 
 func (s *MainTestSuite) TestProcessJobEOB() {
-	// Verifies that we can handle an empty and specified basePath
-	// TODO (BCDA-3895) - we should confirm that the job fails when we supply an empty basePath
-	for _, basePath := range []string{"", "/v1/fhir"} {
-		j := models.Job{
-			ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
-			RequestURL: "/api/v1/ExplanationOfBenefit/$export",
-			Status:     "Pending",
-			JobCount:   1,
-		}
-		s.db.Save(&j)
-
-		complete, err := j.CheckCompletedAndCleanup(s.db)
-		assert.Nil(s.T(), err)
-		assert.False(s.T(), complete)
-
-		jobArgs := models.JobEnqueueArgs{
-			ID:             int(j.ID),
-			ACOID:          j.ACOID.String(),
-			BeneficiaryIDs: []string{"10000", "11000"},
-			ResourceType:   "ExplanationOfBenefit",
-			BBBasePath:     basePath,
-		}
-		args, _ := json.Marshal(jobArgs)
-
-		job := &que.Job{
-			Type: "ProcessJob",
-			Args: args,
-		}
-		fmt.Println("About to queue up the job")
-		err = processJob(job)
-		assert.Nil(s.T(), err)
-		_, err = j.CheckCompletedAndCleanup(s.db)
-		assert.Nil(s.T(), err)
-		var completedJob models.Job
-		err = s.db.First(&completedJob, "ID = ?", jobArgs.ID).Error
-		assert.Nil(s.T(), err)
-		// As this test actually connects to BB, we can't be sure it will succeed
-		assert.Contains(s.T(), []string{"Failed", "Completed"}, completedJob.Status)
+	j := models.Job{
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
+		Status:     "Pending",
+		JobCount:   1,
 	}
+	s.db.Save(&j)
+
+	complete, err := j.CheckCompletedAndCleanup(s.db)
+	assert.Nil(s.T(), err)
+	assert.False(s.T(), complete)
+
+	jobArgs := models.JobEnqueueArgs{
+		ID:             int(j.ID),
+		ACOID:          j.ACOID.String(),
+		BeneficiaryIDs: []string{"10000", "11000"},
+		ResourceType:   "ExplanationOfBenefit",
+		BBBasePath:     "/v1/fhir",
+	}
+	args, _ := json.Marshal(jobArgs)
+
+	job := &que.Job{
+		Type: "ProcessJob",
+		Args: args,
+	}
+	fmt.Println("About to queue up the job")
+	err = processJob(job)
+	assert.Nil(s.T(), err)
+	_, err = j.CheckCompletedAndCleanup(s.db)
+	assert.Nil(s.T(), err)
+	var completedJob models.Job
+	err = s.db.First(&completedJob, "ID = ?", jobArgs.ID).Error
+	assert.Nil(s.T(), err)
+	// As this test actually connects to BB, we can't be sure it will succeed
+	assert.Contains(s.T(), []string{"Failed", "Completed"}, completedJob.Status)
+}
+
+func (s *MainTestSuite) TestProcessJob_EmptyBasePath() {
+	j := models.Job{
+		ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+		RequestURL: "/api/v1/ExplanationOfBenefit/$export",
+		Status:     "Pending",
+		JobCount:   1,
+	}
+	s.db.Save(&j)
+
+	complete, err := j.CheckCompletedAndCleanup(s.db)
+	assert.Nil(s.T(), err)
+	assert.False(s.T(), complete)
+
+	jobArgs := models.JobEnqueueArgs{
+		ID:             int(j.ID),
+		ACOID:          j.ACOID.String(),
+		BeneficiaryIDs: []string{"10000", "11000"},
+		ResourceType:   "ExplanationOfBenefit",
+	}
+	args, _ := json.Marshal(jobArgs)
+
+	job := &que.Job{
+		Type: "ProcessJob",
+		Args: args,
+	}
+	fmt.Println("About to queue up the job")
+	err = processJob(job)
+	assert.EqualError(s.T(), err, "empty BBBasePath: Must be set")
 }
 
 func (s *MainTestSuite) TestProcessJob_InvalidArgs() {

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -429,6 +429,7 @@ func (s *MainTestSuite) TestProcessJob_InvalidJobID() {
 		ACOID:          "00000000-0000-0000-0000-000000000000",
 		BeneficiaryIDs: []string{},
 		ResourceType:   "Patient",
+		BBBasePath:     "/v1/fhir",
 	})
 
 	qj := que.Job{
@@ -453,6 +454,7 @@ func (s *MainTestSuite) TestProcessJob_NoBBClient() {
 		ACOID:          j.ACOID.String(),
 		BeneficiaryIDs: []string{},
 		ResourceType:   "Patient",
+		BBBasePath:     "/v1/fhir",
 	})
 
 	qj := que.Job{
@@ -508,6 +510,7 @@ func (s *MainTestSuite) TestQueueJobWithNoParent() {
 				ACOID:          "00000000-0000-0000-0000-000000000000",
 				BeneficiaryIDs: []string{},
 				ResourceType:   "Patient",
+				BBBasePath:     "/v1/fhir",
 			})
 
 			qj := &que.Job{


### PR DESCRIPTION
### Fixes [BCDA-3895](https://jira.cms.gov/browse/BCDA-3895)

All jobs should have a `BBBasePath` set and should not need to fall back to to the `/v1/fhir/` default anymore.

### Proposed Changes

Remove fallback code for basepath and add error checking.

### Change Details

Removed the `basePath` fallback check. Added a separate test to check for that an error is raised if no `BBBasePath` arg is provided.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Tested via unittests.

### Feedback Requested

Let me know if this an ideal way to build and return an error!
