### PR TITLE
Remove references to deprecated newrelic library

### DIFF
--- a/bcda/cclf/metrics/metrics_test.go
+++ b/bcda/cclf/metrics/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/newrelic/go-agent/_integrations/nrlogrus"
+	"github.com/newrelic/go-agent/v3/integrations/nrlogrus"
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/sirupsen/logrus/hooks/test"
 )

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/CMSgov/bcda-app/conf"
 
 	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
-	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -140,7 +140,7 @@ func (w *worker) ProcessJob(ctx context.Context, job models.Job, jobArgs models.
 func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.APIClient,
 	cmsID string, jobArgs models.JobEnqueueArgs) (fileUUID string, size int64, err error) {
 	segment := getSegment(ctx, "writeBBDataToFile")
-	defer endSegment(segment)
+	segment.End()
 
 	var bundleFunc func(bbID string) (*fhirmodels.Bundle, error)
 	switch jobArgs.ResourceType {
@@ -270,7 +270,7 @@ func appendErrorToFile(ctx context.Context, fileUUID string,
 	code fhircodes.IssueTypeCode_Value,
 	detailsCode, detailsDisplay string, jobID int) {
 	segment := getSegment(ctx, "appendErrorToFile")
-	defer endSegment(segment)
+	segment.End()
 
 	oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, code, detailsCode, detailsDisplay)
 
@@ -296,7 +296,7 @@ func appendErrorToFile(ctx context.Context, fileUUID string,
 
 func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, fileUUID string, jobID int) {
 	segment := getSegment(ctx, "fhirBundleToResourceNDJSON")
-	defer endSegment(segment)
+	segment.End()
 
 	for _, entry := range b.Entries {
 		if entry["resource"] == nil {
@@ -381,12 +381,6 @@ func getSegment(ctx context.Context, name string) newrelic.Segment {
 		segment.StartTime = txn.StartSegmentNow()
 	}
 	return segment
-}
-
-func endSegment(segment newrelic.Segment) {
-	if err := segment.End(); err != nil {
-		log.Warnf("Failed to end segment %s", err)
-	}
 }
 
 func createDir(path string) error {

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/jackc/pgx v3.1.1-0.20180608201956-39bbc98d99d7+incompatible
 	github.com/lib/pq v1.9.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
-	github.com/newrelic/go-agent v3.9.0+incompatible
 	github.com/newrelic/go-agent/v3 v3.9.0
+	github.com/newrelic/go-agent/v3/integrations/nrlogrus v1.0.0
 	github.com/otiai10/copy v1.4.2
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
@@ -53,7 +53,6 @@ replace (
 	github.com/go-chi/render => github.com/go-chi/render v1.0.1
 	github.com/jackc/pgx => github.com/jackc/pgx v3.1.1-0.20180608201956-39bbc98d99d7+incompatible
 	github.com/lib/pq => github.com/lib/pq v1.9.0
-	github.com/newrelic/go-agent => github.com/newrelic/go-agent v3.9.0+incompatible
 	github.com/newrelic/go-agent/v3 => github.com/newrelic/go-agent/v3 v3.9.0
 	github.com/opencensus-integrations/gomongowrapper => github.com/eug48/gomongowrapper v0.0.3
 	github.com/pborman/uuid => github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3

--- a/go.sum
+++ b/go.sum
@@ -425,10 +425,10 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/newrelic/go-agent v3.9.0+incompatible h1:W2Zummx9jNATZVX6QVjYksX1TwxJGf4E6x1Wf3CG/jY=
-github.com/newrelic/go-agent v3.9.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/newrelic/go-agent/v3 v3.9.0 h1:5bcTbdk/Up5cIYIkQjCG92Y+uNoett9wmhuz4kPiFlM=
 github.com/newrelic/go-agent/v3 v3.9.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
+github.com/newrelic/go-agent/v3/integrations/nrlogrus v1.0.0 h1:qmAtZBKzuzxTkcBBfWHbeImk0Wxjooc522xaafANKJs=
+github.com/newrelic/go-agent/v3/integrations/nrlogrus v1.0.0/go.mod h1:JpiVn2lqR9Vk6Iq7mYGQPJhKEnthbba4QqM8Jb1JTW0=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
### Change Details
golangci-lint started reporting errors about the deprecated newrelic library. We needed to change all imports from 
`github.com/newrelic/go-agent` to `github.com/newrelic/go-agent/v3`.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
CI passes - we were utilizing the same underlying NewRelic version so we shouldn't see any regressions with the change of import paths.