### PR TITLE
Update file ingestion test to use a static CCLF_REF_DATE

### DIFF
--- a/bcda/cclf/fileprocessor_test.go
+++ b/bcda/cclf/fileprocessor_test.go
@@ -303,7 +303,9 @@ func TestGetCCLFMetadata(t *testing.T) {
 func TestMultipleFileTypes(t *testing.T) {
 	dir, err := ioutil.TempDir("", "*")
 	assert.NoError(t, err)
-
+	cclfRefDate := os.Getenv("CCLF_REF_DATE")
+	os.Setenv("CCLF_REF_DATE", "201201")
+	defer os.Setenv("CCLF_REF_DATE", cclfRefDate)
 	defer os.RemoveAll(dir)
 
 	// Create various CCLF files that have unique perfYear:fileType
@@ -322,7 +324,7 @@ func TestMultipleFileTypes(t *testing.T) {
 
 	for _, fileMap := range m {
 		// We should contain 4 unique entries, one for each unique perfYear:fileType tuple
-		assert.Equal(t, 4, len(fileMap)) 
+		assert.Equal(t, 4, len(fileMap))
 		for _, files := range fileMap {
 			assert.Equal(t, 2, len(files)) // each tuple contains two files
 		}


### PR DESCRIPTION
When the `TestMultipleFileTypes` unit test was added to `bcda/cclf/fileprocessor_test.go`, it was intentionally isolated from the `FileProcessorTestSuite`.   By excluding this test from the `FileProcessorTestSuite`, we are unable to take advantage of the pre-processing done as part of the test setup.  One of the items included in the test setup is the setting of `CCLF_REF_DATE`, to ensure that we can use CCLF files with static dates in the filename (if we do not set this value, then our unit tests fail because the `CCLF_MAX_AGE` is surpassed).  With the current test implementation, the `TestMultipleFileTypes` test fails 45 days after the test was written (with the defined static timestamp in the CCLF filename).  The failure Is:

```
date 'D201113.T000001' from file T.BCD.A9990.ZC0R20.D201113.T0000010 out of range; comparison date 201228
```


This PR is intended to fix the faulty test to ensure that we are not bound by dates.

### Change Details

- Set `CCLF_REF_DATE` for the `TestMultipleFileTypes` test (and reset it back to the original value at the end of the test)

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

This feature branch was built in [Jenkins](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/2086/parameters/) and passed all unit tests.

### Feedback Requested

Please review.  A future effort might be necessary to examine all unit tests which are isolated from a test suite to see if we can integrate them into the test suite (to ensure consistency across all unit tests).