### PR TITLE
bcda-4134 Feature: remove cclf xref table

### DIFF
--- a/db/migrations/bcda/000008_remove_cclf_bene_xref_table.down.sql
+++ b/db/migrations/bcda/000008_remove_cclf_bene_xref_table.down.sql
@@ -33,3 +33,13 @@ COMMIT;
 BEGIN;
 ALTER TABLE ONLY public.cclf_beneficiary_xrefs ALTER COLUMN id SET DEFAULT nextval('public.cclf_beneficiary_xrefs_id_seq'::regclass);
 COMMIT;
+
+-- Name: cclf_beneficiary_xrefs cclf_beneficiary_xrefs_pkey; Type: CONSTRAINT; Schema: public; 
+BEGIN;
+ALTER TABLE ONLY public.cclf_beneficiary_xrefs ADD CONSTRAINT cclf_beneficiary_xrefs_pkey PRIMARY KEY (id);
+COMMIT;
+
+-- Name: idx_cclf_beneficiary_xrefs_deleted_at; Type: INDEX; Schema: public; 
+BEGIN;
+CREATE INDEX IF NOT EXISTS idx_cclf_beneficiary_xrefs_deleted_at ON public.cclf_beneficiary_xrefs USING btree (deleted_at);
+COMMIT;

--- a/db/migrations/bcda/000008_remove_cclf_bene_xref_table.down.sql
+++ b/db/migrations/bcda/000008_remove_cclf_bene_xref_table.down.sql
@@ -1,5 +1,6 @@
--- Name: cclf_beneficiary_xrefs; Type: TABLE; Schema: public; 
 BEGIN;
