### PR TITLE
bcda-4219 Feature: support kcc and dc models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ load-fixtures:
 load-synthetic-cclf-data:
 	docker-compose up -d api
 	docker-compose up -d db
-	$(eval ACO_SIZES := dev dev-auth dev-cec dev-cec-auth dev-ng dev-ng-auth small medium large extra-large)
+	$(eval ACO_SIZES := dev dev-auth dev-cec dev-cec-auth dev-ng dev-ng-auth dev-ckcc dev-ckcc-auth dev-kcf dev-kcf-auth dev-dc dev-dc-auth small medium large extra-large)
 	# The "test" environment provides baseline CCLF ingestion for ACO
 	for acoSize in $(ACO_SIZES) ; do \
 		docker-compose run --rm api sh -c 'bcda import-synthetic-cclf-package --acoSize='$$acoSize' --environment=test' ; \

--- a/bcda/cclf/fileprocessor.go
+++ b/bcda/cclf/fileprocessor.go
@@ -135,10 +135,30 @@ func getCMSID(name string) (string, error) {
 
 func getCCLFFileMetadata(cmsID, fileName string) (cclfFileMetadata, error) {
 	var metadata cclfFileMetadata
-	// CCLF filename convention for SSP with BCD identifier: P.BCD.A****.ZC[0|8][Y|R]**.Dyymmdd.Thhmmsst
-	// CCLF filename convention for NGACO:  P.V***.ACO.ZC[0|8][Y|R].Dyymmdd.Thhmmsst
-	// CCLF file name convetion for CEC: P.CEC.ZC[0|8][Y|R].Dyymmdd.Thhmmsst
-	filenameRegexp := regexp.MustCompile(`(T|P)(?:\.BCD)?\.(.*?)(?:\.ACO)?\.ZC(0|8)(Y|R)(\d{2})\.(D\d{6}\.T\d{6})\d`)
+	const (
+		prefix = `(P|T)\.`
+		suffix = `\.ZC(0|8)(Y|R)(\d{2})\.(D\d{6}\.T\d{6})\d`
+		aco    = `(?:\.ACO)`
+		bcd    = `(?:BCD\.)`
+
+		// CCLF filename convention for SSP with BCD identifier: P.BCD.A****.ZC[0|8][Y|R]**.Dyymmdd.Thhmmsst
+		ssp = `A\d{4}`
+		// CCLF filename convention for NGACO: P.V***.ACO.ZC[0|8][Y|R].Dyymmdd.Thhmmsst
+		ngaco = `V\d{3}`
+		// CCLF file name convention for CEC: P.CEC.ZC[0|8][Y|R].Dyymmdd.Thhmmsst
+		cec = `CEC`
+		// CCLF file name convention for CKCC: P.C****.ACO.ZC(Y|R)**.Dyymmdd.Thhmmsst
+		ckcc = `C\d{4}`
+		// CCLF file name convention for KCF: P.K****.ACO.ZC[0|8](Y|R)**.Dyymmdd.Thhmmsst
+		kcf = `K\d{4}`
+		// CCLF file name convention for DC: P.D****.ACO.ZC(Y|R)**.Dyymmdd.Thhmmsst
+		dc = `D\d{4}`
+
+		pattern = prefix + `(` + bcd + ssp + `|` + ngaco + aco + `|` + cec +
+			`|` + ckcc + aco + `|` + kcf + aco + `|` + dc + aco + `)` + suffix
+	)
+
+	filenameRegexp := regexp.MustCompile(pattern)
 	parts := filenameRegexp.FindStringSubmatch(fileName)
 
 	if len(parts) != 7 {

--- a/bcda/cclf/fileprocessor_test.go
+++ b/bcda/cclf/fileprocessor_test.go
@@ -172,10 +172,13 @@ func TestGetCMSID(t *testing.T) {
 
 func TestGetCCLFMetadata(t *testing.T) {
 	const (
-		sspID, cecID, ngacoID = "A9999", "E9999", "V999"
-		sspProd, sspTest      = "P.BCD." + sspID, "T.BCD." + sspID
-		cecProd, cecTest      = "P.CEC", "T.CEC"
-		ngacoProd, ngacoTest  = "P." + ngacoID + ".ACO", "T." + ngacoID + ".ACO"
+		sspID, cecID, ngacoID, ckccID, kcfID, dcID = "A9999", "E9999", "V999", "C9999", "K9999", "D9999"
+		sspProd, sspTest                           = "P.BCD." + sspID, "T.BCD." + sspID
+		cecProd, cecTest                           = "P.CEC", "T.CEC"
+		ngacoProd, ngacoTest                       = "P." + ngacoID + ".ACO", "T." + ngacoID + ".ACO"
+		ckccProd, ckccTest                         = "P." + ckccID + ".ACO", "T." + ckccID + ".ACO"
+		kcfProd, kcfTest                           = "P." + kcfID + ".ACO", "T." + kcfID + ".ACO"
+		dcProd, dcTest                             = "P." + dcID + ".ACO", "T." + dcID + ".ACO"
 	)
 
 	start := time.Now()
@@ -200,6 +203,9 @@ func TestGetCCLFMetadata(t *testing.T) {
 		strings.Replace(gen(sspProd, validTime), "ZC8Y", "ZC8R", 1)
 	cecProdFile, cecTestFile := gen(cecProd, validTime), gen(cecTest, validTime)
 	ngacoProdFile, ngacoTestFile := gen(ngacoProd, validTime), gen(ngacoTest, validTime)
+	ckccProdFile, ckccTestFile := gen(ckccProd, validTime), gen(ckccTest, validTime)
+	kcfProdFile, kcfTestFile := gen(kcfProd, validTime), gen(kcfTest, validTime)
+	dcProdFile, dcTestFile := gen(dcProd, validTime), gen(dcTest, validTime)
 
 	tests := []struct {
 		name     string
@@ -209,6 +215,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 		metadata cclfFileMetadata
 	}{
 		{"Non CCLF0 or CCLF8 file", sspID, "P.A0001.ACO.ZC9Y18.D190108.T2355000", "invalid filename", cclfFileMetadata{}},
+		{"Unsupported CCLF file type", "Z9999", "P.Z0001.ACO.ZC8Y18.D190108.T2355000", "invalid filename", cclfFileMetadata{}},
 		{"Invalid date (no 13th month)", sspID, "T.BCD.A0001.ZC0Y18.D181320.T0001000", "failed to parse date", cclfFileMetadata{}},
 		{"CCLF file too old", sspID, gen(sspProd, startUTC.Add(-365*24*time.Hour)), "out of range", cclfFileMetadata{}},
 		{"CCLF file too new", sspID, gen(sspProd, startUTC.Add(365*24*time.Hour)), "out of range", cclfFileMetadata{}},
@@ -285,6 +292,72 @@ func TestGetCCLFMetadata(t *testing.T) {
 				name:      ngacoTestFile,
 				cclfNum:   8,
 				acoID:     ngacoID,
+				timestamp: validTime,
+				perfYear:  perfYear,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{"Production CKCC file", ckccID, ckccProdFile, "",
+			cclfFileMetadata{
+				env:       "production",
+				name:      ckccProdFile,
+				cclfNum:   8,
+				acoID:     ckccID,
+				timestamp: validTime,
+				perfYear:  perfYear,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{"Test CKCC file", ckccID, ckccTestFile, "",
+			cclfFileMetadata{
+				env:       "test",
+				name:      ckccTestFile,
+				cclfNum:   8,
+				acoID:     ckccID,
+				timestamp: validTime,
+				perfYear:  perfYear,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{"Production KCF file", kcfID, kcfProdFile, "",
+			cclfFileMetadata{
+				env:       "production",
+				name:      kcfProdFile,
+				cclfNum:   8,
+				acoID:     kcfID,
+				timestamp: validTime,
+				perfYear:  perfYear,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{"Test KCF file", kcfID, kcfTestFile, "",
+			cclfFileMetadata{
+				env:       "test",
+				name:      kcfTestFile,
+				cclfNum:   8,
+				acoID:     kcfID,
+				timestamp: validTime,
+				perfYear:  perfYear,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{"Production DC file", dcID, dcProdFile, "",
+			cclfFileMetadata{
+				env:       "production",
+				name:      dcProdFile,
+				cclfNum:   8,
+				acoID:     dcID,
+				timestamp: validTime,
+				perfYear:  perfYear,
+				fileType:  models.FileTypeDefault,
+			},
+		},
+		{"Test DC file", dcID, dcTestFile, "",
+			cclfFileMetadata{
+				env:       "test",
+				name:      dcTestFile,
+				cclfNum:   8,
+				acoID:     dcID,
 				timestamp: validTime,
 				perfYear:  perfYear,
 				fileType:  models.FileTypeDefault,

--- a/bcda/cclf/testutils/cclfUtils.go
+++ b/bcda/cclf/testutils/cclfUtils.go
@@ -37,16 +37,22 @@ func ImportCCLFPackage(acoSize, environment string, fileType models.CCLFFileType
 		fileName string
 		cmsID    string
 	}{
-		"dev":          {"dev", "A9994"},
-		"dev-cec":      {"dev", "E9994"},
-		"dev-cec-auth": {"dev", "E9996"},
-		"dev-ng":       {"dev", "V994"},
-		"dev-ng-auth":  {"dev", "V996"},
-		"dev-auth":     {"dev", "A9996"},
-		"small":        {"small", "A9990"},
-		"medium":       {"medium", "A9991"},
-		"large":        {"large", "A9992"},
-		"extra-large":  {"extra-large", "A9993"},
+		"dev":           {"dev", "A9994"},
+		"dev-auth":      {"dev", "A9996"},
+		"dev-cec":       {"dev", "E9994"},
+		"dev-cec-auth":  {"dev", "E9996"},
+		"dev-ng":        {"dev", "V994"},
+		"dev-ng-auth":   {"dev", "V996"},
+		"dev-ckcc":      {"dev", "C9994"},
+		"dev-ckcc-auth": {"dev", "C9996"},
+		"dev-kcf":       {"dev", "K9994"},
+		"dev-kcf-auth":  {"dev", "K9996"},
+		"dev-dc":        {"dev", "D9994"},
+		"dev-dc-auth":   {"dev", "D9996"},
+		"small":         {"small", "A9990"},
+		"medium":        {"medium", "A9991"},
+		"large":         {"large", "A9992"},
+		"extra-large":   {"extra-large", "A9993"},
 	}[acoSize]
 
 	if !ok {
@@ -85,7 +91,7 @@ func ImportCCLFPackage(acoSize, environment string, fileType models.CCLFFileType
 			filename = fmt.Sprintf("T.BCD.%s.%s%s", info.cmsID, file.Name(), suffix)
 		} else if strings.HasPrefix(info.cmsID, "E") {
 			filename = fmt.Sprintf("T.CEC.%s%s", file.Name(), suffix)
-		} else if strings.HasPrefix(info.cmsID, "V") {
+		} else if hasAnyPrefix(info.cmsID, "V", "C", "K", "D") {
 			filename = fmt.Sprintf("T.%s.ACO.%s%s", info.cmsID, file.Name(), suffix)
 		}
 		sourceFilename := fmt.Sprintf("%s/%s__%s", sourcedir, file.Name(), filename)
@@ -159,4 +165,13 @@ func addFileToZip(zipWriter *zip.Writer, filename string) error {
 	}
 	_, err = io.Copy(writer, fileToZip)
 	return err
+}
+
+func hasAnyPrefix(s string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/bcda/cclf/testutils/cclfUtils_test.go
+++ b/bcda/cclf/testutils/cclfUtils_test.go
@@ -56,6 +56,9 @@ func (s *CCLFUtilTestSuite) TestImport() {
 		{"test", "dev"},
 		{"test-new-beneficiaries", "dev-cec"},
 		{"test", "dev-ng"},
+		{"test", "dev-ckcc"},
+		{"test-new-beneficiaries", "dev-kcf"},
+		{"test", "dev-dc"},
 	}
 	for _, tt := range tests {
 		for _, fileType := range []models.CCLFFileType{models.FileTypeDefault, models.FileTypeRunout} {
@@ -65,5 +68,24 @@ func (s *CCLFUtilTestSuite) TestImport() {
 					assert.NoError(t, err)
 				})
 		}
+	}
+}
+
+func (s *CCLFUtilTestSuite) TestHasAnyPrefix() {
+	tests := []struct {
+		s        string
+		prefixes []string
+		found    bool
+	}{
+		{"A0001", []string{"A"}, true},
+		{"A0001", []string{"B"}, false},
+		{"Z0001", []string{"X", "Y", "Z"}, true},
+		{"Z0001", []string{"A", "B", "C"}, false},
+	}
+	for _, tt := range tests {
+		s.T().Run(fmt.Sprintf("Test String %s - Prefix(es) %s - Expect to be found %t", tt.s, tt.prefixes, tt.found),
+			func(t *testing.T) {
+				assert.Equal(t, tt.found, hasAnyPrefix(tt.s, tt.prefixes...))
+			})
 	}
 }

--- a/bcda/models/service.go
+++ b/bcda/models/service.go
@@ -412,7 +412,10 @@ func IsSupportedACO(cmsID string) bool {
 		ssp     = `^A\d{4}$`
 		ngaco   = `^V\d{3}$`
 		cec     = `^E\d{4}$`
-		pattern = `(` + ssp + `)|(` + ngaco + `)|(` + cec + `)`
+		ckcc    = `^C\d{4}$`
+		kcf     = `^K\d{4}$`
+		dc      = `^D\d{4}$`
+		pattern = `(` + ssp + `)|(` + ngaco + `)|(` + cec + `)|(` + ckcc + `)|(` + kcf + `)|(` + dc + `)`
 	)
 
 	return regexp.MustCompile(pattern).MatchString(cmsID)

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -47,6 +47,21 @@ func TestSupportedACOs(t *testing.T) {
 		{"CEC invalid characters", "E999E", false},
 		{"valid CEC", "E9999", true},
 
+		{"CKCC too short", "C999", false},
+		{"CKCC too long", "C99999", false},
+		{"CKCC invalid characters", "C999V", false},
+		{"valid CKCC", "C9999", true},
+
+		{"KCF too short", "K999", false},
+		{"KCF too long", "K99999", false},
+		{"KCF invalid characters", "K999V", false},
+		{"valid KCF", "K9999", true},
+
+		{"DC too short", "D999", false},
+		{"DC too long", "D99999", false},
+		{"DC invalid characters", "D999V", false},
+		{"valid DC", "D9999", true},
+
 		{"Unregistered ACO", "Z1234", false},
 	}
 


### PR DESCRIPTION
### Fixes [BCDA-4219](https://jira.cms.gov/browse/BCDA-4219)

Update the api to allow for kcc (ckcc/kcf) and dc cclf models.

### Proposed Changes

Update our models service to allow for the ckcc, kcf, and dc cms id types. Update the filename regex in `fileprocessor.go` to not only allow for the new file types but to tighten up our regexing in general and ONLY allow for the specific file types. Update our cclf synthetic file generation to create new dev files for ckcc, kcf, and dc models.

### Change Details

- Updated `models/service.go` to allow new kcc and dc models by adding the cms_id to regex.
- Updated `fileprocessor.go` regex to specifically check for our currently whitelisted aco types.
- Updated `cclfUtils.go` to generate synthetic data for the new aco types (kcc and dc).
- Updated makefile `load-synthetic-cclf-data` and add dev generation for kcc and dc models.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

The API now accepts the new kcc and dc aco model types.

We generate synthetic data for the new model types.

![Screen Shot 2021-02-18 at 4 03 16 PM](https://user-images.githubusercontent.com/5296332/108437854-f7555d80-7202-11eb-82e3-deabeed455fd.png)

![Screen Shot 2021-02-18 at 4 03 35 PM](https://user-images.githubusercontent.com/5296332/108437868-fde3d500-7202-11eb-9c96-560ac40fecba.png)

![Screen Shot 2021-02-18 at 4 03 48 PM](https://user-images.githubusercontent.com/5296332/108437881-01775c00-7203-11eb-87fc-ae169f44d885.png)

### Feedback Requested

Usual feedback; let me know if this could benefit from more testing and let me know if Go improvements could be done.