### PR TITLE
bcda-3838 Feature: Update errors to use MBI id

### DIFF
--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -218,7 +218,7 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, cm
 	failed := false
 
 	for _, beneID := range jobArgs.BeneficiaryIDs {
-		bundle := func() (string, error) {
+		errMsg, err := func() (string, error) {
 			bene, err := getBeneficiary(beneID, bb, db)
 			if err != nil {
 				return fmt.Sprintf("Error retrieving BlueButton ID for cclfBeneficiary MBI %s", bene.MBI), err
@@ -229,9 +229,9 @@ func writeBBDataToFile(ctx context.Context, bb client.APIClient, db *gorm.DB, cm
 			}
 			fhirBundleToResourceNDJSON(ctx, w, b, jobArgs.ResourceType, beneID, cmsID, fileUUID, jobArgs.ID)
 			return "", nil
-		}
+		}()
 
-		if errMsg, err := bundle(); err != nil {
+		if err != nil {
 			log.Error(err)
 			errorCount++
 			appendErrorToFile(ctx, fileUUID, responseutils.Exception, responseutils.BbErr, errMsg, jobArgs.ID)

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -212,8 +212,8 @@ func (s *MainTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold() 
 	fData, err := ioutil.ReadFile(errorFilePath)
 	assert.NoError(s.T(), err)
 
-	ooResp := fmt.Sprintf(`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary abcdef10000 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary abcdef10000 in ACO %s"}}]}
-{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary abcdef11000 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary abcdef11000 in ACO %s"}}]}`, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID)
+	ooResp := fmt.Sprintf(`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary MBI abcdef10000 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary MBI abcdef10000 in ACO %s"}}]}
+{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary MBI abcdef11000 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary MBI abcdef11000 in ACO %s"}}]}`, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID)
 	assert.Equal(s.T(), ooResp+"\n", string(fData))
 	bbc.AssertExpectations(s.T())
 }
@@ -254,8 +254,8 @@ func (s *MainTestSuite) TestWriteEOBDataToFileWithErrorsAboveFailureThreshold() 
 	fData, err := ioutil.ReadFile(errorFilePath)
 	assert.NoError(s.T(), err)
 
-	ooResp := fmt.Sprintf(`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary a1000089833 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary a1000089833 in ACO %s"}}]}
-{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary a1000065301 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary a1000065301 in ACO %s"}}]}`, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID)
+	ooResp := fmt.Sprintf(`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary MBI a1000089833 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary MBI a1000089833 in ACO %s"}}]}
+{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"exception","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary MBI a1000065301 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary MBI a1000065301 in ACO %s"}}]}`, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID, s.testACO.UUID)
 	assert.Equal(s.T(), ooResp+"\n", string(fData))
 	bbc.AssertExpectations(s.T())
 	// should not have requested third beneficiary EOB because failure threshold was reached after second
@@ -303,6 +303,8 @@ func (s *MainTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {
 
 	errorFileScanner := bufio.NewScanner(bytes.NewReader(d))
 	for _, cclfBeneID := range cclfBeneficiaryIDs {
+		var cclfBeneficiary models.CCLFBeneficiary
+		s.db.First(&cclfBeneficiary, cclfBeneID)
 		assert.True(s.T(), errorFileScanner.Scan())
 		var jsonObj map[string]interface{}
 		err := json.Unmarshal(errorFileScanner.Bytes(), &jsonObj)
@@ -312,7 +314,7 @@ func (s *MainTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {
 		issue := issues[0].(map[string]interface{})
 		assert.Equal(s.T(), "error", issue["severity"])
 		details := issue["details"].(map[string]interface{})
-		assert.Equal(s.T(), fmt.Sprintf("Error retrieving BlueButton ID for cclfBeneficiary %s", cclfBeneID), details["text"])
+		assert.Equal(s.T(), fmt.Sprintf("Error retrieving BlueButton ID for cclfBeneficiary MBI %s", cclfBeneficiary.MBI), details["text"])
 	}
 	assert.False(s.T(), errorFileScanner.Scan(), "There should be only 2 entries in the file.")
 


### PR DESCRIPTION
### Fixes [BCDA-3838](https://jira.cms.gov/browse/BCDA-3838)

Errors that are written to the `errors.ndjson` either use the BB id or the beneficiary id. Neither of these are useful to us and the error should be updated to use another id that can be helpful.

### Proposed Changes

- Update error message to use the MBI identifier instead.

### Change Details

- Error message was updated to use MBI id.
- `handleBBError` func was moved entirely as it wasn't necessary for the couple times it was called. The logic was moved into the top level function where the `errorCount` lives (and we dont have to to pass a pointer around anymore).
- `beneBBID` was renamed to `getBeneficiary` since it now returns the entire beneficiary instead of just the BB id.
- Top level code was updated to use a closure method that passes back the err and error message that will be written to the file.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [ ] no PHI/PII is affected by this change

### Acceptance Validation

Unittests have been updated to check for the correct error messages.

### Feedback Requested

Since we are now check for the MBI I changed the `TestWriteEOBDataToFile_BlueButtonIDNotFound` in `main_test.go` to search for the cclf bene when making assertions. I haven't done a lot of db searches so I just wanted to make sure this a solid choice. Or would it be smarter to keep a slice of `cclfBeneficiarys` from the beginning (when they are created) and just iterate over those later when making assertions...