### PR TITLE
BCDA-4019 - Update Bulk Request Header Names

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -338,8 +338,8 @@ func addRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) 
 	req.Header.Add("keep-alive", "")
 	req.Header.Add("BlueButton-OriginalUrl", req.URL.String())
 	req.Header.Add("BlueButton-OriginalQuery", req.URL.RawQuery)
-	req.Header.Add("BULK-JOBID", jobID)
-	req.Header.Add("BULK-CLIENTID", cmsID)
+	req.Header.Add(jobIDHeader, jobID)
+	req.Header.Add(clientIDHeader, cmsID)
 	req.Header.Add("IncludeIdentifiers", "mbi")
 
 	// We SHOULD NOT be specifying "Accept-Encoding: gzip" on the request header.

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -333,8 +333,8 @@ func addRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) 
 	req.Header.Add("keep-alive", "")
 	req.Header.Add("BlueButton-OriginalUrl", req.URL.String())
 	req.Header.Add("BlueButton-OriginalQuery", req.URL.RawQuery)
-	req.Header.Add("BCDA-JOBID", jobID)
-	req.Header.Add("BCDA-CMSID", cmsID)
+	req.Header.Add("BULK-JOBID", jobID)
+	req.Header.Add("BULK-CLIENTID", cmsID)
 	req.Header.Add("IncludeIdentifiers", "mbi")
 
 	// We SHOULD NOT be specifying "Accept-Encoding: gzip" on the request header.
@@ -398,8 +398,8 @@ func (h *httpLogger) logRequest(req *http.Request) {
 		"bb_query_id": req.Header.Get("BlueButton-OriginalQueryId"),
 		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
 		"bb_uri":      req.URL.String(),
-		"job_id":      req.Header.Get("BCDA-JOBID"),
-		"cms_id":      req.Header.Get("BCDA-CMSID"),
+		"job_id":      req.Header.Get("BULK-JOBID"),
+		"cms_id":      req.Header.Get("BULK-CLIENTID"),
 	}).Infoln("request")
 }
 
@@ -409,7 +409,7 @@ func (h *httpLogger) logResponse(req *http.Request, resp *http.Response) {
 		"bb_query_id": req.Header.Get("BlueButton-OriginalQueryId"),
 		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
 		"bb_uri":      req.URL.String(),
-		"job_id":      req.Header.Get("BCDA-JOBID"),
-		"cms_id":      req.Header.Get("BCDA-CMSID"),
+		"job_id":      req.Header.Get("BULK-JOBID"),
+		"cms_id":      req.Header.Get("BULK-CLIENTID"),
 	}).Infoln("response")
 }

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -33,6 +33,11 @@ import (
 
 var logger *logrus.Logger
 
+const (
+	clientIDHeader = "BULK-CLIENTID"
+	jobIDHeader    = "BULK-JOBID"
+)
+
 // BlueButtonConfig holds the configuration settings needed to create a BlueButtonClient
 // TODO (BCDA-3755): Move the other env vars used in NewBlueButtonClient to this struct
 type BlueButtonConfig struct {
@@ -398,8 +403,8 @@ func (h *httpLogger) logRequest(req *http.Request) {
 		"bb_query_id": req.Header.Get("BlueButton-OriginalQueryId"),
 		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
 		"bb_uri":      req.URL.String(),
-		"job_id":      req.Header.Get("BULK-JOBID"),
-		"cms_id":      req.Header.Get("BULK-CLIENTID"),
+		"job_id":      req.Header.Get(jobIDHeader),
+		"cms_id":      req.Header.Get(clientIDHeader),
 	}).Infoln("request")
 }
 
@@ -409,7 +414,7 @@ func (h *httpLogger) logResponse(req *http.Request, resp *http.Response) {
 		"bb_query_id": req.Header.Get("BlueButton-OriginalQueryId"),
 		"bb_query_ts": req.Header.Get("BlueButton-OriginalQueryTimestamp"),
 		"bb_uri":      req.URL.String(),
-		"job_id":      req.Header.Get("BULK-JOBID"),
-		"cms_id":      req.Header.Get("BULK-CLIENTID"),
+		"job_id":      req.Header.Get(jobIDHeader),
+		"cms_id":      req.Header.Get(clientIDHeader),
 	}).Infoln("response")
 }

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -451,7 +451,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotNil(t, uuid.Parse(req.Header.Get("BlueButton-OriginalQueryId")))
 				assert.Equal(t, "1", req.Header.Get("BlueButton-OriginalQueryCounter"))
 
