### PR TITLE
Fix Dockerfile.ssas to account for go module migration.

### DIFF
--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -15,7 +15,9 @@ RUN go get github.com/mattn/go-colorable
 # We need to run main --start at a particular location in order to guarantee that
 # the config files are placed in the expected spot
 RUN git clone https://github.com/CMSgov/bcda-ssas-app.git
-WORKDIR /go/bcda-ssas-app/ssas/service/main/
-RUN GO111MODULE=on go install
+WORKDIR /go/bcda-ssas-app
+RUN go install ./ssas/service/main
+# Make sure we are in the directory to ensure the config files are resolved as expected
+WORKDIR /go/bcda-ssas-app/ssas
 
 CMD ["main", "--start"]

--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -10,8 +10,6 @@ RUN go get -u github.com/derekparker/delve/cmd/dlv
 RUN go get github.com/BurntSushi/toml
 RUN go get github.com/howeyc/fsnotify
 RUN go get github.com/mattn/go-colorable
-RUN go get github.com/CMSgov/bcda-ssas-app/ssas/service/main
+RUN (cd $(mktemp -d); GO111MODULE=on go get github.com/CMSgov/bcda-ssas-app/ssas/service/main)
 
-WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app/ssas
-RUN go install github.com/CMSgov/bcda-ssas-app/ssas/service/main
 CMD ["main", "--start"]

--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -10,6 +10,12 @@ RUN go get -u github.com/derekparker/delve/cmd/dlv
 RUN go get github.com/BurntSushi/toml
 RUN go get github.com/howeyc/fsnotify
 RUN go get github.com/mattn/go-colorable
-RUN (cd $(mktemp -d); GO111MODULE=on go get github.com/CMSgov/bcda-ssas-app/ssas/service/main)
+# Clone bcda-ssas-app over running "go get" since we have issue determining
+# the path where the bcda-ssas-app is placed.
+# We need to run main --start at a particular location in order to guarantee that
+# the config files are placed in the expected spot
+RUN git clone https://github.com/CMSgov/bcda-ssas-app.git
+WORKDIR /go/bcda-ssas-app/ssas/service/main/
+RUN GO111MODULE=on go install
 
 CMD ["main", "--start"]


### PR DESCRIPTION
### Change Details
Clone the bcda-ssas-app repository instead of running `go get github.com/CMSgov/bcda-ssas-app`. With the migration to go modules, we do not have a guaranteed path which we'll find the bcda-ssas-app binaries. By cloning the repository and running `go install`, we can determine where we need to set the `WORKINGDIR` in order for the config parameters to be resolved correctly.

### Alternatives
We tried a couple other solutions, but ran into other snags.
1. https://github.com/golang/go/issues/40276

```
(cd $(mktemp -d); GO111MODULE=on go get github.com/CMSgov/bcda-ssas-app)
```
Allowed us to download and install the ssas-app binary, but we were not able to determine where the module was downloaded to. We felt like it would be easier/clearer to download the repository instead.

2. We tried adding it to the go.mod file as an indirect dependency. However, this would pin the version of bcda-ssas-app, since we cannot specify a branch.
 
### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. CI passes. Since this only affects testing, we should be confident that the change will work when deploying to the lower envs.
2. Deployed to Dev to confirm

![Screen Shot 2021-01-15 at 4 42 46 PM](https://user-images.githubusercontent.com/21049223/104788927-c2ac3d00-5750-11eb-8ae8-beb1c2e246bf.png)

![Screen Shot 2021-01-15 at 4 44 05 PM](https://user-images.githubusercontent.com/21049223/104788963-e4a5bf80-5750-11eb-90cf-20d45061afb1.png)
