### PR TITLE
bcda-4135 Feature: remove deleted at columns from db

### DIFF
--- a/db/migrations/bcda/000007_remove_deleted_at_columns.down.sql
+++ b/db/migrations/bcda/000007_remove_deleted_at_columns.down.sql
@@ -1,0 +1,34 @@
+-- Add deleted_at column to acos
+BEGIN;
+ALTER TABLE public.acos ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;
+
+-- Add deleted_at column to cclf_beneficiaries
+BEGIN;
+ALTER TABLE public.cclf_beneficiaries ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;
+
+-- Add deleted_at column to cclf_files
+BEGIN;
+ALTER TABLE public.cclf_files ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;
+
+-- Add deleted_at column to job_keys
+BEGIN;
+ALTER TABLE public.job_keys ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;
+
+-- Add deleted_at column to jobs
+BEGIN;
+ALTER TABLE public.jobs ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;
+
+-- Add deleted_at column to suppressions
+BEGIN;
+ALTER TABLE public.suppressions ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;
+
+-- Add deleted_at column to suppression_files
+BEGIN;
+ALTER TABLE public.suppression_files ADD COLUMN deleted_at timestamp with time zone;
+COMMIT;

--- a/db/migrations/bcda/000007_remove_deleted_at_columns.up.sql
+++ b/db/migrations/bcda/000007_remove_deleted_at_columns.up.sql
@@ -1,0 +1,34 @@
+-- Remove deleted_at column from acos
+BEGIN;
+ALTER TABLE public.acos DROP COLUMN deleted_at;
+COMMIT;
+
+-- Remove deleted_at column from cclf_beneficiaries
+BEGIN;
+ALTER TABLE public.cclf_beneficiaries DROP COLUMN deleted_at;
+COMMIT;
+
+-- Remove deleted_at column from cclf_files
+BEGIN;
+ALTER TABLE public.cclf_files DROP COLUMN deleted_at;
+COMMIT;
+
+-- Remove deleted_at column from job_keys
+BEGIN;
+ALTER TABLE public.job_keys DROP COLUMN deleted_at;
+COMMIT;
+
+-- Remove deleted_at column from jobs
+BEGIN;
+ALTER TABLE public.jobs DROP COLUMN deleted_at;
+COMMIT;
+
+-- Remove deleted_at column from suppressions
+BEGIN;
+ALTER TABLE public.suppressions DROP COLUMN deleted_at;
+COMMIT;
+
+-- Remove deleted_at column from suppression_files
+BEGIN;
+ALTER TABLE public.suppression_files DROP COLUMN deleted_at;
+COMMIT;

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -86,16 +86,6 @@ var migration5Tables = []interface{}{
 	"suppression_files",
 }
 
-var migration7Tables = []string{
-	"acos",
-	"cclf_beneficiaries",
-	"cclf_files",
-	"job_keys",
-	"jobs",
-	"suppressions",
-	"suppression_files",
-}
-
 func (s *MigrationTestSuite) TestBCDAMigration() {
 	migrator := migrator{
 		migrationPath: "./bcda/",
@@ -109,6 +99,9 @@ func (s *MigrationTestSuite) TestBCDAMigration() {
 
 	migration1Tables := []string{"acos", "cclf_beneficiaries", "cclf_beneficiary_xrefs",
 		"cclf_files", "job_keys", "jobs", "suppression_files", "suppressions"}
+
+	migration7Tables := []string{"acos", "cclf_beneficiaries", "cclf_files",
+		"job_keys", "jobs", "suppressions", "suppression_files"}
 
 	// Tests should begin with "up" migrations, in order, followed by "down" migrations in reverse order
 	tests := []struct {

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -86,6 +86,16 @@ var migration5Tables = []interface{}{
 	"suppression_files",
 }
 
+var migration7Tables = []string{
+	"acos",
+	"cclf_beneficiaries",
+	"cclf_files",
+	"job_keys",
+	"jobs",
+	"suppressions",
+	"suppression_files",
+}
+
 func (s *MigrationTestSuite) TestBCDAMigration() {
 	migrator := migrator{
 		migrationPath: "./bcda/",
@@ -260,6 +270,30 @@ func (s *MigrationTestSuite) TestBCDAMigration() {
 					createdAt, updatedAt = updateTestRow(t, db, v.tableName, v.fields)
 					assert.True(t, updatedAt.After(createdAt))  // Updated at will be more recent than Created at after update
 					deleteTestRow(t, db, v.tableName, v.fields) // Due to migrations further down, some test rows NEED to be deleted
+				}
+			},
+		},
+		{
+			"Remove deleted_at columns from database tables",
+			func(t *testing.T) {
+				for _, table := range migration7Tables {
+					assertColumnExists(t, true, db, table, "deleted_at")
+				}
+				migrator.runMigration(t, "7")
+				for _, table := range migration7Tables {
+					assertColumnExists(t, false, db, table, "deleted_at")
+				}
+			},
+		},
+		{
+			"Add deleted_at columns to database tables",
+			func(t *testing.T) {
+				for _, table := range migration7Tables {
+					assertColumnExists(t, false, db, table, "deleted_at")
+				}
+				migrator.runMigration(t, "6")
+				for _, table := range migration7Tables {
+					assertColumnExists(t, true, db, table, "deleted_at")
 				}
 			},
 		},


### PR DESCRIPTION
### Fixes [BCDA-4135](https://jira.cms.gov/browse/BCDA-4135)

With our move from GORM to sql builder we lost access to some automatic GORM functionality that created and updated bookkeeping columns in our tables. `deleted_at` is one of those columns.

### Proposed Changes

Create a migration that removes the `deleted_at` column from all the tables that contain it since we do not use this data for anything.

### Change Details

- Migration up removes `deleted_at` column.
- Migration down adds `deleted_at` column.
- Unit tests verify migrations

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Migration removes `deleted_at` column.

The migration was applied manually to the unit test database and the unit tests run to assure the migration wont affect the unit tests in the future.

![image](https://user-images.githubusercontent.com/5296332/107560442-35fb7000-6b92-11eb-9fd7-3f5ca2e9bca2.png)

[jenkins smoke test](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/2908/) ran successfully after applying the [migration](https://bcda-ci.adhocteam.us/job/BCDA%20-%20SQL%20Migrate/114/) to dev.

### Feedback Requested

I did not update our unit test db snapshot since, according to @mtrang1263 there is an upcoming change that will apply our migrations automatically to our unit test database making the snapshot change unnecessary. Let me know if that bothers anybody to the point of where I need to go in and apply the changes manually.