-				assert.Equal(t, "", req.Header.Get("keep-alive"))
+				assert.Empty(t, req.Header.Get("keep-alive"))
 				assert.Nil(t, req.Header.Values("X-Forwarded-Proto"))
 				assert.Nil(t, req.Header.Values("X-Forwarded-Host"))
 

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -461,8 +461,8 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 
 				assert.Equal(t, jobID, req.Header.Get(jobIDHeader))
 				assert.Equal(t, cmsID, req.Header.Get(clientIDHeader))
-				assert.Equal(t, "", req.Header.Get(oldJobIDHeader))
-				assert.Equal(t, "", req.Header.Get(oldClientIDHeader))
+				assert.Empty(t, req.Header.Get(oldJobIDHeader))
+				assert.Empty(t, req.Header.Get(oldClientIDHeader))
 
 				assert.Equal(t, "mbi", req.Header.Get("IncludeIdentifiers"))
 

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -452,8 +452,8 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 					"%s does not end with %s", req.Header.Get("BlueButton-OriginalUrl"), req.URL.String())
 				assert.Equal(t, req.URL.RawQuery, req.Header.Get("BlueButton-OriginalQuery"))
 
-				assert.Equal(t, jobID, req.Header.Get("BCDA-JOBID"))
-				assert.Equal(t, cmsID, req.Header.Get("BCDA-CMSID"))
+				assert.Equal(t, jobID, req.Header.Get("BULK-JOBID"))
+				assert.Equal(t, cmsID, req.Header.Get("BULK-CLIENTID"))
 				assert.Equal(t, "mbi", req.Header.Get("IncludeIdentifiers"))
 
 				// Verify that we have compression enabled on these HTTP requests.

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	clientIDHeader    = "BULK-CLIENTID"
+	jobIDHeader       = "BULK-JOBID"
+	oldClientIDHeader = "BCDA-JOBID"
+	oldJobIDHeader    = "BCDA-CMSID"
+)
+
 type BBTestSuite struct {
 	suite.Suite
 }
@@ -452,8 +459,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 					"%s does not end with %s", req.Header.Get("BlueButton-OriginalUrl"), req.URL.String())
 				assert.Equal(t, req.URL.RawQuery, req.Header.Get("BlueButton-OriginalQuery"))
 
-				assert.Equal(t, jobID, req.Header.Get("BULK-JOBID"))
-				assert.Equal(t, cmsID, req.Header.Get("BULK-CLIENTID"))
+				assert.Equal(t, jobID, req.Header.Get(jobIDHeader))
+				assert.Equal(t, cmsID, req.Header.Get(clientIDHeader))
+				assert.Equal(t, "", req.Header.Get(oldJobIDHeader))
+				assert.Equal(t, "", req.Header.Get(oldClientIDHeader))
+
 				assert.Equal(t, "mbi", req.Header.Get("IncludeIdentifiers"))
 
 				// Verify that we have compression enabled on these HTTP requests.


### PR DESCRIPTION
### Fixes [BCDA-4019](https://jira.cms.gov/browse/BCDA-4019)

Bulk headers do not match those listed in [https://github.com/CMSgov/beneficiary-fhir-data/blob/master/docs/request-audit-headers.md](https://github.com/CMSgov/beneficiary-fhir-data/blob/master/docs/request-audit-headers.md)

### Proposed Changes
- Update our bulk request headers to match listed [BFD Audit Headers](https://github.com/CMSgov/beneficiary-fhir-data/blob/master/docs/request-audit-headers.md)
- Update associated tests and logs to utilize new headers

### Change Details
`BCDA-JOBID`  should now be `BULK-JOBID`

`BCDA-CMSID` should now be `BULK-CLIENTID`

See: [https://github.com/CMSgov/beneficiary-fhir-data/pull/386](https://github.com/CMSgov/beneficiary-fhir-data/pull/386)

### Security Implications
- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

-  [x] no PHI/PII is affected by this change

### Acceptance Validation
Unit tests have been updated to check for the correct headers