### PR TITLE
Relax regex requirements to handle CEC/NGACOs

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -684,7 +684,7 @@ func setBlacklistState(cmsID string, blacklistState bool) error {
 }
 
 // CCLF file name pattern and regex
-const cclfPattern = `((?:T|P)\.BCD\..*\.ZC\d*)Y(\d{2}\.D\d{6}\.T\d{7})`
+const cclfPattern = `((?:T|P).*\.ZC[A-B0-9]*)Y(\d{2}\.D\d{6}\.T\d{7})`
 
 var cclfregex = regexp.MustCompile(cclfPattern)
 

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -862,6 +862,8 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 	// cclf file names that are contained within the cclf zip files
 	cclfFiles := []string{
 		"T.BCD.A0001.ZC48Y18.D181120.T1000001",
+		"T.BCD.A0001.ZCAY18.D181120.T1000001",
+		"T.BCD.A0001.ZCBY18.D181120.T1000001",
 		"T.BCD.A0001.ZC48Y18.D181120.T1000002",
 		"T.BCD.A0001.ZC48Y18.D181120.T1000003",
 		"P.V001.ACO.ZC8Y20.D201002.T0806400",
@@ -901,6 +903,8 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 	// runout cclf file names that will be generated for each zip file
 	cclfRFiles := []string{
 		"T.BCD.A0001.ZC48R18.D181120.T1000001",
+		"T.BCD.A0001.ZCAR18.D181120.T1000001",
+		"T.BCD.A0001.ZCBR18.D181120.T1000001",
 		"T.BCD.A0001.ZC48R18.D181120.T1000002",
 		"T.BCD.A0001.ZC48R18.D181120.T1000003",
 		"P.V001.ACO.ZC8R20.D201002.T0806400",

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -855,6 +855,8 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 		"T.BCD.A0002.ZCY18.D181120.T9999990",
 		"T.BCD.A0002.ZCY18.D181120.T9999991",
 		"T.BCD.A0002.ZCY18.D181120.T9999992",
+		"P.BCD.E0002.ZCY20.D200914.T0850090",
+		"P.BCD.V002.ZCY20.D201002.T0811490",
 		"not_a_cclf_file",
 	}
 	// cclf file names that are contained within the cclf zip files
@@ -862,6 +864,8 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 		"T.BCD.A0001.ZC48Y18.D181120.T1000001",
 		"T.BCD.A0001.ZC48Y18.D181120.T1000002",
 		"T.BCD.A0001.ZC48Y18.D181120.T1000003",
+		"P.V001.ACO.ZC8Y20.D201002.T0806400",
+		"P.CEC.ZC8Y20.D201108.T0958300",
 	}
 
 	// create the test files under the temporary directory
@@ -879,7 +883,7 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 	fmt.Print(buf.String())
 	assert.Nil(err)
 	assert.Contains(buf.String(), "Completed CCLF runout file generation.")
-	assert.Contains(buf.String(), "Generated 3 zip files.")
+	assert.Contains(buf.String(), "Generated 5 zip files.")
 	buf.Reset()
 
 	// runout zip file names that will be generated
@@ -887,6 +891,8 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 		"T.BCD.A0002.ZCR18.D181120.T9999990",
 		"T.BCD.A0002.ZCR18.D181120.T9999991",
 		"T.BCD.A0002.ZCR18.D181120.T9999992",
+		"P.BCD.E0002.ZCR20.D200914.T0850090",
+		"P.BCD.V002.ZCR20.D201002.T0811490",
 	}
 
 	// assert the zip file count matches after cloning
@@ -897,6 +903,8 @@ func (s *CLITestSuite) TestCloneCCLFZips() {
 		"T.BCD.A0001.ZC48R18.D181120.T1000001",
 		"T.BCD.A0001.ZC48R18.D181120.T1000002",
 		"T.BCD.A0001.ZC48R18.D181120.T1000003",
+		"P.V001.ACO.ZC8R20.D201002.T0806400",
+		"P.CEC.ZC8R20.D201108.T0958300",
 	}
 
 	// assert that each zip was cloned with the proper name and each zip file


### PR DESCRIPTION
We encountered an issue when attempting to copy the CCLF files for NGACOs. The regex for the NGACO file names did not match the expectations.

To resolve this, we relaxed the regex requirements.

### Change Details
1. Relax the regex requirements for renaming the CCLF files.
2. Adding tests with NGACO/CEC files to verify the rename works as expected.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Added unit tests to verify CEC/NGACO files would be renamed.
2. Verified fix by running the updated CLI on our NGACO files. They were renamed correctly.