### PR TITLE
bcda-4565 Feature: Signal handling for cli tools

### DIFF
--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -113,7 +114,7 @@ func (s *CLITestSuite) TestIgnoreSignals() {
 	// 3. Sending both SIGINT and SIGTERM signals to verify the signals are being handled (ignored).
 	// 4. Assert that the signal channel is empty, meaning both signals have been handled.
 	sigs := ignoreSignals()
-	defer close(sigs)
+	defer signal.Stop(sigs)
 
 	process, err := os.FindProcess(os.Getpid())
 	assert.NoError(s.T(), err)
@@ -123,7 +124,7 @@ func (s *CLITestSuite) TestIgnoreSignals() {
 	err = process.Signal(syscall.SIGTERM)
 	assert.NoError(s.T(), err)
 
-	time.Sleep(50 * time.Millisecond) // Assure both signal requests have a chance to be handled
+	time.Sleep(100 * time.Millisecond) // Assure both signal requests have a chance to be handled
 
 	assert.Equal(s.T(), 0, len(sigs), "ignoreSignals has not pulled the signal from sigs channel")
 }

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -118,8 +118,10 @@ func (s *CLITestSuite) TestIgnoreSignals() {
 	process, err := os.FindProcess(os.Getpid())
 	assert.NoError(s.T(), err)
 
-	process.Signal(syscall.SIGINT)
-	process.Signal(syscall.SIGTERM)
+	err = process.Signal(syscall.SIGINT)
+	assert.NoError(s.T(), err)
+	err = process.Signal(syscall.SIGTERM)
+	assert.NoError(s.T(), err)
 
 	time.Sleep(50 * time.Millisecond) // Assure both signal requests have a chance to be handled
 


### PR DESCRIPTION
### Fixes [BCDA-4565](https://jira.cms.gov/browse/BCDA-4565)

Currently, if our cclf and 1800 medicare ingestions process gets a termination signal from AWS it will stop immediately. Since we attempt to ingest on an hourly basis we would like these ingestions to get a chance to finish.

### Proposed Changes

Add signal handling to both ingestion cli process commands that ignores the termination signals.

Note that AWS will send a power down request to its ec2 instances when trying to shut them down. This results in the instance giving a `SIGTERM` to its running processes to kill them gracefully. If the instance takes to long shutting down, AWS will then send a `SIGKILL` signal instead to force it to shutdown immediately. That wait time depends on how our ops team has set that up... though by default the wait time should be more than long enough for our ingestions to finish.

### Change Details

- add `ignoreSignals` method that consumes the `SIGINT` and `SIGTERM` signals, logs that they have been received, and ignores them. 
- add test to verify `ignoreSignals` ignores the signals correctly.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

CCLF ingestion and 1800 Medicare ingestion now ignores `SIGINT` and `SIGTERM` signals to allows running ingestions to finish.

### Feedback Requested

This was my proposed solution... there may be a better way to do this.