### PR TITLE
bcda-4258 Feature: Integrate wait-for-it container in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ load-fixtures:
 
 	docker-compose up -d db queue
 	echo "Wait for databases to be ready..."
-	sleep 5
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait sh -c "wait-for-it -h db -p 5432 -t 60 && wait-for-it -h queue -p 5432 -t 60"
 
 	# Initialize schemas
 	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable&x-migrations-table=schema_migrations_bcda" -path /go/src/github.com/CMSgov/bcda-app/db/migrations/bcda up
@@ -115,12 +115,10 @@ load-fixtures:
 	$(MAKE) load-fixtures-ssas
 
 	# Ensure components are started as expected
-	docker-compose restart api worker ssas
-	sleep 5
+	docker-compose up -d api worker ssas
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait sh -c "wait-for-it -h api -p 3000 -t 60 && wait-for-it -h ssas -p 3003 -t 60"
 
 load-synthetic-cclf-data:
-	docker-compose up -d api
-	docker-compose up -d db
 	$(eval ACO_SIZES := dev dev-auth dev-cec dev-cec-auth dev-ng dev-ng-auth dev-ckcc dev-ckcc-auth dev-kcf dev-kcf-auth dev-dc dev-dc-auth small medium large extra-large)
 	# The "test" environment provides baseline CCLF ingestion for ACO
 	for acoSize in $(ACO_SIZES) ; do \
@@ -137,8 +135,6 @@ load-synthetic-cclf-data:
 	done
 
 load-synthetic-suppression-data:
-	docker-compose up -d api
-	docker-compose up -d db
 	docker-compose run api sh -c 'bcda import-suppression-directory --directory=../shared_files/synthetic1800MedicareFiles'
 	# Update the suppression entries to guarantee there are qualified entries when searching for suppressed benes.
 	# See postgres#GetSuppressedMBIs for more information
@@ -152,12 +148,7 @@ docker-build:
 	docker-compose build --force-rm
 	docker-compose -f docker-compose.test.yml build --force-rm
 
-docker-bootstrap:
-	$(MAKE) docker-build
-	$(MAKE) documentation
-	docker-compose up -d
-	sleep 40
-	$(MAKE) load-fixtures
+docker-bootstrap: docker-build documentation load-fixtures
 
 api-shell:
 	docker-compose exec api bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - "3000:3000"
       - "3001:3001"
     depends_on:
+      - ssas
+      - db
       - queue
   worker:
     build:
@@ -94,6 +96,7 @@ services:
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
     depends_on:
+      - db
       - queue
   documentation:
     build:


### PR DESCRIPTION
### Fixes [BCDA-4258](https://jira.cms.gov/browse/BCDA-4258)

We have a series of `sleep` commands in our `Makefile`. We want to remove these and leverage a tool.

### Proposed Changes

Take advantage of the `wait-for-it` docker container to wait on our `db`, `api`, and other containers we build.

### Change Details

- Update Makefile to integrate `wait-for-it`.
- Update `depends_on` in `docker-compose.yml` builds to have a correct dependency tree.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

All sleeps in the makefile are removed and we are waiting for our services to start.

Jenkins build pass: https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/2235/

### Feedback Requested

Scrutinize my make skills. Also, note that I didn't add `api` to the workers dependency due to a cyclical dependency error.