### PR TITLE
BCDA-4512: Add migration scripts for updating import_status column

### DIFF
--- a/db/migrations/manual/20210512-gpdc-import-status-completed.sql
+++ b/db/migrations/manual/20210512-gpdc-import-status-completed.sql
@@ -1,0 +1,4 @@
+-- SQL script to re-enable DC models' ability to receive data. 
+BEGIN;
+UPDATE cclf_files SET import_status = 'Completed' WHERE aco_cms_id LIKE 'D%';
+COMMIT;

--- a/db/migrations/manual/20210512-gpdc-import-status-ignore-manual.sql
+++ b/db/migrations/manual/20210512-gpdc-import-status-ignore-manual.sql
@@ -1,0 +1,5 @@
+-- SQL script to manually prevent DC models from receiving export data. 
+BEGIN;
+-- only files with an import status set to 'Completed' are able to be retrieved
+UPDATE cclf_files SET import_status = 'Ignore_Manual' WHERE aco_cms_id LIKE 'D%';
+COMMIT;


### PR DESCRIPTION
### Fixes [BCDA-4512](https://jira.cms.gov/browse/BCDA-4512)

GPDC models are currently authorized to make credentials for BCDA access, but are not authorized to receive data. In response to [this incident](https://confluence.cms.gov/display/BCDA/20210510+-+BCDA+GPDC+model+making+a+call), we are adding a migration script to track database changes made to prevent GPDC models from receiving data prior to when they should be.

### Proposed Changes
These migration scripts are for tracking purposes only. When GPDC models are authorized to receive data, the `gpdc-import-status-completed` script may be run to enable the model's access.

**Note:** monthly CCLF ingestion will overwrite the updated `import_status` column; if needed, re-run this script to ensure `import_status` remains set to `Ignore_Manual` for GPDC models.


### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Feedback Requested
General improvements and/or missing info
