### PR TITLE
Adding file path env vars to vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,18 @@
         "TEST_DB_URL": "postgresql://postgres:toor@localhost:15432/bcda_test?sslmode=disable",
         "DATABASE_URL": "postgresql://postgres:toor@localhost:15432/bcda_test?sslmode=disable",
         "QUEUE_DATABASE_URL": "postgresql://postgres:toor@localhost:15432/bcda_test?sslmode=disable",
-        "BCDA_API_CONFIG_PATH": "${workspaceFolder}/shared_files/decrypted/api.yml"
+        "BCDA_API_CONFIG_PATH": "${workspaceFolder}/shared_files/decrypted/api.yml",
+        // Since we have different directory structure in our test containers, we should
+        // define all files/directory paths here
+        "ATO_PUBLIC_KEY_FILE": "${workspaceFolder}/shared_files/ATO_public.pem",
+        "ATO_PRIVATE_KEY_FILE": "${workspaceFolder}/shared_files/ATO_private.pem",
+        "BB_CLIENT_CERT_FILE": "${workspaceFolder}/shared_files/decrypted/bfd-dev-test-cert.pem",
+        "BB_CLIENT_KEY_FILE": "${workspaceFolder}/shared_files/decrypted/bfd-dev-test-key.pem",
+        "FHIR_PAYLOAD_DIR": "${workspaceFolder}/bcdaworker/data",
+        "FHIR_STAGING_DIR": "${workspaceFolder}/bcdaworker/tmpdata",
+        "FHIR_ARCHIVE_DIR": "${workspaceFolder}/bcdaworker/archive",
+        "JWT_PRIVATE_KEY_FILE": "${workspaceFolder}/shared_files/api_unit_test_auth_private.pem",
+        "JWT_PUBLIC_KEY_FILE": "${workspaceFolder}/shared_files/api_unit_test_auth_public.pem",
     },
     "go.testEnvFile": "${workspaceFolder}/shared_files/decrypted/local.env",
     "go.testFlags": [


### PR DESCRIPTION
### Fixes [BCDA-4342](https://jira.cms.gov/browse/BCDA-4342)

To enable local testing (in vscode), we need to update file/folder paths to reference the workspace folder.

### Change Details
Update settings.json to include env vars that need to reference the workspace path.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change

### Acceptance Validation
Verified that once this settings.json was updated, requests_test.go was able to be executed within vscode.