### PR TITLE
VSCode Settings Update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "go.buildOnSave": "package",
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
-        "--fast"
+        "--fast",
+        "--exclude=\"(conf\\.(Un)?[S,s]etEnv)\"",
     ]
 }


### PR DESCRIPTION
### Related to [BCDA-4086](https://jira.cms.gov/browse/BCDA-4086)

### Proposed Changes
Update settings.json for VScode to not fire off warning for two function calls in the conf package.

### Change Details
Adding a setting into vscode to ignore warnings generated for not handling errors for conf.SetEnv and conf.UnsetEnv. Future update to application will remove/replace making these calls.


### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation
VScode ignores warnings related to conf.SetEnv and conf.UnsetEnv.

### Feedback Requested
Make sure the setting.json looks sound.
