### PR TITLE
BCDA-4532: Enable Application Code to Send Events to BFD Insights

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -457,8 +457,9 @@ func setUpApp() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 				s, f, sk, err := suppression.ImportSuppressionDirectory(filePath)
-				insights.PutRecord("import-suppression-directory", "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
-				fmt.Fprintf(app.Writer, "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
+				logStatement := fmt.Sprintf("Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
+				insights.PutEvent("import-suppression-directory", logStatement)
+				fmt.Fprintf(app.Writer, logStatement)
 				return err
 			},
 		},

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -24,7 +24,6 @@ import (
 	cclfUtils "github.com/CMSgov/bcda-app/bcda/cclf/testutils"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/insights"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/bcda/service"
@@ -458,7 +457,6 @@ func setUpApp() *cli.App {
 			Action: func(c *cli.Context) error {
 				s, f, sk, err := suppression.ImportSuppressionDirectory(filePath)
 				fmt.Fprintf(app.Writer, "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
-				insights.PutEvent(insights.GetFirehose(), "import-suppression-directory", "Completed 1-800-MEDICARE suppression data import")
 				return err
 			},
 		},

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -457,9 +457,8 @@ func setUpApp() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 				s, f, sk, err := suppression.ImportSuppressionDirectory(filePath)
-				logStatement := fmt.Sprintf("Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
-				insights.PutEvent("import-suppression-directory", logStatement)
-				fmt.Fprint(app.Writer, logStatement)
+				fmt.Fprintf(app.Writer, "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
+				insights.PutEvent(insights.GetFirehose(), "import-suppression-directory", "Completed 1-800-MEDICARE suppression data import")
 				return err
 			},
 		},

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -459,7 +459,7 @@ func setUpApp() *cli.App {
 				s, f, sk, err := suppression.ImportSuppressionDirectory(filePath)
 				logStatement := fmt.Sprintf("Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
 				insights.PutEvent("import-suppression-directory", logStatement)
-				fmt.Fprintf(app.Writer, logStatement)
+				fmt.Fprint(app.Writer, logStatement)
 				return err
 			},
 		},

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -24,6 +24,7 @@ import (
 	cclfUtils "github.com/CMSgov/bcda-app/bcda/cclf/testutils"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/insights"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/bcda/service"
@@ -456,6 +457,7 @@ func setUpApp() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 				s, f, sk, err := suppression.ImportSuppressionDirectory(filePath)
+				insights.PutRecord("import-suppression-directory", "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
 				fmt.Fprintf(app.Writer, "Completed 1-800-MEDICARE suppression data import.\nFiles imported: %v\nFiles failed: %v\nFiles skipped: %v\n", s, f, sk)
 				return err
 			},

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -37,7 +37,7 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 	if utils.GetEnvBool("BCDA_ENABLE_INSIGHTS_EVENTS", true) {
 
 		targetEnv := conf.GetEnv("DEPLOYMENT_TARGET")
-		streamName := "bfd-insights-bcda-" + targetEnv + "-" + name
+		streamName := "bfd-insights-bcda-" + targetEnv + "-event_processor"
 
 		recordInput := &firehose.PutRecordInput{}
 		recordInput = recordInput.SetDeliveryStreamName(streamName)

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -45,7 +45,7 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 		data := Event{
 			Name:      name,
 			Timestamp: time.Now().UnixNano() / 1e6,
-			Result:    "{ \"event\":" + event + "}",
+			Result:    "{\"event\":\"" + event + "\"}",
 		}
 
 		b, err := json.Marshal(data)

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -63,4 +63,7 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 			log.API.Error(err)
 		}
 	}
+	else {
+		log.API.Info("Insights is not enabled for the application.  No data was sent to BFD.")
+	}
 }

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -26,10 +26,14 @@ func GetFirehose() *firehose.Firehose {
 	return instance
 }
 
+type JsonResult struct {
+	EventMsg string `json:"event"`
+}
+
 type Event struct {
-	Name      string    `json:"name"`
-	Timestamp time.Time `json:"timestamp"`
-	Result    string    `json:"json_result"`
+	Name      string     `json:"name"`
+	Timestamp time.Time  `json:"timestamp"`
+	Result    JsonResult `json:"json_result"`
 }
 
 func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
@@ -42,10 +46,14 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 		recordInput := &firehose.PutRecordInput{}
 		recordInput = recordInput.SetDeliveryStreamName(streamName)
 
+		eventMsg := JsonResult{
+			EventMsg: event,
+		}
+
 		data := Event{
 			Name:      name,
 			Timestamp: time.Now(),
-			Result:    event,
+			Result:    eventMsg,
 		}
 
 		b, err := json.Marshal(data)

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -26,14 +26,10 @@ func GetFirehose() *firehose.Firehose {
 	return instance
 }
 
-type JsonResult struct {
-	EventMsg string `json:"event"`
-}
-
 type Event struct {
-	Name      string     `json:"name"`
-	Timestamp int64      `json:"timestamp"`
-	Result    JsonResult `json:"json_result"`
+	Name      string `json:"name"`
+	Timestamp int64  `json:"timestamp"`
+	Result    string `json:"json_result"`
 }
 
 func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
@@ -46,14 +42,10 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 		recordInput := &firehose.PutRecordInput{}
 		recordInput = recordInput.SetDeliveryStreamName(streamName)
 
-		eventMsg := JsonResult{
-			EventMsg: event,
-		}
-
 		data := Event{
 			Name:      name,
 			Timestamp: time.Now().UnixNano() / 1e6,
-			Result:    eventMsg,
+			Result:    "{ \"event\":" + event + "}",
 		}
 
 		b, err := json.Marshal(data)

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -62,8 +62,7 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 		if err != nil {
 			log.API.Error(err)
 		}
-	}
-	else {
+	} else {
 		log.API.Info("Insights is not enabled for the application.  No data was sent to BFD.")
 	}
 }

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -2,8 +2,6 @@ package insights
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,7 +47,7 @@ func PutEvent(name string, event string) {
 		record := &firehose.Record{Data: b}
 		recordInput = recordInput.SetRecord(record)
 
-		_, err := firehoseService.PutRecord(recordInput)
+		_, err = firehoseService.PutRecord(recordInput)
 
 		if err != nil {
 			log.API.Error(err)

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -6,14 +6,13 @@ import (
 	"os"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/firehose"
 
 	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
 )
 
 type Event struct {
@@ -44,18 +43,16 @@ func PutEvent(name string, event string) {
 		b, err := json.Marshal(data)
 
 		if err != nil {
-			log.Printf("Error: %v", err)
-			os.Exit(1)
+			log.API.Error(err)
 		}
 
 		record := &firehose.Record{Data: b}
 		recordInput = recordInput.SetRecord(record)
 
-		resp, err := firehoseService.PutRecord(recordInput)
+		_, err := firehoseService.PutRecord(recordInput)
+
 		if err != nil {
-			fmt.Printf("PutRecord err: %v\n", err)
-		} else {
-			fmt.Printf("PutRecord: %v\n", resp)
+			log.API.Error(err)
 		}
 	}
 }

--- a/bcda/insights/insights.go
+++ b/bcda/insights/insights.go
@@ -32,7 +32,7 @@ type JsonResult struct {
 
 type Event struct {
 	Name      string     `json:"name"`
-	Timestamp time.Time  `json:"timestamp"`
+	Timestamp int64      `json:"timestamp"`
 	Result    JsonResult `json:"json_result"`
 }
 
@@ -52,7 +52,7 @@ func PutEvent(svc firehoseiface.FirehoseAPI, name string, event string) {
 
 		data := Event{
 			Name:      name,
-			Timestamp: time.Now(),
+			Timestamp: time.Now().UnixNano() / 1e6,
 			Result:    eventMsg,
 		}
 

--- a/bcda/insights/insights_test.go
+++ b/bcda/insights/insights_test.go
@@ -1,0 +1,46 @@
+package insights
+
+import (
+	"testing"
+
+	"github.com/CMSgov/bcda-app/conf"
+
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type mockFirehoseClient struct {
+	firehoseiface.FirehoseAPI
+}
+
+type InsightsTestSuite struct {
+	suite.Suite
+	mockSvc mockFirehoseClient
+}
+
+func (s *InsightsTestSuite) SetupTest() {
+	s.mockSvc = &mockFirehoseClient{}
+}
+
+func InsightsTestSuite(t *testing.T) {
+	suite.Run(t, new(InsightsTestSuite))
+}
+
+func PutRecord(*firehose.PutRecordInput) (*firehose.PutRecordOutput, error) {
+	// TODO
+}
+
+func (s *InsightsTestSuite) TestInsightsDisabled() {
+	origSetting := conf.GetEnv("BCDA_ENABLE_INSIGHTS_EVENTS")
+	conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", false)
+
+	s.T().Cleanup(func() {
+		conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", origSetting)
+	})
+
+	PutEvent(s.mockSvc, "TestInsightsDisabledName", "TestInsightsDisabledEvent")
+
+	// TODO: assert
+}

--- a/bcda/insights/insights_test.go
+++ b/bcda/insights/insights_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -19,7 +20,7 @@ type mockFirehoseClient struct {
 
 type InsightsTestSuite struct {
 	suite.Suite
-	mockSvc mockFirehoseClient
+	mockSvc *mockFirehoseClient
 }
 
 func (s *InsightsTestSuite) SetupTest() {
@@ -30,23 +31,53 @@ func TestInsightsTestSuite(t *testing.T) {
 	suite.Run(t, new(InsightsTestSuite))
 }
 
-func PutRecord(*firehose.PutRecordInput) (*firehose.PutRecordOutput, error) {
-	
+func (m *mockFirehoseClient) PutRecord(input *firehose.PutRecordInput) (*firehose.PutRecordOutput, error) {
+	log.API.Infof("Mock called with DeliveryStreamName %s and PutRecordInput: %s", *input.DeliveryStreamName, input.Record.Data)
+	return nil, nil
 }
 
 func (s *InsightsTestSuite) TestInsightsDisabled() {
 	origSetting := conf.GetEnv("BCDA_ENABLE_INSIGHTS_EVENTS")
-	conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", false)
+	conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", "false")
+	originalLog := log.API
 
 	s.T().Cleanup(func() {
 		conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", origSetting)
+		log.API = originalLog
 	})
 
+	// Override log.API so we can verify the output
 	buf := new(bytes.Buffer)
-	log.API.SetOutput(&buf)
+	newLog := logrus.New()
+	newLog.SetOutput(buf)
+	log.API = newLog
 
 	PutEvent(s.mockSvc, "TestInsightsDisabledName", "TestInsightsDisabledEvent")
+	assert.Contains(s.T(), buf.String(), "Insights is not enabled for the application.  No data was sent to BFD.")
+}
 
-	assert.Contains(buf.String(), "Insights is not enabled for the application.  No data was sent to BFD.")
-	buf.Reset()	
+func (s *InsightsTestSuite) TestInsightsEnabled() {
+
+	origSetting := conf.GetEnv("BCDA_ENABLE_INSIGHTS_EVENTS")
+	origEnv := conf.GetEnv("DEPLOYMENT_TARGET")
+	conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", "true")
+	conf.SetEnv(s.T(), "DEPLOYMENT_TARGET", "unit-test")
+	originalLog := log.API
+
+	s.T().Cleanup(func() {
+		conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", origSetting)
+		conf.SetEnv(s.T(), "DEPLOYMENT_TARGET", origEnv)
+		log.API = originalLog
+	})
+
+	// Override log.API so we can verify the output
+	buf := new(bytes.Buffer)
+	newLog := logrus.New()
+	newLog.SetOutput(buf)
+	log.API = newLog
+
+	PutEvent(s.mockSvc, "TestInsightsEnabledName", "TestInsightsEnabledEvent")
+	assert.Contains(s.T(), buf.String(), "TestInsightsEnabledName")
+	assert.Contains(s.T(), buf.String(), "TestInsightsEnabledEvent")
+	assert.Contains(s.T(), buf.String(), "bfd-insights-bcda-unit-test-TestInsightsEnabledName")
 }

--- a/bcda/insights/insights_test.go
+++ b/bcda/insights/insights_test.go
@@ -1,9 +1,11 @@
 package insights
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
 
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
@@ -24,12 +26,12 @@ func (s *InsightsTestSuite) SetupTest() {
 	s.mockSvc = &mockFirehoseClient{}
 }
 
-func InsightsTestSuite(t *testing.T) {
+func TestInsightsTestSuite(t *testing.T) {
 	suite.Run(t, new(InsightsTestSuite))
 }
 
 func PutRecord(*firehose.PutRecordInput) (*firehose.PutRecordOutput, error) {
-	// TODO
+	
 }
 
 func (s *InsightsTestSuite) TestInsightsDisabled() {
@@ -40,7 +42,11 @@ func (s *InsightsTestSuite) TestInsightsDisabled() {
 		conf.SetEnv(s.T(), "BCDA_ENABLE_INSIGHTS_EVENTS", origSetting)
 	})
 
+	buf := new(bytes.Buffer)
+	log.API.SetOutput(&buf)
+
 	PutEvent(s.mockSvc, "TestInsightsDisabledName", "TestInsightsDisabledEvent")
 
-	// TODO: assert
+	assert.Contains(buf.String(), "Insights is not enabled for the application.  No data was sent to BFD.")
+	buf.Reset()	
 }

--- a/bcda/insights/insights_test.go
+++ b/bcda/insights/insights_test.go
@@ -79,5 +79,5 @@ func (s *InsightsTestSuite) TestInsightsEnabled() {
 	PutEvent(s.mockSvc, "TestInsightsEnabledName", "TestInsightsEnabledEvent")
 	assert.Contains(s.T(), buf.String(), "TestInsightsEnabledName")
 	assert.Contains(s.T(), buf.String(), "TestInsightsEnabledEvent")
-	assert.Contains(s.T(), buf.String(), "bfd-insights-bcda-unit-test-TestInsightsEnabledName")
+	assert.Contains(s.T(), buf.String(), "bfd-insights-bcda-unit-test-event_processor")
 }


### PR DESCRIPTION

### Fixes [BCDA-4532](https://jira.cms.gov/browse/BCDA-4532)

We have built a capability for BFD Insights to acquire BCDA metrics by using a lambda to periodically poll our Read Replica database, extract the necessary metrics, and push them to BFD Insights.  However, there exists the need to send real-time events to BFD Insights via the BCDA application itself.  This PR adds a utility to allow the BCDA application to send real-time events to BFD.

These changes were implemented and tested in conjunction with the infrastructure changes outlined in [this PR](https://github.com/CMSgov/bcda-ops/pull/740).

### Change Details

- Added a utility function (`PutEvent`) which can be used to send a real-time event to BFD Insights (as long as the `BCDA_ENABLE_INSIGHTS_EVENTS` feature flag is enabled).
- Added proper unit test coverage for the new utility function.

Note: [a version](https://github.com/CMSgov/bcda-app/pull/707/commits/5e2c540dc732ef658b1b2f6c7af44d0914c223a2) of this feature branch containing a was deployed so that the utility function could be tested.  The purpose of this PR, however, is to simply introduce the utility function.  The development team can now determine where the utility function can be invoked to send data to BFD Insights.  The invocation of the utility function is as simple as this:

```
insights.PutEvent(insights.GetFirehose(), "name-of-event", "log message")
```

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
> Related to [this](https://confluence.cms.gov/display/BCDA/20-09-14%3A+BFD+Insights+-+AWS+Kinesis+Firehose+Integration+with+BCDA) security checklist
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

The feature branches (for both `bcda-app` and `bcda-ops`) were deployed to `dev` with the feature flag `BCDA_ENABLE_INSIGHTS_EVENTS` enabled.  In addition, some code was added to `bcda-apps` so that events for 1-800-Medicare data ingestion would be transmitted to BFD.  After invoking a 1-800-Medicare data ingestion, it was confirmed that data appeared in BFD Insights by querying Athena directly:


<img width="1644" alt="Screen Shot 2021-05-19 at 12 27 40 PM" src="https://user-images.githubusercontent.com/37818548/118849485-ca662480-b89d-11eb-8664-164040ca55d0.png">

...
... 

<img width="1640" alt="Screen Shot 2021-05-19 at 12 28 19 PM" src="https://user-images.githubusercontent.com/37818548/118849480-c9cd8e00-b89d-11eb-8bb3-ee629250cf14.png">




### Feedback Requested

Please review.
