### PR TITLE
BCDA-4017 Feature: Add IncludeTaxNumbers: True header to EOB requests

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -184,6 +184,8 @@ func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, si
 	// ServiceDate only uses yyyy-mm-dd
 	const svcDateFmt = "2006-01-02"
 
+	header := make(http.Header)
+	header.Add("IncludeTaxNumbers", "true")
 	params := GetDefaultParams()
 	params.Set("patient", patientID)
 	params.Set("excludeSAMHSA", "true")
@@ -199,7 +201,8 @@ func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, si
 		return nil, err
 	}
 
-	return bbc.getBundleData(u, jobID, cmsID, nil)
+	return bbc.getBundleData(u, jobID, cmsID, header)
+	//return bbc.getBundleData(u, jobID, cmsID, nil)
 }
 
 func (bbc *BlueButtonClient) GetMetadata() (string, error) {

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -202,7 +202,6 @@ func (bbc *BlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, si
 	}
 
 	return bbc.getBundleData(u, jobID, cmsID, header)
-	//return bbc.getBundleData(u, jobID, cmsID, nil)
 }
 
 func (bbc *BlueButtonClient) GetMetadata() (string, error) {

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -312,6 +312,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				excludeSAMHSAChecker,
 				noServiceDateChecker,
 				noIncludeAddressFieldsChecker,
+				includeTaxNumbersChecker,
 			},
 		},
 		{
@@ -330,6 +331,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				excludeSAMHSAChecker,
 				noServiceDateChecker,
 				noIncludeAddressFieldsChecker,
+				includeTaxNumbersChecker,
 			},
 		},
 		{
@@ -348,6 +350,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				excludeSAMHSAChecker,
 				serviceDateChecker,
 				noIncludeAddressFieldsChecker,
+				includeTaxNumbersChecker,
 			},
 		},
 		{
@@ -365,6 +368,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				nowChecker,
 				noExcludeSAMHSAChecker,
 				includeAddressFieldsChecker,
+				noIncludeTaxNumbersChecker,
 			},
 		},
 		{
@@ -382,6 +386,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				nowChecker,
 				noExcludeSAMHSAChecker,
 				includeAddressFieldsChecker,
+				noIncludeTaxNumbersChecker,
 			},
 		},
 		{
@@ -399,6 +404,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				nowChecker,
 				noExcludeSAMHSAChecker,
 				noIncludeAddressFieldsChecker,
+				noIncludeTaxNumbersChecker,
 			},
 		},
 		{
@@ -416,6 +422,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				nowChecker,
 				noExcludeSAMHSAChecker,
 				noIncludeAddressFieldsChecker,
+				noIncludeTaxNumbersChecker,
 			},
 		},
 		{
@@ -431,6 +438,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 			[]func(*testing.T, *http.Request){
 				noExcludeSAMHSAChecker,
 				noIncludeAddressFieldsChecker,
+				noIncludeTaxNumbersChecker,
 			},
 		},
 	}
@@ -566,6 +574,12 @@ func noIncludeAddressFieldsChecker(t *testing.T, req *http.Request) {
 }
 func includeAddressFieldsChecker(t *testing.T, req *http.Request) {
 	assert.Equal(t, "true", req.Header.Get("IncludeAddressFields"))
+}
+func noIncludeTaxNumbersChecker(t *testing.T, req *http.Request) {
+	assert.Empty(t, req.Header.Get("IncludeTaxNumbers"))
+}
+func includeTaxNumbersChecker(t *testing.T, req *http.Request) {
+	assert.Equal(t, "true", req.Header.Get("IncludeTaxNumbers"))
 }
 
 func TestBBTestSuite(t *testing.T) {


### PR DESCRIPTION
### Fixes [BCDA-4017: Add IncludeTaxNumbers: True header to EOB requests](https://jira.cms.gov/browse/BCDA-4017)

Adds a header to the Explanation of Benefits requests to take advantage of the new optional flag on BlueButton to provide the tax numbers for the claim.

### Proposed Changes

Add IncludeTaxNumbers: True header to the GetExplanationOfBenefits function in bluebutton.go

### Change Details

Create variable with default header, add additional header, and include the header in bluebutton getBundleData

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Local unit tests passing.

### Feedback Requested

Missing stuff, Best Practices, Better Ideas