### PR TITLE
Hotfix: Pin usql to version 0.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,5 +77,7 @@ replace (
 	github.com/soheilhy/cmux => github.com/soheilhy/cmux v0.1.4
 	github.com/tsenart/vegeta => github.com/tsenart/vegeta v12.1.0+incompatible
 	github.com/urfave/cli => github.com/urfave/cli v1.20.1-0.20180226030253-8e01ec4cd3e2
+	github.com/xo/usql => github.com/xo/usql v0.8.2
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
+
 )


### PR DESCRIPTION
The newest version of https://github.com/xo/usql was causing build failures for our test package. This fix pins usql at the previous stable version 0.8.2.

### Change Details
Add replace directive in `go.mod` to pin correct version of usql

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation
Builds successfully locally

### Feedback Requested