### PR TITLE
BCDA-4477: Update to Postgres 11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: "3"
 
 services:
   queue:
-    image: postgres:10
+    image: postgres:11
     environment:
       - POSTGRES_DB=bcda_queue
       - POSTGRES_PASSWORD=toor
     ports:
       - "5433:5432"
   db:
-    image: postgres:10
+    image: postgres:11
     environment:
       - POSTGRES_DB=bcda
       - POSTGRES_PASSWORD=toor


### PR DESCRIPTION
### Partially Fixes [BCDA-4477](https://jira.cms.gov/browse/BCDA-4477)

The ACO API environment is currently running on Postgres 10.  To ensure we don't get too far behind, we should upgrade to Postgres 11.  

### Proposed Changes

The system/infrastructure (i.e., RDS) will be updated in separate implementations in `bcda-ops`.  However, to ensure the local development environment functions with Postgres 11, the Docker Compose stack configuration should be updated.

### Change Details

Updated the Docker Compose stack configuration to ensure the local development environment (and CI) used Postgres 11.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Because the Docker Compose configuration is the only thing affected as part of this PR, a successful execution of the CI steps in Github Actions is sufficient acceptance.

### Feedback Requested

Please review.
