### PR TITLE
BCDA 4237 Adding ALR Models

### DIFF
--- a/bcda/models/alr.go
+++ b/bcda/models/alr.go
@@ -6,7 +6,7 @@ import (
 
 type Alr struct {
 	ID            uint
-	ACOID         uint // Link to AlrMetaData
+	MetaKey       uint // Foreign Key
 	BeneMBI       string
 	BeneHIC       string
 	BeneFirstName string
@@ -15,20 +15,11 @@ type Alr struct {
 	BeneDOB       time.Time
 	BeneDOD       time.Time
 	Timestamp     time.Time
-	KeyValue      string // This stores all the other "violate" fields
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	KeyValue      map[string]string // All "violate" fields
 }
 
 type AlrMetaData struct {
-	MetaDataID uint // Foreign key
-	ACO        string
-	Timestamp  time.Time
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	ID        uint // Primary Key
+	ACO       string
+	Timestamp time.Time
 }
-
-// Thought in progress...
-/* type CSVContents struct {
-	Dataframe dataframe.DataFrame
-} */

--- a/bcda/models/alr.go
+++ b/bcda/models/alr.go
@@ -14,7 +14,6 @@ type Alr struct {
 	BeneSex       string
 	BeneDOB       time.Time
 	BeneDOD       time.Time
-	Timestamp     time.Time
 	KeyValue      map[string]string // All "violate" fields
 }
 

--- a/bcda/models/alr.go
+++ b/bcda/models/alr.go
@@ -23,6 +23,7 @@ type Alr struct {
 type AlrMetaData struct {
 	MetaDataID uint // Foreign key
 	ACO        string
+	Timestamp  time.Time
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }

--- a/bcda/models/alr.go
+++ b/bcda/models/alr.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"time"
+)
+
+type Alr struct {
+	ID            uint
+	ACOID         uint // Link to AlrMetaData
+	BeneMBI       string
+	BeneHIC       string
+	BeneFirstName string
+	BeneLastName  string
+	BeneSex       string
+	BeneDOB       time.Time
+	BeneDOD       time.Time
+	Timestamp     time.Time
+	KeyValue      string // This stores all the other "violate" fields
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type AlrMetaData struct {
+	MetaDataID uint // Foreign key
+	ACO        string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// Thought in progress...
+/* type CSVContents struct {
+	Dataframe dataframe.DataFrame
+} */

--- a/db/migrations/bcda/000010_alr.down.sql
+++ b/db/migrations/bcda/000010_alr.down.sql
@@ -1,0 +1,5 @@
+-- ALR uses two tables
+BEGIN;
+DROP TABLE public.alr CASCADE;
+DROP TABLE public.alr_meta CASCADE;
+COMMIT;

--- a/db/migrations/bcda/000010_alr.down.sql
+++ b/db/migrations/bcda/000010_alr.down.sql
@@ -1,5 +1,10 @@
 -- ALR uses two tables
 BEGIN;
+-- Remove the two triggers
+DROP TRIGGER set_timestamp ON public.alr;
+DROP TRIGGER set_timestamp ON public.alr_meta;
+
+-- Drop the tables
 DROP TABLE public.alr CASCADE;
 DROP TABLE public.alr_meta CASCADE;
 COMMIT;

--- a/db/migrations/bcda/000010_alr.up.sql
+++ b/db/migrations/bcda/000010_alr.up.sql
@@ -1,21 +1,23 @@
 BEGIN;
 
+-- Create ALR table
 CREATE TABLE IF NOT EXISTS public.alr (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     id bigint NOT NULL,
     -- metakey is the foreign key referencing id in alr_meta
-    metakey integer NOT NULL,
+    metakey bigint NOT NULL,
     mbi character(11) NOT NULL,
     hic character(12),
-    firstname character(30),
-    lastname character(40),
+    firstname character varying(30),
+    lastname character varying(40),
     sex character(1),
     dob timestamp,
     dod timestamp,
     keyvalue bytea
 );
 
+-- Create ALR Metadata table
 CREATE TABLE IF NOT EXISTS public.alr_meta (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -25,14 +27,39 @@ CREATE TABLE IF NOT EXISTS public.alr_meta (
     UNIQUE (id, aco, timestp)
 );
 
+-- Index the ALR Metadata table by two fields
 CREATE INDEX IF NOT EXISTS idx_metaid_timestamp ON public.alr_meta USING btree (aco, timestp);
 
+-- Set PK and FK
 ALTER TABLE ONLY public.alr_meta
     ADD CONSTRAINT primary_key_alr_meta PRIMARY KEY (id);
 ALTER TABLE ONLY public.alr
     ADD CONSTRAINT foreign_key_alr FOREIGN KEY (metakey) REFERENCES public.alr_meta(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
-CREATE SEQUENCE IF NOT EXISTS public.metaid_seq START WITH 1 INCREMENT BY 1 CACHE 1 OWNED BY public.alr_meta.id;
-ALTER TABLE ONLY public.alr_meta ALTER COLUMN id SET DEFAULT nextval('public.metaid_seq');
+-- Set Incrementing to both IDs
+CREATE SEQUENCE IF NOT EXISTS public.alr_meta_id_seq START WITH 1 INCREMENT BY 1 CACHE 1 OWNED BY public.alr_meta.id;
+ALTER TABLE ONLY public.alr_meta ALTER COLUMN id SET DEFAULT nextval('public.alr_meta_id_seq');
+CREATE SEQUENCE IF NOT EXISTS public.alr_id_seq START WITH 1 INCREMENT BY 1 CACHE 1 OWNED BY public.alr.id;
+ALTER TABLE ONLY public.alr ALTER COLUMN id SET DEFAULT nextval('public.alr_id_seq');
+
+-- Function to call when a row is updated
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger trigger_set_timestamp function on updated_at column for alr & alr_meta
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.alr
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON public.alr_meta
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
 
 COMMIT;

--- a/db/migrations/bcda/000010_alr.up.sql
+++ b/db/migrations/bcda/000010_alr.up.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.alr (
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    id bigint NOT NULL,
+    -- metakey is the foreign key referencing id in alr_meta
+    metakey integer NOT NULL,
+    mbi character(10) NOT NULL,
+    hic character varying(10),
+    firstname character(50),
+    lastname character(50),
+    sex character varying(10),
+    dob timestamp,
+    dod timestamp,
+    timestp timestamp with time zone,
+    keyvalue bytea
+);
+
+CREATE TABLE IF NOT EXISTS public.alr_meta (
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    id bigint NOT NULL,
+    aco character varying(5),
+    timestp timestamp with time zone,
+    UNIQUE (id, aco, timestp)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metaid_timestamp ON public.alr_meta (aco, timestp);
+
+ALTER TABLE ONLY public.alr_meta
+    ADD CONSTRAINT primary_key_alr_meta PRIMARY KEY (id);
+ALTER TABLE ONLY public.alr
+    ADD CONSTRAINT foreign_key_alr FOREIGN KEY (metakey) REFERENCES public.alr_meta(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+CREATE SEQUENCE IF NOT EXISTS public.metaid_seq START WITH 1 INCREMENT BY 1 CACHE 1 OWNED BY public.alr_meta.id;
+ALTER TABLE ONLY public.alr_meta ALTER COLUMN id SET DEFAULT nextval('public.metaid_seq');
+
+COMMIT;

--- a/db/migrations/bcda/000010_alr.up.sql
+++ b/db/migrations/bcda/000010_alr.up.sql
@@ -6,14 +6,13 @@ CREATE TABLE IF NOT EXISTS public.alr (
     id bigint NOT NULL,
     -- metakey is the foreign key referencing id in alr_meta
     metakey integer NOT NULL,
-    mbi character(10) NOT NULL,
-    hic character varying(10),
-    firstname character(50),
-    lastname character(50),
-    sex character varying(10),
+    mbi character(11) NOT NULL,
+    hic character(12),
+    firstname character(30),
+    lastname character(40),
+    sex character(1),
     dob timestamp,
     dod timestamp,
-    timestp timestamp with time zone,
     keyvalue bytea
 );
 
@@ -26,7 +25,7 @@ CREATE TABLE IF NOT EXISTS public.alr_meta (
     UNIQUE (id, aco, timestp)
 );
 
-CREATE INDEX IF NOT EXISTS idx_metaid_timestamp ON public.alr_meta (aco, timestp);
+CREATE INDEX IF NOT EXISTS idx_metaid_timestamp ON public.alr_meta USING btree (aco, timestp);
 
 ALTER TABLE ONLY public.alr_meta
     ADD CONSTRAINT primary_key_alr_meta PRIMARY KEY (id);

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -104,6 +104,8 @@ func (s *MigrationTestSuite) TestBCDAMigration() {
 	migration7Tables := []string{"acos", "cclf_beneficiaries", "cclf_files",
 		"job_keys", "jobs", "suppressions", "suppression_files"}
 
+	migration10Tables := []string{"alr", "alr_meta"}
+
 	// Tests should begin with "up" migrations, in order, followed by "down" migrations in reverse order
 	tests := []struct {
 		name  string
@@ -243,6 +245,24 @@ func (s *MigrationTestSuite) TestBCDAMigration() {
 				migrator.runMigration(t, "9")
 				assertColumnExists(t, true, db, "acos", "termination_details")
 				assertColumnDefaultValue(t, db, "termination_details", nullValue, []interface{}{"acos"})
+			},
+		},
+		{
+			"Add ALR tables",
+			func(t *testing.T) {
+				migrator.runMigration(t, "10")
+				for _, table := range migration10Tables {
+					assertTableExists(t, true, db, table)
+				}
+			},
+		},
+		{
+			"Removing ALR tables",
+			func(t *testing.T) {
+				migrator.runMigration(t, "9")
+				for _, table := range migration10Tables {
+					assertTableExists(t, false, db, table)
+				}
 			},
 		},
 		{


### PR DESCRIPTION
### Completes [BCDA-4237](https://jira.cms.gov/browse/BCDA-4237)
We are getting ready to start consuming and serving up Assignment List Report (ALR) data to our customers. To do this, the initial step is to create a model and then make the necessary migrations to prep the database for ingestion.
### Proposed Changes
1. Create ALR Model. We need to keep in mind that a typical ALR submission may have more rows than a typical CCLF submission. In addition, we are currently assuming that seven fields (out of possible hundreds) should be present in each ALR submssions.  The rest of the fields are possibly violate and we cannot guarantee they will be present in each submission.
2. Make the appropriate migration.
### Change Details
1. The ALR model will have two tables. One will house the meta data and will be shorter in terms of rows compared to the second. We will query the first table by ACOs and timestamp to obtain an ID, which will serve as a foreign key to the second table.  The second table will house the actual ALR data submission, and we will filter by the foreign key value from the previous query.
2. Add migration # 10 to include ALR models.
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
Migration looks sound and passes all unit test.