### PR TITLE
Fix runout claim thru/cutoff dates

### DIFF
--- a/bcda/models/service.go
+++ b/bcda/models/service.go
@@ -40,7 +40,9 @@ const (
 	cclf8FileNum = int(8)
 )
 
-func NewService(r Repository, cutoffDuration time.Duration, lookbackDays int, runoutCutoffDuration time.Duration, basePath string) Service {
+func NewService(r Repository, cutoffDuration time.Duration, lookbackDays int,
+	runoutCutoffDuration time.Duration, runoutClaimThru time.Time,
+	basePath string) Service {
 	return &service{
 		repository:        r,
 		logger:            log.StandardLogger(),
@@ -51,7 +53,7 @@ func NewService(r Repository, cutoffDuration time.Duration, lookbackDays int, ru
 		},
 		rp: runoutParameters{
 			// Runouts apply to claims data for the previous year.
-			claimThruDate:  time.Date(time.Now().Year()-1, time.December, 31, 23, 59, 59, 999999, time.UTC),
+			claimThruDate:  runoutClaimThru,
 			cutoffDuration: runoutCutoffDuration,
 		},
 		bbBasePath: basePath,

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -21,7 +21,10 @@ import (
 )
 
 const (
-	defaultRunoutCutoff = 120 * 24 * time.Hour
+	defaultRunoutCutoff    = 120 * 24 * time.Hour
+)
+var (
+	defaultRunoutClaimThru = time.Date(time.Now().Year()-1, time.December, 31, 23, 59, 59, 999999, time.UTC)
 )
 
 func TestSupportedACOs(t *testing.T) {
@@ -45,7 +48,7 @@ func TestSupportedACOs(t *testing.T) {
 		{"CEC invalid characters", "E999E", false},
 		{"valid CEC", "E9999", true},
 
-		{"Unregisted ACO", "Z1234", false},
+		{"Unregistered ACO", "Z1234", false},
 	}
 
 	for _, tt := range tests {
@@ -284,7 +287,7 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 			}
 			repository.On("GetSuppressedMBIs", lookbackDays).Return([]string{suppressedMBI}, nil)
 
-			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff, "").(*service)
+			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff, defaultRunoutClaimThru, "").(*service)
 			newBenes, oldBenes, err := serviceInstance.getNewAndExistingBeneficiaries("cmsID", since)
 
 			if tt.expectedErr != nil {
@@ -381,7 +384,7 @@ func (s *ServiceTestSuite) TestGetBeneficiaries() {
 				repository.On("GetCCLFBeneficiaries", tt.cclfFile.ID, []string{suppressedMBI}).Return(benes, nil)
 			}
 
-			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff, "").(*service)
+			serviceInstance := NewService(repository, 1*time.Hour, lookbackDays, defaultRunoutCutoff, defaultRunoutClaimThru, "").(*service)
 			benes, err := serviceInstance.getBeneficiaries("cmsID", tt.fileType)
 
 			if tt.expectedErr != nil {
@@ -462,7 +465,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			repository.On("GetCCLFBeneficiaries", mock.Anything, mock.Anything).Return(tt.expBenes, nil)
 			// use benes1 as the "old" benes. Allows us to verify the since parameter is populated as expected
 			repository.On("GetCCLFBeneficiaryMBIs", mock.Anything).Return(benes1MBI, nil)
-			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, basePath)
+			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, defaultRunoutClaimThru,basePath)
 			queJobs, err := serviceInstance.GetQueJobs(tt.acoID, &Job{ACOID: uuid.NewUUID()}, tt.resourceTypes, tt.expSince, tt.reqType)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	defaultRunoutCutoff    = 120 * 24 * time.Hour
+	defaultRunoutCutoff = 120 * 24 * time.Hour
 )
+
 var (
 	defaultRunoutClaimThru = time.Date(time.Now().Year()-1, time.December, 31, 23, 59, 59, 999999, time.UTC)
 )
@@ -423,7 +424,6 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 	}
 
 	since := time.Now()
-	serviceDate := time.Date(since.Year()-1, 12, 31, 23, 59, 59, 999999, time.UTC)
 
 	type test struct {
 		name           string
@@ -439,8 +439,8 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 		{"BasicRequest (non-Group)", defaultACOID, DefaultRequest, time.Time{}, time.Time{}, benes1, nil},
 		{"BasicRequest with Since (non-Group) ", defaultACOID, DefaultRequest, since, time.Time{}, benes1, nil},
 		{"GroupAll", defaultACOID, RetrieveNewBeneHistData, since, time.Time{}, append(benes1, benes2...), nil},
-		{"RunoutRequest", defaultACOID, Runout, time.Time{}, serviceDate, benes1, nil},
-		{"RunoutRequest with Since", defaultACOID, Runout, since, serviceDate, benes1, nil},
+		{"RunoutRequest", defaultACOID, Runout, time.Time{}, defaultRunoutClaimThru, benes1, nil},
+		{"RunoutRequest with Since", defaultACOID, Runout, since, defaultRunoutClaimThru, benes1, nil},
 		{"Priority", priorityACOID, DefaultRequest, time.Time{}, time.Time{}, benes1, nil},
 	}
 
@@ -465,7 +465,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			repository.On("GetCCLFBeneficiaries", mock.Anything, mock.Anything).Return(tt.expBenes, nil)
 			// use benes1 as the "old" benes. Allows us to verify the since parameter is populated as expected
 			repository.On("GetCCLFBeneficiaryMBIs", mock.Anything).Return(benes1MBI, nil)
-			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, defaultRunoutClaimThru,basePath)
+			serviceInstance := NewService(repository, 1*time.Hour, 0, defaultRunoutCutoff, defaultRunoutClaimThru, basePath)
 			queJobs, err := serviceInstance.GetQueJobs(tt.acoID, &Job{ACOID: uuid.NewUUID()}, tt.resourceTypes, tt.expSince, tt.reqType)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID


### PR DESCRIPTION

### Change Details
1. Use an environment variable to define runout claim thru date, defaulted to 2020-12-31. 

    We used to compute the claim thru date to lock it to the end of the **previous** year. This would mean that we would have to restart our API instances on 2021-01-1 to have the service date set to 2020-12-31. If we forgot to do this operation, we would have the service date set to 2019-12-31.

2. Use a default runout cutoff time of 120 days. This value was misconfigured (set to 45 days).

<!-- Add detailed discussion of changes here: -->

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change


### Acceptance Validation

CI Passes