### PR TITLE
bcda-3663 Feature: Job status endpoint handles cancelled jobs

### DIFF
--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -203,6 +203,9 @@ func JobStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Expires", job.UpdatedAt.Add(api.GetJobTimeout()).String())
 		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Exception, responseutils.Deleted, "")
 		responseutils.WriteError(oo, w, http.StatusGone)
+	case models.JobStatusCancelled:
+		oo := responseutils.CreateOpOutcome(responseutils.Error, responseutils.Not_found, responseutils.Deleted, "Job has been cancelled.")
+		responseutils.WriteError(oo, w, http.StatusNotFound)
 	}
 }
 

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -333,6 +333,7 @@ func bulkConcurrentRequestHelper(endpoint string, s *APITestSuite) {
 		{models.JobStatusArchived, http.StatusAccepted},
 		{models.JobStatusExpired, http.StatusAccepted},
 		{models.JobStatusFailed, http.StatusAccepted},
+		{models.JobStatusCancelled, http.StatusAccepted},
 	}
 	assert.Equal(s.T(), len(models.AllJobStatuses), len(tests), "Not all models.JobStatus tested.")
 
@@ -481,6 +482,7 @@ func (s *APITestSuite) TestJobStatusNotComplete() {
 		{models.JobStatusFailed, http.StatusInternalServerError},
 		{models.JobStatusExpired, http.StatusGone},
 		{models.JobStatusArchived, http.StatusGone},
+		{models.JobStatusCancelled, http.StatusNotFound},
 	}
 
 	for _, tt := range tests {

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -18,10 +18,11 @@ const (
 	JobStatusArchived   JobStatus = "Archived"
 	JobStatusExpired    JobStatus = "Expired"
 	JobStatusFailed     JobStatus = "Failed"
+	JobStatusCancelled  JobStatus = "Cancelled"
 )
 
 var AllJobStatuses []JobStatus = []JobStatus{JobStatusPending, JobStatusInProgress,
-	JobStatusCompleted, JobStatusArchived, JobStatusExpired, JobStatusFailed}
+	JobStatusCompleted, JobStatusArchived, JobStatusExpired, JobStatusFailed, JobStatusCancelled}
 
 type JobStatus string
 type Job struct {


### PR DESCRIPTION
### Fixes [BCDA-3663](https://jira.cms.gov/browse/BCDA-3663)

We are enabling the capabilities for a consumer to cancel a group export request. Since this request is sequestered off to a job queue we mark the job as being in a cancelled state. We need to convey this to the consumer if a status is requested. The return should be a `404` and have an operational outcome json payload as per the fhir spec.

### Proposed Changes

Add a cancelled state check to the case statement in the `api.go` job status endpoint method.

### Change Details

- Updated the models.go job constant to include a `Cancelled` state
- Updated the `api.go` case statement to handle the job cancelled state and return a `404` with an operational outcome. 

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

ACO-API now returns a correct response code for cancelled jobs.

### Feedback Requested

Couple things:

- I ended up not having to update the swagger since theres already a `404` response coming from the job status endpoint (potentially). This is already present in the documentation and it looks like its accurate.
- Thanks to the table driven tests, I only had to add the new job cancelled status to the tests and it worked! But let me know if I should introduce any other tests.

- 