### PR TITLE
BCDA-3486 - Add codecov action on pull requests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -46,3 +46,11 @@ jobs:
       - name: Run all tests
         run: |
           make test
+      - name: Generate codecov report
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./test_results/latest/testcoverage.out # optional
+          flags: unittests # optional
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,6 @@
 name: BCDA CI Workflow
 
-on: [push]
+on: [pull_request]
 
 env:
   COMPOSE_INTERACTIVE_NO_CLI: 1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+# These settings allow us to report coverage numbers as soon as possible.
+# We do not have to wait for codecov to acknowledge CI completion for the reports to be published.
+codecov:
+  require_ci_to_pass: no
+  notify:
+    wait_for_ci: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,files,footer"
+  behavior: new
+  require_changes: false
+  require_base: no
+  require_head: no


### PR DESCRIPTION
### Fixes [BCDA-3486](https://jira.cms.gov/browse/BCDA-3486)

To add immediate signal on how well changes are covered, we want to add a tool report code coverage stats on pull requests.

### Change Details

Use [codecov's github actions](https://github.com/codecov/codecov-action) to publish code coverage stats.

### Security Implications

- [x] new software dependencies

We are using codecov's github actions to publish metrics

- [ ] security controls or supporting software altered

- [x] new data stored or transmitted
 
Code coverage metrics will be reported in PRs

- [x] security checklist is completed for this change[
Completed Checklist](https://confluence.cms.gov/display/BCDA/21+-+04+-+16%3A+Use+Codecov+in+BCDA+Code+Reviews+Security+Checklist?src=contextnavpagetreemode)
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
1. Verified coverage report meets the expectations of the team.