### PR TITLE
Use wait-for-it script to ensure unit test db is running

### DIFF
--- a/Dockerfiles/Dockerfile.wait_for_it
+++ b/Dockerfiles/Dockerfile.wait_for_it
@@ -1,0 +1,5 @@
+FROM debian:buster-slim as wait-for-it
+RUN apt-get update && apt-get install -y "wait-for-it"
+
+FROM debian:buster-slim
+COPY --from=wait-for-it /usr/bin/wait-for-it /usr/bin/wait-for-it

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ unit-test-db:
 	docker-compose -f docker-compose.test.yml up -d db-unit-test
 	
 	# Wait for the database to be ready
-	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 30
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 60
 	
 	# Perform migrations to ensure matching schemas
 	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db-unit-test:5432/bcda_test?sslmode=disable&x-migrations-table=schema_migrations_bcda" -path /go/src/github.com/CMSgov/bcda-app/db/migrations/bcda up

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ unit-test-db:
 	docker-compose -f docker-compose.test.yml up -d db-unit-test
 	
 	# Wait for the database to be ready
-	sleep 5
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 30
 	
 	# Perform migrations to ensure matching schemas
 	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db-unit-test:5432/bcda_test?sslmode=disable&x-migrations-table=schema_migrations_bcda" -path /go/src/github.com/CMSgov/bcda-app/db/migrations/bcda up

--- a/docker-compose.wait-for-it.yml
+++ b/docker-compose.wait-for-it.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  wait:
+    build:
+      context: .
+      dockerfile: Dockerfiles/Dockerfile.wait_for_it
+  


### PR DESCRIPTION
### Fixes issue introduced by [PR](https://github.com/CMSgov/bcda-app/pull/635)

In this [PR](https://github.com/CMSgov/bcda-app/pull/635), we rebuild the database container and run the migration script to ensure that the database schema matches our expectations. To ensure that we start with a clean state, we teardown and rebuild the database container. We expect that this process does not take longer 5s.

However, our build were failing on the CI pipeline since the sleep time was not adequate. 

### Change Details

Use the strategy listed [here](https://github.com/vishnubob/wait-for-it/issues/57#issuecomment-497661237) to ensure that the unit-test-db container is started as expected

### Security Implications

- [x] new software dependencies

We are using this [project](https://github.com/vishnubob/wait-for-it) as recommended by [Docker team](https://docs.docker.com/compose/startup-order/) to ensure that our database instance works as expected.
 
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Successful CI run [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20App%20Build%20and%20Package/587/)
     * Looking at the logs, it was taking 19s to finish. We had set a sleep timer of 5s.
     ```
     wait-for-it: waiting 30 seconds for db-unit-test:5432
     wait-for-it: db-unit-test:5432 is available after 19 seconds
     ```
2. Successful CI build run with concurrent SSAS build [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20App%20Build%20and%20Package/589/)
     * Looking at the logs, it was taking 26s to finish. We had set a sleep timer of 5s.
     ```
     wait-for-it: waiting 30 seconds for db-unit-test:5432
     wait-for-it: db-unit-test:5432 is available after 26 seconds
     ```
     
Since the run with concurrent SSAS build took 26s, we chose a 60s timeout. This should give us plenty of head room in case the CI build machine is under heavy load.