+
+-- Name: cclf_beneficiary_xrefs; Type: TABLE; Schema: public; 
 CREATE TABLE IF NOT EXISTS public.cclf_beneficiary_xrefs (
     id integer NOT NULL,
     created_at timestamp with time zone,
@@ -12,34 +13,25 @@ CREATE TABLE IF NOT EXISTS public.cclf_beneficiary_xrefs (
     prevs_efct_dt text,
     prevs_obslt_dt text
 );
-COMMIT;
 
 -- Name: cclf_beneficiary_xrefs_id_seq; Type: SEQUENCE; Schema: public; 
-BEGIN;
 CREATE SEQUENCE IF NOT EXISTS public.cclf_beneficiary_xrefs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-COMMIT;
 
 -- Name: cclf_beneficiary_xrefs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; 
-BEGIN;
 ALTER SEQUENCE public.cclf_beneficiary_xrefs_id_seq OWNED BY public.cclf_beneficiary_xrefs.id;
-COMMIT;
 
 -- Name: cclf_beneficiary_xrefs id; Type: DEFAULT; Schema: public; 
-BEGIN;
 ALTER TABLE ONLY public.cclf_beneficiary_xrefs ALTER COLUMN id SET DEFAULT nextval('public.cclf_beneficiary_xrefs_id_seq'::regclass);
-COMMIT;
 
 -- Name: cclf_beneficiary_xrefs cclf_beneficiary_xrefs_pkey; Type: CONSTRAINT; Schema: public; 
-BEGIN;
 ALTER TABLE ONLY public.cclf_beneficiary_xrefs ADD CONSTRAINT cclf_beneficiary_xrefs_pkey PRIMARY KEY (id);
-COMMIT;
 
 -- Name: idx_cclf_beneficiary_xrefs_deleted_at; Type: INDEX; Schema: public; 
-BEGIN;
 CREATE INDEX IF NOT EXISTS idx_cclf_beneficiary_xrefs_deleted_at ON public.cclf_beneficiary_xrefs USING btree (deleted_at);
+
 COMMIT;

--- a/db/migrations/bcda/000008_remove_cclf_bene_xref_table.down.sql
+++ b/db/migrations/bcda/000008_remove_cclf_bene_xref_table.down.sql
@@ -1,0 +1,35 @@
+-- Name: cclf_beneficiary_xrefs; Type: TABLE; Schema: public; 
+BEGIN;
+CREATE TABLE IF NOT EXISTS public.cclf_beneficiary_xrefs (
+    id integer NOT NULL,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone,
+    file_id integer NOT NULL,
+    xref_indicator text,
+    current_num text,
+    prev_num text,
+    prevs_efct_dt text,
+    prevs_obslt_dt text
+);
+COMMIT;
+
+-- Name: cclf_beneficiary_xrefs_id_seq; Type: SEQUENCE; Schema: public; 
+BEGIN;
+CREATE SEQUENCE IF NOT EXISTS public.cclf_beneficiary_xrefs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+COMMIT;
+
+-- Name: cclf_beneficiary_xrefs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; 
+BEGIN;
+ALTER SEQUENCE public.cclf_beneficiary_xrefs_id_seq OWNED BY public.cclf_beneficiary_xrefs.id;
+COMMIT;
+
+-- Name: cclf_beneficiary_xrefs id; Type: DEFAULT; Schema: public; 
+BEGIN;
+ALTER TABLE ONLY public.cclf_beneficiary_xrefs ALTER COLUMN id SET DEFAULT nextval('public.cclf_beneficiary_xrefs_id_seq'::regclass);
+COMMIT;

--- a/db/migrations/bcda/000008_remove_cclf_bene_xref_table.up.sql
+++ b/db/migrations/bcda/000008_remove_cclf_bene_xref_table.up.sql
@@ -1,7 +1,4 @@
 BEGIN;
 DROP TABLE public.cclf_beneficiary_xrefs CASCADE;
-COMMIT;
-
-BEGIN;
 DROP SEQUENCE IF EXISTS public.cclf_beneficiary_xrefs_id_seq;
 COMMIT;

--- a/db/migrations/bcda/000008_remove_cclf_bene_xref_table.up.sql
+++ b/db/migrations/bcda/000008_remove_cclf_bene_xref_table.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+DROP TABLE public.cclf_beneficiary_xrefs CASCADE;
+COMMIT;
+
+BEGIN;
+DROP SEQUENCE IF EXISTS public.cclf_beneficiary_xrefs_id_seq;
+COMMIT;

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -279,6 +279,22 @@ func (s *MigrationTestSuite) TestBCDAMigration() {
 			},
 		},
 		{
+			"Drop cclf_beneficiary_xrefs table",
+			func(t *testing.T) {
+				assertTableExists(t, true, db, "cclf_beneficiary_xrefs")
+				migrator.runMigration(t, "8")
+				assertTableExists(t, false, db, "cclf_beneficiary_xrefs")
+			},
+		},
+		{
+			"Create cclf_beneficiary_xrefs table",
+			func(t *testing.T) {
+				assertTableExists(t, false, db, "cclf_beneficiary_xrefs")
+				migrator.runMigration(t, "7")
+				assertTableExists(t, true, db, "cclf_beneficiary_xrefs")
+			},
+		},
+		{
 			"Add deleted_at columns to database tables",
 			func(t *testing.T) {
 				for _, table := range migration7Tables {


### PR DESCRIPTION
### Fixes [BCDA-4134](https://jira.cms.gov/browse/BCDA-4134)

The `cclf_beneficiary_xrefs` table is not being used in our db schema.

### Proposed Changes

Drop `cclf_beneficiary_xrefs` table in a migration.

### Change Details

- Create up migration to remove xref table.
- Create down migration to readd xref table, the id sequence, and the indexes.
- 
### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

We are dropping the xref table from our schema.

The migration was successfully applied to [dev](https://bcda-ci.adhocteam.us/job/BCDA%20-%20SQL%20Migrate/121/).

The Smoke tests [Passed](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/2918/) after the migration.

Sister [PR](https://github.com/CMSgov/bcda-ops/pull/659) in bcda-ops.

### Feedback Requested

I kept the unittest pretty basic (checking existence of the table). If anybody feels strongly about making the asserts more specific, please comment on what you'd like to see.

This migration will be run on dev and smoke tested to make sure it doesnt have any issues.