### PR TITLE
BCDA-4214 - Use claims data cutoff when creating jobs for terminated ACO

### DIFF
--- a/bcda/models/service.go
+++ b/bcda/models/service.go
@@ -233,8 +233,13 @@ func (s *service) createQueueJobs(conditions RequestConditions, since time.Time,
 					BBBasePath:      s.bbBasePath,
 				}
 
+				// If the caller made a request for runout data
+				// it takes precedence over any other claims date
+				// that may be applied
 				if conditions.ReqType == Runout {
 					enqueueArgs.ServiceDate = s.rp.claimThruDate
+				} else if !conditions.claimsDate.IsZero() {
+					enqueueArgs.ServiceDate = conditions.claimsDate
 				}
 
 				args, err := json.Marshal(enqueueArgs)

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -446,13 +446,13 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 
 	since := time.Now()
 	terminationDetails := &Termination{
-		ClaimsStrategy:  ClaimsHistorical,
+		ClaimsStrategy:      ClaimsHistorical,
 		AttributionStrategy: AttributionHistorical,
 		TerminationDate:     time.Now().Add(-30 * 24 * time.Hour).Round(time.Millisecond).UTC(),
 	}
 
-	// sinceAfterTermination := terminationDetails.TerminationDate.Add(10 * 24 * time.Hour)
-	// sinceBeforeTermination := terminationDetails.TerminationDate.Add(-10 * 24 * time.Hour)
+	sinceAfterTermination := terminationDetails.TerminationDate.Add(10 * 24 * time.Hour)
+	sinceBeforeTermination := terminationDetails.TerminationDate.Add(-10 * 24 * time.Hour)
 
 	type test struct {
 		name               string
@@ -472,13 +472,11 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 		{"RunoutRequest", defaultACOID, Runout, time.Time{}, defaultRunoutClaimThru, benes1, nil, nil},
 		{"RunoutRequest with Since", defaultACOID, Runout, since, defaultRunoutClaimThru, benes1, nil, nil},
 		{"Priority", priorityACOID, DefaultRequest, time.Time{}, time.Time{}, benes1, nil, nil},
-		{"TerminatedACO", defaultACOID, DefaultRequest, time.Time{}, terminationDetails.TerminationDate, benes1, nil, terminationDetails},
-		{"TerminatedACONewBenes", defaultACOID, RetrieveNewBeneHistData, since, terminationDetails.TerminationDate, append(benes1, benes2...), nil, terminationDetails},
+		{"Since After Termination", defaultACOID, DefaultRequest, sinceAfterTermination, terminationDetails.TerminationDate, benes1, nil, terminationDetails},
+		{"Since Before Termination", defaultACOID, DefaultRequest, sinceBeforeTermination, terminationDetails.TerminationDate, benes1, nil, terminationDetails},
+		{"New Benes With Since After Termination", defaultACOID, RetrieveNewBeneHistData, sinceAfterTermination, terminationDetails.TerminationDate, benes1, nil, terminationDetails},
+		{"New Benes With Since Before Termination", defaultACOID, RetrieveNewBeneHistData, sinceBeforeTermination, terminationDetails.TerminationDate, append(benes1, benes2...), nil, terminationDetails},
 		{"TerminatedACORunout", defaultACOID, Runout, time.Time{}, defaultRunoutClaimThru, benes1, nil, terminationDetails}, // Runout cutoff takes precedence over termination cutoff
-		// {"Since After Termination", defaultACOID, DefaultRequest, sinceAfterTermination, time.Time{}, benes1, nil, terminationDetails},
-		// {"Since Before Termination", defaultACOID, DefaultRequest, sinceBeforeTermination, time.Time{}, benes1, nil, terminationDetails},
-		// {"New Benes With Since After Termination", defaultACOID, RetrieveNewBeneHistData, sinceAfterTermination, time.Time{}, benes1, nil, terminationDetails},
-		// {"New Benes With Since Before Termination", defaultACOID, RetrieveNewBeneHistData, sinceBeforeTermination, time.Time{}, append(benes1, benes2...), nil, terminationDetails},
 	}
 
 	// Add all combinations of resource types

--- a/bcda/models/service_test.go
+++ b/bcda/models/service_test.go
@@ -447,7 +447,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 	since := time.Now()
 	terminationDetails := &Termination{
 		ClaimsStrategy:  ClaimsHistorical,
-		TerminationDate: time.Now().Add(-30 * 24 * time.Hour).Round(time.Millisecond),
+		TerminationDate: time.Now().Add(-30 * 24 * time.Hour).Round(time.Millisecond).UTC(),
 	}
 
 	type test struct {


### PR DESCRIPTION
### Fixes [BCDA-4214](https://jira.cms.gov/browse/BCDA-4214)

When creating jobs, we need to account for the ACOs termination details (date + claims strategy). This should be applied to the service date field which caps claims data.

### Change Details

1. Apply termination#ClaimsDate() when creating que_jobs.
2. Let runout claims take precedence when computing the claims date cutoff. If the caller is terminated & is making a runout request, we'll  use the runout date instead of termination date. 

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change

### Acceptance Validation
1. CI Passes - added tests to verify that we are applying the correct termination information.