### PR TITLE
BCDA-4372 - Switch from fatal to error logging

### DIFF
--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -28,7 +28,7 @@ func init() {
 
 	c, err := client.NewSSASClient()
 	if err != nil {
-		log.Fatalf("no client for SSAS; %s", err.Error())
+		log.Errorf("no client for SSAS. no provider set; %s", err.Error())
 	}
 	provider = SSASPlugin{client: c, repository: repository}
 


### PR DESCRIPTION
### Fixes error raised by [BCDA-4372](https://jira.cms.gov/browse/BCDA-4372)

With this [PR](https://github.com/CMSgov/bcda-app/pull/684), we exited early if we could not set up the auth provider.

This caused issues with packages that import the auth package, but do not use it. It was causing errors in our NFS instances.


### Change Details
1. Switch init() block to use Errorf instead of Fatalf

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Running deploy on dev environment and verify smoke tests pass