### PR TITLE
Change methodology for building the go-swagger binary

### DIFF
--- a/Dockerfiles/Dockerfile.documentation
+++ b/Dockerfiles/Dockerfile.documentation
@@ -5,9 +5,10 @@ ARG swaggerVersion=3.38.0
 ENV swaggerVersion ${swaggerVersion}
 RUN apk update upgrade
 RUN apk add git build-base gcc
-
-RUN go get -u github.com/go-swagger/go-swagger/cmd/swagger
-
+RUN dir=$(mktemp -d) && \
+    git clone https://github.com/go-swagger/go-swagger "$dir" && \
+    cd "$dir" && \
+    go install ./cmd/swagger
 WORKDIR /go/src/github.com/CMSgov/bcda-app
 
 # Download swagger UI and update references to our swagger.json files


### PR DESCRIPTION
### Overview

When running `make docker-bootstrap`, we encountered the following error when building the documentation container:

```
Step 6/11 : RUN go get -u github.com/go-swagger/go-swagger/cmd/swagger
 ---> Running in 4fe5388ba4e0
cannot find package "github.com/hashicorp/hcl/hcl/printer" in any of:
	/usr/local/go/src/github.com/hashicorp/hcl/hcl/printer (from $GOROOT)
	/go/src/github.com/hashicorp/hcl/hcl/printer (from $GOPATH)
```

Looking at go-swagger's [go.mod](https://github.com/go-swagger/go-swagger/blob/master/go.mod) file, it doesn't reference github.com/hashicorp/hcl/hcl/printer so it makes sense that this dependency is missing. We are still looking at the reason for this regression.

### Change Details

Using the [go-swagger installation guide](https://goswagger.io/install.html#installing-from-source), we replaced our `go get` command with their recommended process.

### Security Implications

- [ ] new software dependencies
No software dependencies changed. We are updated our process of building the dependency.

- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Build passes - Since we were failing on the building the documentation container, this should give us enough confidence that the issue is fixed.