### PR TITLE
BCDA-4515: Implement jobs endpoints for v2

### DIFF
--- a/Dockerfiles/Dockerfile.documentation
+++ b/Dockerfiles/Dockerfile.documentation
@@ -27,5 +27,5 @@ CMD mkdir -p swaggerui/v2 && \
     cp -r /tmp/swagger-ui-${swaggerVersion}/dist/* swaggerui/v1/ && \
     cp -r /tmp/swagger-ui-${swaggerVersion}/dist/* swaggerui/v2/ && \
     swagger generate spec -o swaggerui/v1/swagger.json -m --include-tag metadata --include-tag bulkData --include-tag auth --include-tag job && \
-    swagger generate spec -o swaggerui/v2/swagger.json -m --include-tag metadataV2 --include-tag bulkDataV2 --include-tag auth --include-tag job && \
+    swagger generate spec -o swaggerui/v2/swagger.json -m --include-tag metadataV2 --include-tag bulkDataV2 --include-tag auth --include-tag jobV2 && \
     swagger generate spec -o swaggerui/swagger.json -m

--- a/bcda/api/alr_test.go
+++ b/bcda/api/alr_test.go
@@ -57,7 +57,7 @@ func (s *AlrTestSuite) TestAlrRequest() {
 	enqueuer := &queueing.MockEnqueuer{}
 	enqueuer.On("AddAlrJob", mock.Anything, mock.Anything).Return(nil)
 
-	h := newHandler([]string{"Patient", "Observation"}, "v1", s.db)
+	h := newHandler([]string{"Patient", "Observation"}, "v1", "v1", s.db)
 	h.Enq = enqueuer
 
 	// Set up request with the correct context scoped values

--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -52,13 +52,15 @@ type Handler struct {
 	supportedResources map[string]struct{}
 
 	bbBasePath string
+
+	apiVersion string
 }
 
-func NewHandler(resources []string, basePath string) *Handler {
-	return newHandler(resources, basePath, database.Connection)
+func NewHandler(resources []string, basePath string, apiVersion string) *Handler {
+	return newHandler(resources, basePath, apiVersion, database.Connection)
 }
 
-func newHandler(resources []string, basePath string, db *sql.DB) *Handler {
+func newHandler(resources []string, basePath string, apiVersion string, db *sql.DB) *Handler {
 	h := &Handler{JobTimeout: time.Hour * time.Duration(utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24))}
 
 	h.Enq = queueing.NewEnqueuer()
@@ -78,6 +80,7 @@ func newHandler(resources []string, basePath string, db *sql.DB) *Handler {
 	}
 
 	h.bbBasePath = basePath
+	h.apiVersion = apiVersion
 
 	return h
 }
@@ -357,7 +360,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 		}
 
 		// We've successfully created the job
-		w.Header().Set("Content-Location", fmt.Sprintf("%s://%s/api/v1/jobs/%d", scheme, r.Host, newJob.ID))
+		w.Header().Set("Content-Location", fmt.Sprintf("%s://%s/api/%s/jobs/%d", scheme, r.Host, h.apiVersion, newJob.ID))
 		w.WriteHeader(http.StatusAccepted)
 	}()
 

--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -1,12 +1,17 @@
 package api
 
 import (
+	"context"
 	"database/sql"
-	"errors"
+	"encoding/json"
+	goerrors "errors"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi"
+	"github.com/pkg/errors"
 
 	"net/http"
 	"time"
@@ -27,6 +32,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/bcda/web/middleware"
 	"github.com/CMSgov/bcda-app/bcdaworker/queueing"
+	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
 )
 
@@ -118,6 +124,140 @@ func (h *Handler) BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.bulkRequest(w, r, reqType)
+}
+
+func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
+	jobIDStr := chi.URLParam(r, "jobID")
+
+	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
+	if err != nil {
+		err = errors.Wrap(err, "cannot convert jobID to uint")
+		log.API.Error(err)
+		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, err.Error())
+		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		return
+	}
+
+	job, jobKeys, err := h.Svc.GetJobAndKeys(context.Background(), uint(jobID))
+	if err != nil {
+		log.API.Error(err)
+		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
+		// NOTE: This is a catch all and may not necessarily mean that the job was not found.
+		// So returning a StatusNotFound may be a misnomer
+		responseutils.WriteError(oo, w, http.StatusNotFound)
+		return
+	}
+
+	switch job.Status {
+
+	case models.JobStatusFailed, models.JobStatusFailedExpired:
+		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.InternalErr, "Service encountered numerous errors.  Unable to complete the request.")
+		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+	case models.JobStatusPending, models.JobStatusInProgress:
+		w.Header().Set("X-Progress", job.StatusMessage())
+		w.WriteHeader(http.StatusAccepted)
+		return
+	case models.JobStatusCompleted:
+		// If the job should be expired, but the cleanup job hasn't run for some reason, still respond with 410
+		if job.UpdatedAt.Add(h.JobTimeout).Before(time.Now()) {
+			w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
+			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
+				responseutils.NotFoundErr, "")
+			responseutils.WriteError(oo, w, http.StatusGone)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
+		scheme := "http"
+		if servicemux.IsHTTPS(r) {
+			scheme = "https"
+		}
+
+		rb := BulkResponseBody{
+			TransactionTime:     job.TransactionTime,
+			RequestURL:          job.RequestURL,
+			RequiresAccessToken: true,
+			Files:               []FileItem{},
+			Errors:              []FileItem{},
+			JobID:               job.ID,
+		}
+
+		for _, jobKey := range jobKeys {
+			// data files
+			fi := FileItem{
+				Type: jobKey.ResourceType,
+				URL:  fmt.Sprintf("%s://%s/data/%d/%s", scheme, r.Host, jobID, strings.TrimSpace(jobKey.FileName)),
+			}
+			rb.Files = append(rb.Files, fi)
+
+			// error files
+			errFileName := strings.Split(jobKey.FileName, ".")[0]
+			errFilePath := fmt.Sprintf("%s/%d/%s-error.ndjson", conf.GetEnv("FHIR_PAYLOAD_DIR"), jobID, errFileName)
+			if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
+				errFI := FileItem{
+					Type: "OperationOutcome",
+					URL:  fmt.Sprintf("%s://%s/data/%d/%s-error.ndjson", scheme, r.Host, jobID, errFileName),
+				}
+				rb.Errors = append(rb.Errors, errFI)
+			}
+		}
+
+		jsonData, err := json.Marshal(rb)
+		if err != nil {
+			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
+				responseutils.InternalErr, "")
+			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			return
+		}
+
+		_, err = w.Write([]byte(jsonData))
+		if err != nil {
+			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
+				responseutils.InternalErr, "")
+			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	case models.JobStatusArchived, models.JobStatusExpired:
+		w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
+		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
+			responseutils.NotFoundErr, "")
+		responseutils.WriteError(oo, w, http.StatusGone)
+	case models.JobStatusCancelled, models.JobStatusCancelledExpired:
+		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_NOT_FOUND,
+			responseutils.NotFoundErr, "Job has been cancelled.")
+		responseutils.WriteError(oo, w, http.StatusNotFound)
+	}
+}
+
+func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
+	jobIDStr := chi.URLParam(r, "jobID")
+
+	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
+	if err != nil {
+		err = errors.Wrap(err, "cannot convert jobID to uint")
+		log.API.Error(err)
+		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, err.Error())
+		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		return
+	}
+
+	_, err = h.Svc.CancelJob(context.Background(), uint(jobID))
+	if err != nil {
+		switch err {
+		case service.ErrJobNotCancellable:
+			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DeletedErr, err.Error())
+			responseutils.WriteError(oo, w, http.StatusGone)
+			return
+		default:
+			log.API.Error(err)
+			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, err.Error())
+			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusAccepted)
 }
 
 func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType service.RequestType) {
@@ -259,7 +399,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 			oo       *fhirmodels.OperationOutcome
 			respCode int
 		)
-		if ok := errors.As(err, &service.CCLFNotFoundError{}); ok && reqType == service.Runout {
+		if ok := goerrors.As(err, &service.CCLFNotFoundError{}); ok && reqType == service.Runout {
 			oo = responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
 				responseutils.NotFoundErr, err.Error())
 			respCode = http.StatusNotFound
@@ -313,7 +453,7 @@ func readAuthData(r *http.Request) (data auth.AuthData, err error) {
 	var ok bool
 	data, ok = r.Context().Value(auth.AuthDataContextKey).(auth.AuthData)
 	if !ok {
-		err = errors.New("no auth data in context")
+		err = goerrors.New("no auth data in context")
 	}
 	return
 }

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -96,7 +96,7 @@ func (s *RequestsTestSuite) TestRunoutEnabled() {
 			}
 
 			mockSvc.On("GetQueJobs", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(jobs, tt.errToReturn)
-			h := newHandler([]string{"ExplanationOfBenefit", "Coverage", "Patient"}, "/v1/fhir", s.db)
+			h := newHandler([]string{"ExplanationOfBenefit", "Coverage", "Patient"}, "/v1/fhir", "v1", s.db)
 			h.Svc = mockSvc
 
 			req := s.genGroupRequest("runout", middleware.RequestParameters{})
@@ -135,7 +135,7 @@ func (s *RequestsTestSuite) TestRunoutDisabled() {
 // TestRequests verifies that we can initiate an export job for all resource types using all the different handlers
 func (s *RequestsTestSuite) TestRequests() {
 
-	h := newHandler([]string{"ExplanationOfBenefit", "Coverage", "Patient"}, "/v1/fhir", s.db)
+	h := newHandler([]string{"ExplanationOfBenefit", "Coverage", "Patient"}, "/v1/fhir", "v1", s.db)
 
 	// Use a mock to ensure that this test does not generate artifacts in the queue for other tests
 	enqueuer := &queueing.MockEnqueuer{}

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -2,27 +2,20 @@ package v1
 
 import (
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi"
 	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
-	"github.com/pkg/errors"
 
 	"github.com/CMSgov/bcda-app/bcda/api"
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/health"
-	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
-	"github.com/CMSgov/bcda-app/bcda/service"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
@@ -111,108 +104,7 @@ func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
 		500: errorResponse
 */
 func JobStatus(w http.ResponseWriter, r *http.Request) {
-	jobIDStr := chi.URLParam(r, "jobID")
-
-	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
-	if err != nil {
-		err = errors.Wrap(err, "cannot convert jobID to uint")
-		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, err.Error())
-		responseutils.WriteError(oo, w, http.StatusBadRequest)
-		return
-	}
-
-	job, jobKeys, err := h.Svc.GetJobAndKeys(context.Background(), uint(jobID))
-	if err != nil {
-		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
-		// NOTE: This is a catch all and may not necessarily mean that the job was not found.
-		// So returning a StatusNotFound may be a misnomer
-		responseutils.WriteError(oo, w, http.StatusNotFound)
-		return
-	}
-
-	switch job.Status {
-
-	case models.JobStatusFailed, models.JobStatusFailedExpired:
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.InternalErr, "Service encountered numerous errors.  Unable to complete the request.")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
-	case models.JobStatusPending, models.JobStatusInProgress:
-		w.Header().Set("X-Progress", job.StatusMessage())
-		w.WriteHeader(http.StatusAccepted)
-		return
-	case models.JobStatusCompleted:
-		// If the job should be expired, but the cleanup job hasn't run for some reason, still respond with 410
-		if job.UpdatedAt.Add(h.JobTimeout).Before(time.Now()) {
-			w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, "")
-			responseutils.WriteError(oo, w, http.StatusGone)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
-		scheme := "http"
-		if servicemux.IsHTTPS(r) {
-			scheme = "https"
-		}
-
-		rb := api.BulkResponseBody{
-			TransactionTime:     job.TransactionTime,
-			RequestURL:          job.RequestURL,
-			RequiresAccessToken: true,
-			Files:               []api.FileItem{},
-			Errors:              []api.FileItem{},
-			JobID:               job.ID,
-		}
-
-		for _, jobKey := range jobKeys {
-			// data files
-			fi := api.FileItem{
-				Type: jobKey.ResourceType,
-				URL:  fmt.Sprintf("%s://%s/data/%d/%s", scheme, r.Host, jobID, strings.TrimSpace(jobKey.FileName)),
-			}
-			rb.Files = append(rb.Files, fi)
-
-			// error files
-			errFileName := strings.Split(jobKey.FileName, ".")[0]
-			errFilePath := fmt.Sprintf("%s/%d/%s-error.ndjson", conf.GetEnv("FHIR_PAYLOAD_DIR"), jobID, errFileName)
-			if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
-				errFI := api.FileItem{
-					Type: "OperationOutcome",
-					URL:  fmt.Sprintf("%s://%s/data/%d/%s-error.ndjson", scheme, r.Host, jobID, errFileName),
-				}
-				rb.Errors = append(rb.Errors, errFI)
-			}
-		}
-
-		jsonData, err := json.Marshal(rb)
-		if err != nil {
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.InternalErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
-			return
-		}
-
-		_, err = w.Write([]byte(jsonData))
-		if err != nil {
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.InternalErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-	case models.JobStatusArchived, models.JobStatusExpired:
-		w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-			responseutils.NotFoundErr, "")
-		responseutils.WriteError(oo, w, http.StatusGone)
-	case models.JobStatusCancelled, models.JobStatusCancelledExpired:
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_NOT_FOUND,
-			responseutils.NotFoundErr, "Job has been cancelled.")
-		responseutils.WriteError(oo, w, http.StatusNotFound)
-	}
+	h.JobStatus(w, r)
 }
 
 type gzipResponseWriter struct {
@@ -248,32 +140,7 @@ func (w gzipResponseWriter) Write(b []byte) (int, error) {
 		500: errorResponse
 */
 func DeleteJob(w http.ResponseWriter, r *http.Request) {
-	jobIDStr := chi.URLParam(r, "jobID")
-
-	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
-	if err != nil {
-		err = errors.Wrap(err, "cannot convert jobID to uint")
-		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, err.Error())
-		responseutils.WriteError(oo, w, http.StatusBadRequest)
-		return
-	}
-
-	_, err = h.Svc.CancelJob(context.Background(), uint(jobID))
-	if err != nil {
-		switch err {
-		case service.ErrJobNotCancellable:
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DeletedErr, err.Error())
-			responseutils.WriteError(oo, w, http.StatusGone)
-			return
-		default:
-			log.API.Error(err)
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, err.Error())
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
-			return
-		}
-	}
-	w.WriteHeader(http.StatusAccepted)
+	h.DeleteJob(w, r)
 }
 
 /*

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -24,7 +24,7 @@ import (
 var h *api.Handler
 
 func init() {
-	h = api.NewHandler([]string{"Patient", "Coverage", "ExplanationOfBenefit", "Observation"}, "/v1/fhir")
+	h = api.NewHandler([]string{"Patient", "Coverage", "ExplanationOfBenefit", "Observation"}, "/v1/fhir", "v1")
 }
 
 /*

--- a/bcda/api/v2/api.go
+++ b/bcda/api/v2/api.go
@@ -89,6 +89,62 @@ func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
+	swagger:route GET /api/v1/jobs/{jobId} job jobStatus
+
+	Get job status
+
+	Returns the current status of an export job.
+
+	Produces:
+	- application/fhir+json
+
+	Schemes: http, https
+
+	Security:
+		bearer_token:
+
+	Responses:
+		202: jobStatusResponse
+		200: completedJobResponse
+		400: badRequestResponse
+		401: invalidCredentials
+		404: notFoundResponse
+		410: goneResponse
+		500: errorResponse
+*/
+func JobStatus(w http.ResponseWriter, r *http.Request) {
+	h.JobStatus(w, r)
+}
+
+/*
+	swagger:route DELETE /api/v1/jobs/{jobId} job deleteJob
+
+	Cancel a job
+
+	Cancels a currently running job.
+
+	Produces:
+	- application/fhir+json
+
+	Schemes: http, https
+
+	Security:
+		bearer_token:
+
+	Responses:
+		202: deleteJobResponse
+		400: badRequestResponse
+		401: invalidCredentials
+		404: notFoundResponse
+		410: goneResponse
+		500: errorResponse
+*/
+
+func DeleteJob(w http.ResponseWriter, r *http.Request) {
+	h.DeleteJob(w, r)
+}
+
+/*
 	swagger:route GET /api/v2/metadata metadataV2 metadata
 
 	Get metadata

--- a/bcda/api/v2/api.go
+++ b/bcda/api/v2/api.go
@@ -27,7 +27,7 @@ var (
 func init() {
 	var err error
 
-	h = api.NewHandler([]string{"Patient", "Coverage"}, "/v2/fhir")
+	h = api.NewHandler([]string{"Patient", "Coverage"}, "/v2/fhir", "v2")
 	// Ensure that we write the serialized FHIR resources as a single line.
 	// Needed to comply with the NDJSON format that we are using.
 	marshaller, err = jsonformat.NewMarshaller(false, "", "", jsonformat.R4)

--- a/bcda/api/v2/api.go
+++ b/bcda/api/v2/api.go
@@ -89,7 +89,7 @@ func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	swagger:route GET /api/v1/jobs/{jobId} job jobStatus
+	swagger:route GET /api/v2/jobs/{jobId} jobV2 jobStatusV2
 
 	Get job status
 
@@ -117,7 +117,7 @@ func JobStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	swagger:route DELETE /api/v1/jobs/{jobId} job deleteJob
+	swagger:route DELETE /api/v2/jobs/{jobId} jobV2 deleteJobV2
 
 	Cancel a job
 

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -3,19 +3,25 @@ package v2
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/CMSgov/bcda-app/bcda/api"
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
+	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/web/middleware"
 	"github.com/CMSgov/bcda-app/bcdaworker/queueing"
 	"github.com/CMSgov/bcda-app/conf"
@@ -25,6 +31,7 @@ import (
 	"github.com/google/fhir/go/jsonformat"
 	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
 	fhirresources "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
+	fhiroo "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/operation_outcome_go_proto"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -32,7 +39,11 @@ import (
 )
 
 const (
-	acoUnderTest = constants.LargeACOUUID // Should use a different ACO compared to v1 tests
+	expiryHeaderFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+)
+
+var (
+	acoUnderTest = uuid.Parse(constants.LargeACOUUID)
 )
 
 type APITestSuite struct {
@@ -66,10 +77,291 @@ func (s *APITestSuite) SetupSuite() {
 	client.SetLogger(log.BBAPI)
 }
 
+func (s *APITestSuite) TearDownTest() {
+	postgrestest.DeleteJobsByACOID(s.T(), s.db, acoUnderTest)
+}
+
 func TestAPITestSuite(t *testing.T) {
 	suite.Run(t, new(APITestSuite))
 }
 
+func (s *APITestSuite) TestJobStatusBadInputs() {
+	tests := []struct {
+		name          string
+		jobID         string
+		expStatusCode int
+		expErrCode    string
+	}{
+		{"InvalidJobID", "abcd", 400, responseutils.RequestErr},
+		{"DoesNotExist", "0", 404, responseutils.DbErr},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/jobs/%s", tt.jobID), nil)
+			rr := httptest.NewRecorder()
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("jobID", tt.jobID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			ad := s.makeContextValues(acoUnderTest)
+			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+
+			JobStatus(rr, req)
+
+			respOO := getOperationOutcome(t, rr.Body.Bytes())
+
+			assert.Equal(t, fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+			assert.Equal(t, fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+			assert.Equal(t, tt.expErrCode, respOO.Issue[0].Details.Coding[0].Code.Value)
+		})
+	}
+}
+
+func (s *APITestSuite) TestJobStatusNotComplete() {
+	tests := []struct {
+		status        models.JobStatus
+		expStatusCode int
+	}{
+		{models.JobStatusPending, http.StatusAccepted},
+		{models.JobStatusInProgress, http.StatusAccepted},
+		{models.JobStatusFailed, http.StatusInternalServerError},
+		{models.JobStatusFailedExpired, http.StatusInternalServerError},
+		{models.JobStatusExpired, http.StatusGone},
+		{models.JobStatusArchived, http.StatusGone},
+		{models.JobStatusCancelled, http.StatusNotFound},
+		{models.JobStatusCancelledExpired, http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(string(tt.status), func(t *testing.T) {
+			j := models.Job{
+				ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+				RequestURL: "/api/v2/Patient/$export?_type=ExplanationOfBenefit",
+				Status:     tt.status,
+			}
+			postgrestest.CreateJobs(t, s.db, &j)
+			defer postgrestest.DeleteJobByID(t, s.db, j.ID)
+
+			req := s.createJobStatusRequest(acoUnderTest, j.ID)
+			rr := httptest.NewRecorder()
+
+			JobStatus(rr, req)
+			assert.Equal(t, tt.expStatusCode, rr.Code)
+			if rr.Code == http.StatusAccepted {
+				assert.Contains(t, rr.Header().Get("X-Progress"), tt.status)
+				assert.Equal(t, "", rr.Header().Get("Expires"))
+			} else if rr.Code == http.StatusInternalServerError {
+				assert.Contains(t, rr.Body.String(), "Service encountered numerous errors")
+			} else if rr.Code == http.StatusGone {
+				assertExpiryEquals(t, j.CreatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
+			}
+		})
+	}
+}
+
+// https://stackoverflow.com/questions/34585957/postgresql-9-3-how-to-insert-upper-case-uuid-into-table
+func (s *APITestSuite) TestJobStatusCompleted() {
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v2/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+
+	var expectedUrls []string
+	for i := 1; i <= 10; i++ {
+		fileName := fmt.Sprintf("%s.ndjson", uuid.NewRandom().String())
+		expectedurl := fmt.Sprintf("%s/%s/%s", "http://example.com/data", fmt.Sprint(j.ID), fileName)
+		expectedUrls = append(expectedUrls, expectedurl)
+		postgrestest.CreateJobKeys(s.T(), s.db,
+			models.JobKey{JobID: j.ID, FileName: fileName, ResourceType: "ExplanationOfBenefit"})
+	}
+
+	req := s.createJobStatusRequest(acoUnderTest, j.ID)
+	rr := httptest.NewRecorder()
+
+	JobStatus(rr, req)
+
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+	assert.Equal(s.T(), "application/json", rr.Header().Get("Content-Type"))
+	str := rr.Header().Get("Expires")
+	fmt.Println(str)
+	assertExpiryEquals(s.T(), j.CreatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
+
+	var rb api.BulkResponseBody
+	err := json.Unmarshal(rr.Body.Bytes(), &rb)
+	if err != nil {
+		s.T().Error(err)
+	}
+
+	assert.Equal(s.T(), j.RequestURL, rb.RequestURL)
+	assert.Equal(s.T(), true, rb.RequiresAccessToken)
+	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
+	assert.Equal(s.T(), len(expectedUrls), len(rb.Files))
+	// Order of these values is impossible to know so this is the only way
+	for _, fileItem := range rb.Files {
+		inOutput := false
+		for _, expectedUrl := range expectedUrls {
+			if fileItem.URL == expectedUrl {
+				inOutput = true
+				break
+			}
+		}
+		assert.True(s.T(), inOutput)
+
+	}
+	assert.Empty(s.T(), rb.Errors)
+}
+
+func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v2/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+
+	fileName := fmt.Sprintf("%s.ndjson", uuid.NewRandom().String())
+	jobKey := models.JobKey{
+		JobID:        j.ID,
+		FileName:     fileName,
+		ResourceType: "ExplanationOfBenefit",
+	}
+	postgrestest.CreateJobKeys(s.T(), s.db, jobKey)
+
+	f := fmt.Sprintf("%s/%s", conf.GetEnv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID))
+	if _, err := os.Stat(f); os.IsNotExist(err) {
+		err = os.MkdirAll(f, os.ModePerm)
+		if err != nil {
+			s.T().Error(err)
+		}
+	}
+
+	errFileName := strings.Split(jobKey.FileName, ".")[0]
+	errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", conf.GetEnv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID), errFileName)
+	_, err := os.Create(errFilePath)
+	if err != nil {
+		s.T().Error(err)
+	}
+
+	req := s.createJobStatusRequest(acoUnderTest, j.ID)
+	rr := httptest.NewRecorder()
+
+	JobStatus(rr, req)
+
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+	assert.Equal(s.T(), "application/json", rr.Header().Get("Content-Type"))
+
+	var rb api.BulkResponseBody
+	err = json.Unmarshal(rr.Body.Bytes(), &rb)
+	if err != nil {
+		s.T().Error(err)
+	}
+
+	dataurl := fmt.Sprintf("%s/%s/%s", "http://example.com/data", fmt.Sprint(j.ID), fileName)
+	errorurl := fmt.Sprintf("%s/%s/%s-error.ndjson", "http://example.com/data", fmt.Sprint(j.ID), errFileName)
+
+	assert.Equal(s.T(), j.RequestURL, rb.RequestURL)
+	assert.Equal(s.T(), true, rb.RequiresAccessToken)
+	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
+	assert.Equal(s.T(), dataurl, rb.Files[0].URL)
+	assert.Equal(s.T(), "OperationOutcome", rb.Errors[0].Type)
+	assert.Equal(s.T(), errorurl, rb.Errors[0].URL)
+
+	os.Remove(errFilePath)
+}
+
+// This job is old, but has not yet been marked as expired.
+func (s *APITestSuite) TestJobStatusNotExpired() {
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v2/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+
+	j.UpdatedAt = time.Now().Add(-(h.JobTimeout + time.Second))
+	postgrestest.UpdateJob(s.T(), s.db, j)
+
+	req := s.createJobStatusRequest(acoUnderTest, j.ID)
+	rr := httptest.NewRecorder()
+
+	JobStatus(rr, req)
+
+	assert.Equal(s.T(), http.StatusGone, rr.Code)
+	assertExpiryEquals(s.T(), j.UpdatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
+}
+
+func (s *APITestSuite) TestDeleteJobBadInputs() {
+	tests := []struct {
+		name          string
+		jobID         string
+		expStatusCode int
+		expErrCode    string
+	}{
+		{"InvalidJobID", "abcd", 400, responseutils.RequestErr},
+		{"DoesNotExist", "0", 404, responseutils.DbErr},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v2/jobs/%s", tt.jobID), nil)
+			rr := httptest.NewRecorder()
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("jobID", tt.jobID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			ad := s.makeContextValues(acoUnderTest)
+			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+
+			JobStatus(rr, req)
+
+			respOO := getOperationOutcome(t, rr.Body.Bytes())
+
+			assert.Equal(t, fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+			assert.Equal(t, fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+			assert.Equal(t, tt.expErrCode, respOO.Issue[0].Details.Coding[0].Code.Value)
+		})
+	}
+}
+
+func (s *APITestSuite) TestDeleteJob() {
+	tests := []struct {
+		status        models.JobStatus
+		expStatusCode int
+	}{
+		{models.JobStatusPending, http.StatusAccepted},
+		{models.JobStatusInProgress, http.StatusAccepted},
+		{models.JobStatusFailed, http.StatusGone},
+		{models.JobStatusExpired, http.StatusGone},
+		{models.JobStatusArchived, http.StatusGone},
+		{models.JobStatusCompleted, http.StatusGone},
+		{models.JobStatusCancelled, http.StatusGone},
+		{models.JobStatusFailedExpired, http.StatusGone},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(string(tt.status), func(t *testing.T) {
+			j := models.Job{
+				ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+				RequestURL: "/api/v2/Patient/$export?_type=Patient,Coverage",
+				Status:     tt.status,
+			}
+			postgrestest.CreateJobs(t, s.db, &j)
+			defer postgrestest.DeleteJobByID(t, s.db, j.ID)
+
+			req := s.createJobStatusRequest(acoUnderTest, j.ID)
+			rr := httptest.NewRecorder()
+
+			DeleteJob(rr, req)
+			assert.Equal(t, tt.expStatusCode, rr.Code)
+			if rr.Code == http.StatusGone {
+				assert.Contains(t, rr.Body.String(), "Job was not cancelled because it is not Pending or In Progress")
+			}
+		})
+	}
+}
 func (s *APITestSuite) TestMetadataResponse() {
 	ts := httptest.NewServer(http.HandlerFunc(Metadata))
 	defer ts.Close()
@@ -179,6 +471,40 @@ func (s *APITestSuite) TestResourceTypes() {
 }
 
 func (s *APITestSuite) getAuthData() (data auth.AuthData) {
-	aco := postgrestest.GetACOByUUID(s.T(), s.db, uuid.Parse(acoUnderTest))
-	return auth.AuthData{ACOID: acoUnderTest, CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
+	aco := postgrestest.GetACOByUUID(s.T(), s.db, acoUnderTest)
+	return auth.AuthData{ACOID: acoUnderTest.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
+}
+
+func (s *APITestSuite) makeContextValues(acoID uuid.UUID) (data auth.AuthData) {
+	aco := postgrestest.GetACOByUUID(s.T(), s.db, acoID)
+	return auth.AuthData{ACOID: aco.UUID.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
+}
+
+func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http.Request {
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v2/jobs/%d", jobID), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("jobID", fmt.Sprint(jobID))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	ad := s.makeContextValues(acoID)
+	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+}
+
+// Compare expiry header against the expected time value.
+// There seems to be some slight difference in precision here,
+// so we'll compare up to seconds
+func assertExpiryEquals(t *testing.T, expectedTime time.Time, expiry string) {
+	expiryTime, err := time.Parse(expiryHeaderFormat, expiry)
+	if err != nil {
+		t.Fatalf("Failed to parse %s to time.Time %s", expiry, err)
+	}
+
+	assert.Equal(t, time.Duration(0), expectedTime.Round(time.Second).Sub(expiryTime.Round(time.Second)))
+}
+
+func getOperationOutcome(t *testing.T, data []byte) *fhiroo.OperationOutcome {
+	unmarshaller, err := jsonformat.NewUnmarshaller("UTC", jsonformat.R4)
+	assert.NoError(t, err)
+	container, err := unmarshaller.Unmarshal(data)
+	assert.NoError(t, err)
+	return container.(*fhirresources.ContainedResource).GetOperationOutcome()
 }

--- a/bcda/models/SwaggerStructs.go
+++ b/bcda/models/SwaggerStructs.go
@@ -126,7 +126,7 @@ type NDJSON string
 // A JobStatus parameter model.
 //
 // This is used for operations that want the ID of a job in the path
-// swagger:parameters jobStatus serveData deleteJob
+// swagger:parameters jobStatus jobStatusV2 serveData deleteJob deleteJobV2
 type JobIDParam struct {
 	// ID of data export job
 	//

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -61,6 +61,8 @@ func NewAPIRouter() http.Handler {
 		r.Route("/api/v2", func(r chi.Router) {
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Patient/$export", v2.BulkPatientRequest))
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Group/{groupId}/$export", v2.BulkGroupRequest))
+			r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Get(m.WrapHandler("/jobs/{jobID}", v2.JobStatus))
+			r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Delete(m.WrapHandler("/jobs/{jobID}", v2.DeleteJob))
 			r.Get(m.WrapHandler("/metadata", v2.Metadata))
 		})
 	}

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -198,6 +198,8 @@ func (s *RouterTestSuite) TestV2EndpointsDisabled() {
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 	res = s.getAPIRoute("/api/v2/Group/all/$export")
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+	res = s.getAPIRoute("/api/v2/jobs/{jobID}")
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 	res = s.getAPIRoute("/api/v2/metadata")
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 }
@@ -212,6 +214,8 @@ func (s *RouterTestSuite) TestV2EndpointsEnabled() {
 	res := s.getAPIRoute("/api/v2/Patient/$export")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 	res = s.getAPIRoute("/api/v2/Group/all/$export")
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute("/api/v2/jobs/{jobID}")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 	res = s.getAPIRoute("/api/v2/metadata")
 	assert.Equal(s.T(), http.StatusOK, res.StatusCode)

--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -43,7 +43,7 @@ func init() {
 	flag.StringVar(&apiVersion, "apiVersion", "v1", "resourceType to test")
 	flag.IntVar(&timeout, "timeout", 300, "amount of time to wait for file to be ready and downloaded.")
 	flag.StringVar(&endpoint, "endpoint", "", "base type of request endpoint in the format of Patient or Group/all or Group/new")
-	flag.IntVar(&httpRetry, "httpRetry", 3, "amount of times to retry an http request")
+	flag.IntVar(&httpRetry, "httpRetry", 4, "amount of times to retry an http request")
 	flag.Parse()
 }
 


### PR DESCRIPTION
### Fixes [BCDA-4515](https://jira.cms.gov/browse/BCDA-4515)
We use the `jobs/{jobID}` endpoint in v1 to allow GET requests to check the status of a job, and DELETE requests to cancel an in-progress or pending job. This ticket makes the endpoints available in v2.

### Change Details
- Move `JobStatus` and `DeleteJob` methods out of `api/v1/api.go` and into `api/requests.go`; this allows each method to be version-agnostic and easily accessible for both v1 and v2.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
Unit, smoke, and postman tests passing locally
Confirmed `/jobs/...` endpoint was available locally with v2 enabled, via Swagger
<img width="1000" alt="v2_jobs_endpoints" src="https://user-images.githubusercontent.com/28958790/118883234-9fd69480-b8ba-11eb-873d-76e68691ea7c.png">


### Feedback Requested
- I had to increase the `httpRetry` flag in `bcda_client.go` from 3 to 4 in order for smoke tests to pass; any concerns with that change?
- Any additional test coverage needed
- General improvements or suggestions