### PR TITLE
bcda-4649 Feature: API v2 response r4 compatible

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -93,7 +93,7 @@ func newHandler(resources []string, basePath string, apiVersion string, db *sql.
 	case "v2":
 		h.RespWriter = responseutilsv2.NewResponseWriter()
 	default:
-		log.API.Fatalf("Unexpected API version: %s", h.apiVersion)
+		log.API.Fatalf("unexpected API version: %s", h.apiVersion)
 	}
 
 	return h

--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -16,9 +16,6 @@ import (
 	"net/http"
 	"time"
 
-	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
-	fhirmodels "github.com/google/fhir/go/proto/google/fhir/proto/stu3/resources_go_proto"
-
 	"github.com/pborman/uuid"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
@@ -26,7 +23,8 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
-	"github.com/CMSgov/bcda-app/bcda/responseutils"
+	responseutils "github.com/CMSgov/bcda-app/bcda/responseutils"
+	responseutilsv2 "github.com/CMSgov/bcda-app/bcda/responseutils/v2"
 	"github.com/CMSgov/bcda-app/bcda/service"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/CMSgov/bcda-app/bcda/utils"
@@ -54,6 +52,13 @@ type Handler struct {
 	bbBasePath string
 
 	apiVersion string
+
+	RespWriter fhirResponseWriter
+}
+
+type fhirResponseWriter interface {
+	Exception(http.ResponseWriter, int, string, string)
+	NotFound(http.ResponseWriter, int, string, string)
 }
 
 func NewHandler(resources []string, basePath string, apiVersion string) *Handler {
@@ -81,6 +86,15 @@ func newHandler(resources []string, basePath string, apiVersion string, db *sql.
 
 	h.bbBasePath = basePath
 	h.apiVersion = apiVersion
+
+	switch h.apiVersion {
+	case "v1":
+		h.RespWriter = responseutils.NewResponseWriter()
+	case "v2":
+		h.RespWriter = responseutilsv2.NewResponseWriter()
+	default:
+		log.API.Fatalf("Unexpected API version: %s", h.apiVersion)
+	}
 
 	return h
 }
@@ -117,8 +131,7 @@ func (h *Handler) BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		fallthrough
 	default:
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, "Invalid group ID")
-		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		h.RespWriter.Exception(w, http.StatusBadRequest, responseutils.RequestErr, "Invalid group ID")
 		return
 	}
 
@@ -136,26 +149,23 @@ func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		err = errors.Wrap(err, "cannot convert jobID to uint")
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, err.Error())
-		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		h.RespWriter.Exception(w, http.StatusBadRequest, responseutils.RequestErr, err.Error())
 		return
 	}
 
 	job, jobKeys, err := h.Svc.GetJobAndKeys(context.Background(), uint(jobID))
 	if err != nil {
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
 		// NOTE: This is a catch all and may not necessarily mean that the job was not found.
 		// So returning a StatusNotFound may be a misnomer
-		responseutils.WriteError(oo, w, http.StatusNotFound)
+		h.RespWriter.Exception(w, http.StatusNotFound, responseutils.DbErr, "")
 		return
 	}
 
 	switch job.Status {
 
 	case models.JobStatusFailed, models.JobStatusFailedExpired:
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.InternalErr, "Service encountered numerous errors.  Unable to complete the request.")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "Service encountered numerous errors.  Unable to complete the request.")
 	case models.JobStatusPending, models.JobStatusInProgress:
 		w.Header().Set("X-Progress", job.StatusMessage())
 		w.WriteHeader(http.StatusAccepted)
@@ -164,9 +174,7 @@ func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
 		// If the job should be expired, but the cleanup job hasn't run for some reason, still respond with 410
 		if job.UpdatedAt.Add(h.JobTimeout).Before(time.Now()) {
 			w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, "")
-			responseutils.WriteError(oo, w, http.StatusGone)
+			h.RespWriter.Exception(w, http.StatusGone, responseutils.NotFoundErr, "")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -207,30 +215,23 @@ func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
 
 		jsonData, err := json.Marshal(rb)
 		if err != nil {
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.InternalErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "")
 			return
 		}
 
 		_, err = w.Write([]byte(jsonData))
 		if err != nil {
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.InternalErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "")
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
 	case models.JobStatusArchived, models.JobStatusExpired:
 		w.Header().Set("Expires", job.UpdatedAt.Add(h.JobTimeout).String())
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-			responseutils.NotFoundErr, "")
-		responseutils.WriteError(oo, w, http.StatusGone)
+		h.RespWriter.Exception(w, http.StatusGone, responseutils.NotFoundErr, "")
 	case models.JobStatusCancelled, models.JobStatusCancelledExpired:
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_NOT_FOUND,
-			responseutils.NotFoundErr, "Job has been cancelled.")
-		responseutils.WriteError(oo, w, http.StatusNotFound)
+		h.RespWriter.NotFound(w, http.StatusNotFound, responseutils.NotFoundErr, "Job has been cancelled.")
+
 	}
 }
 
@@ -241,8 +242,7 @@ func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		err = errors.Wrap(err, "cannot convert jobID to uint")
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, err.Error())
-		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		h.RespWriter.Exception(w, http.StatusBadRequest, responseutils.RequestErr, err.Error())
 		return
 	}
 
@@ -250,13 +250,11 @@ func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case service.ErrJobNotCancellable:
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DeletedErr, err.Error())
-			responseutils.WriteError(oo, w, http.StatusGone)
+			h.RespWriter.Exception(w, http.StatusGone, responseutils.DeletedErr, err.Error())
 			return
 		default:
 			log.API.Error(err)
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, err.Error())
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.DbErr, err.Error())
 			return
 		}
 	}
@@ -273,8 +271,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	)
 
 	if ad, err = readAuthData(r); err != nil {
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.TokenErr, "")
-		responseutils.WriteError(oo, w, http.StatusUnauthorized)
+		h.RespWriter.Exception(w, http.StatusUnauthorized, responseutils.TokenErr, "")
 		return
 	}
 
@@ -290,18 +287,14 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	}
 
 	if err = h.validateRequest(resourceTypes); err != nil {
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr,
-			err.Error())
-		responseutils.WriteError(oo, w, http.StatusBadRequest)
+		h.RespWriter.Exception(w, http.StatusBadRequest, responseutils.RequestErr, err.Error())
 		return
 	}
 
 	bb, err := client.NewBlueButtonClient(client.NewConfig(h.bbBasePath))
 	if err != nil {
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-			responseutils.InternalErr, "")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "")
 		return
 	}
 
@@ -325,9 +318,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	if err != nil {
 		err = fmt.Errorf("failed to start transaction: %w", err)
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-			responseutils.InternalErr, "")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "")
 		return
 	}
 	// Use a transaction backed repository to ensure all of our upserts are encapsulated into a single transaction
@@ -354,8 +345,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 		// We've added logic into the worker to handle this situation.
 		if err = tx.Commit(); err != nil {
 			log.API.Error(err.Error())
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.DbErr, "")
 			return
 		}
 
@@ -367,8 +357,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	newJob.ID, err = rtx.CreateJob(ctx, newJob)
 	if err != nil {
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.DbErr, "")
 		return
 	}
 
@@ -376,8 +365,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	b, err := bb.GetPatient("FAKE_PATIENT", strconv.FormatUint(uint64(newJob.ID), 10), acoID.String(), "", time.Now())
 	if err != nil {
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.FormatErr, "Failure to retrieve transactionTime metadata from FHIR Data Server.")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.FormatErr, "Failure to retrieve transactionTime metadata from FHIR Data Server.")
 		return
 	}
 	newJob.TransactionTime = b.Meta.LastUpdated
@@ -399,19 +387,17 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	if err != nil {
 		log.API.Error(err)
 		var (
-			oo       *fhirmodels.OperationOutcome
 			respCode int
+			errType  string
 		)
 		if ok := goerrors.As(err, &service.CCLFNotFoundError{}); ok && reqType == service.Runout {
-			oo = responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, err.Error())
 			respCode = http.StatusNotFound
+			errType = responseutils.NotFoundErr
 		} else {
-			oo = responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.InternalErr, err.Error())
 			respCode = http.StatusInternalServerError
+			errType = responseutils.InternalErr
 		}
-		responseutils.WriteError(oo, w, respCode)
+		h.RespWriter.Exception(w, respCode, errType, err.Error())
 		return
 	}
 	newJob.JobCount = len(queJobs)
@@ -419,8 +405,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	// We've now computed all of the fields necessary to populate a fully defined job
 	if err = rtx.UpdateJob(ctx, newJob); err != nil {
 		log.API.Error(err.Error())
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.DbErr, "")
 		return
 	}
 
@@ -433,9 +418,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 
 		if err = h.Enq.AddJob(*j, int(jobPriority)); err != nil {
 			log.API.Error(err)
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.InternalErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "")
 			return
 		}
 	}
@@ -445,7 +428,7 @@ func (h *Handler) validateRequest(resourceTypes []string) error {
 
 	for _, resourceType := range resourceTypes {
 		if _, ok := h.supportedResources[resourceType]; !ok {
-			return fmt.Errorf("Invalid resource type %s. Supported types %s.", resourceType, h.supportedResources)
+			return fmt.Errorf("invalid resource type %s. Supported types %s", resourceType, h.supportedResources)
 		}
 	}
 

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/database/databasetest"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
+	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/service"
 	"github.com/CMSgov/bcda-app/bcda/web/middleware"
 	"github.com/CMSgov/bcda-app/bcdaworker/queueing"
@@ -127,6 +128,7 @@ func (s *RequestsTestSuite) TestRunoutDisabled() {
 	req := s.genGroupRequest("runout", middleware.RequestParameters{})
 	w := httptest.NewRecorder()
 	h := &Handler{}
+	h.RespWriter = responseutils.NewResponseWriter()
 	h.BulkGroupRequest(w, req)
 
 	resp := w.Result()

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
 
 	"github.com/CMSgov/bcda-app/bcda/api"
 	"github.com/CMSgov/bcda-app/bcda/auth"
@@ -239,18 +238,14 @@ func GetVersion(w http.ResponseWriter, r *http.Request) {
 	respBytes, err := json.Marshal(respMap)
 	if err != nil {
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.InternalErr, "")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
-		return
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(respBytes)
 	if err != nil {
 		log.API.Error(err)
-		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.InternalErr, "")
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
-		return
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 }
 

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -239,6 +239,7 @@ func GetVersion(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.API.Error(err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -246,6 +247,7 @@ func GetVersion(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.API.Error(err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/bcda/auth/api_test.go
+++ b/bcda/auth/api_test.go
@@ -31,9 +31,9 @@ type TokenResponse struct {
 
 type AuthAPITestSuite struct {
 	suite.Suite
-	rr    *httptest.ResponseRecorder
-	db    *sql.DB
-	r     models.Repository
+	rr *httptest.ResponseRecorder
+	db *sql.DB
+	r  models.Repository
 }
 
 func (s *AuthAPITestSuite) SetupSuite() {
@@ -105,10 +105,10 @@ func (s *AuthAPITestSuite) TestWelcome() {
 	// Expect failure with invalid token
 	router := chi.NewRouter()
 	router.Use(auth.ParseToken)
-	router.With(auth.RequireTokenAuth).Get("/", auth.Welcome)
+	router.With(auth.RequireTokenAuth).Get("/v1/", auth.Welcome)
 	server := httptest.NewServer(router)
 	client := server.Client()
-	req, err := http.NewRequest("GET", server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", server.URL), nil)
 	assert.NoError(s.T(), err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", badToken))
 	req.Header.Add("Accept", "application/json")
@@ -117,7 +117,7 @@ func (s *AuthAPITestSuite) TestWelcome() {
 	assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
 
 	// Expect success with valid token
-	req, err = http.NewRequest("GET", server.URL, nil)
+	req, err = http.NewRequest("GET", fmt.Sprintf("%s/v1/", server.URL), nil)
 	if err != nil {
 		assert.FailNow(s.T(), err.Error())
 	}

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/go-chi/chi"
-	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
 
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
-	"github.com/CMSgov/bcda-app/bcda/responseutils"
+	responseutils "github.com/CMSgov/bcda-app/bcda/responseutils"
+	responseutilsv2 "github.com/CMSgov/bcda-app/bcda/responseutils/v2"
 	"github.com/CMSgov/bcda-app/log"
 )
 
@@ -45,11 +45,20 @@ func ParseToken(next http.Handler) http.Handler {
 			return
 		}
 
+		rw, err := getRespWriter(r.URL.Path)
+		if err != nil {
+			// Since ParseToken is called on all requests, there is a chance it can be called outside
+			// of the API version scope (i.e. /_version). Though these endpoints dont require a token it
+			// will still process one if provided. In these cases we default to the v1 fhir response.
+			rw = responseutils.NewResponseWriter()
+			return
+		}
+
 		authRegexp := regexp.MustCompile(`^Bearer (\S+)$`)
 		authSubmatches := authRegexp.FindStringSubmatch(authHeader)
 		if len(authSubmatches) < 2 {
 			log.Auth.Warn("Invalid Authorization header value")
-			respond(w, http.StatusUnauthorized)
+			rw.Exception(w, http.StatusUnauthorized, responseutils.TokenErr, "")
 			return
 		}
 
@@ -58,7 +67,7 @@ func ParseToken(next http.Handler) http.Handler {
 		token, err := GetProvider().VerifyToken(tokenString)
 		if err != nil {
 			log.Auth.Errorf("Unable to verify token; %s", err)
-			respond(w, http.StatusUnauthorized)
+			rw.Exception(w, http.StatusUnauthorized, responseutils.TokenErr, "")
 			return
 		}
 
@@ -75,12 +84,12 @@ func ParseToken(next http.Handler) http.Handler {
 				ad, err = adFromClaims(repository, claims)
 				if err != nil {
 					log.Auth.Error(err)
-					respond(w, http.StatusUnauthorized)
+					rw.Exception(w, http.StatusUnauthorized, responseutils.TokenErr, "")
 					return
 				}
 			default:
 				log.Auth.Errorf("Unsupported claims issuer %s", claims.Issuer)
-				respond(w, http.StatusNotFound)
+				rw.Exception(w, http.StatusNotFound, responseutils.TokenErr, "")
 				return
 			}
 		}
@@ -92,10 +101,17 @@ func ParseToken(next http.Handler) http.Handler {
 
 func RequireTokenAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw, err := getRespWriter(r.URL.Path)
+		if err != nil {
+			// Cannot discern API Version; default non fhir error response
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		token := r.Context().Value(TokenContextKey)
 		if token == nil {
 			log.Auth.Error("No token found")
-			respond(w, http.StatusUnauthorized)
+			rw.Exception(w, http.StatusUnauthorized, responseutils.TokenErr, "")
 			return
 		}
 
@@ -103,7 +119,7 @@ func RequireTokenAuth(next http.Handler) http.Handler {
 			err := GetProvider().AuthorizeAccess(token.Raw)
 			if err != nil {
 				log.Auth.Error(err)
-				respond(w, http.StatusUnauthorized)
+				rw.Exception(w, http.StatusUnauthorized, responseutils.TokenErr, "")
 				return
 			}
 
@@ -115,19 +131,22 @@ func RequireTokenAuth(next http.Handler) http.Handler {
 // CheckBlacklist checks the auth data is associated with a blacklisted entity
 func CheckBlacklist(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw, err := getRespWriter(r.URL.Path)
+		if err != nil {
+			// Cannot discern API Version; default non fhir error response
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		ad, ok := r.Context().Value(AuthDataContextKey).(AuthData)
 		if !ok {
 			log.Auth.Error()
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, "AuthData not found")
-			responseutils.WriteError(oo, w, http.StatusNotFound)
+			rw.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, "AuthData not found")
 			return
 		}
 
 		if ad.Blacklisted {
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.UnauthorizedErr, fmt.Sprintf("ACO (CMS_ID: %s) is unauthorized", ad.CMSID))
-			responseutils.WriteError(oo, w, http.StatusForbidden)
+			rw.Exception(w, http.StatusForbidden, responseutils.UnauthorizedErr, fmt.Sprintf("ACO (CMS_ID: %s) is unauthorized", ad.CMSID))
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -136,21 +155,24 @@ func CheckBlacklist(next http.Handler) http.Handler {
 
 func RequireTokenJobMatch(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw, err := getRespWriter(r.URL.Path)
+		if err != nil {
+			// Cannot discern API Version; default non fhir error response
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		ad, ok := r.Context().Value(AuthDataContextKey).(AuthData)
 		if !ok {
 			log.Auth.Error()
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, "AuthData not found")
-			responseutils.WriteError(oo, w, http.StatusNotFound)
+			rw.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, "AuthData not found")
 			return
 		}
 
 		jobID, err := strconv.ParseUint(chi.URLParam(r, "jobID"), 10, 64)
 		if err != nil {
 			log.Auth.Error(err)
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, err.Error())
-			responseutils.WriteError(oo, w, http.StatusNotFound)
+			rw.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, err.Error())
 			return
 		}
 
@@ -159,9 +181,7 @@ func RequireTokenJobMatch(next http.Handler) http.Handler {
 		job, err := repository.GetJobByID(context.Background(), uint(jobID))
 		if err != nil {
 			log.Auth.Error(err)
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, "")
-			responseutils.WriteError(oo, w, http.StatusNotFound)
+			rw.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, "")
 			return
 		}
 
@@ -169,16 +189,24 @@ func RequireTokenJobMatch(next http.Handler) http.Handler {
 		if !strings.EqualFold(ad.ACOID, job.ACOID.String()) {
 			log.Auth.Errorf("ACO %s does not have access to job ID %d %s",
 				ad.ACOID, job.ID, job.ACOID)
-			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
-				responseutils.NotFoundErr, "")
-			responseutils.WriteError(oo, w, http.StatusNotFound)
+			rw.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, "")
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
 }
 
-func respond(w http.ResponseWriter, status int) {
-	oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.TokenErr, "")
-	responseutils.WriteError(oo, w, status)
+type fhirResponseWriter interface {
+	Exception(http.ResponseWriter, int, string, string)
+	NotFound(http.ResponseWriter, int, string, string)
+}
+
+func getRespWriter(path string) (fhirResponseWriter, error) {
+	if strings.Contains(path, "/v1/") {
+		return responseutils.NewResponseWriter(), nil
+	} else if strings.Contains(path, "/v2/") {
+		return responseutilsv2.NewResponseWriter(), nil
+	} else {
+		return nil, fmt.Errorf("unexpected API version in: %s", path)
+	}
 }

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -36,7 +36,7 @@ type MiddlewareTestSuite struct {
 func (s *MiddlewareTestSuite) CreateRouter() http.Handler {
 	router := chi.NewRouter()
 	router.Use(auth.ParseToken)
-	router.With(auth.RequireTokenAuth).Get("/", func(w http.ResponseWriter, r *http.Request) {
+	router.With(auth.RequireTokenAuth).Get("/v1/", func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("Test router"))
 		if err != nil {
 			log.Fatal(err)
@@ -59,7 +59,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthWithInvalidSignature() {
 	client := s.server.Client()
 	badToken := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImlUcVhYSTB6YkFuSkNLRGFvYmZoa00xZi02ck1TcFRmeVpNUnBfMnRLSTgifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.cJOP_w-hBqnyTsBm3T6lOE5WpcHaAkLuQGAs1QO-lg2eWs8yyGW8p9WagGjxgvx7h9X72H7pXmXqej3GdlVbFmhuzj45A9SXDOAHZ7bJXwM1VidcPi7ZcrsMSCtP1hiN"
 
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthWithInvalidSignature() {
 }
 
 func (s *MiddlewareTestSuite) TestRequireTokenAuthWithInvalidToken() {
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthWithValidToken() {
 	client := s.server.Client()
 
 	// Valid token should return a 200 response
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenAuthWithEmptyToken() {
 	client := s.server.Client()
 
 	// Valid token should return a 200 response
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchWithMistmatchingData() {
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("jobID", tt.jobID)
 
-			req, err := http.NewRequest("GET", s.server.URL, nil)
+			req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 			assert.NoError(t, err)
 
 			ad := auth.AuthData{
@@ -217,7 +217,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchWithRightACO() {
 	postgrestest.CreateJobs(s.T(), db, &j)
 	jobID := strconv.Itoa(int(j.ID))
 
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenACOMatchInvalidToken() {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobID", jobID)
 
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func (s *MiddlewareTestSuite) TestCheckBlacklist() {
 			if tt.ad != nil {
 				ctx = context.WithValue(ctx, auth.AuthDataContextKey, *tt.ad)
 			}
-			req, err := http.NewRequestWithContext(ctx, "GET", "", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "/v1/", nil)
 			assert.NoError(t, err)
 			handler.ServeHTTP(rr, req)
 

--- a/bcda/auth/ssas_middleware_test.go
+++ b/bcda/auth/ssas_middleware_test.go
@@ -36,7 +36,7 @@ type SSASMiddlewareTestSuite struct {
 func (s *SSASMiddlewareTestSuite) createRouter() http.Handler {
 	router := chi.NewRouter()
 	router.Use(auth.ParseToken)
-	router.With(auth.RequireTokenAuth).Get("/", func(w http.ResponseWriter, r *http.Request) {
+	router.With(auth.RequireTokenAuth).Get("/v1/", func(w http.ResponseWriter, r *http.Request) {
 		ad := r.Context().Value(auth.AuthDataContextKey).(auth.AuthData)
 		render.JSON(w, r, ad)
 	})
@@ -60,7 +60,7 @@ func (s *SSASMiddlewareTestSuite) TearDownSuite() {
 }
 
 func (s *SSASMiddlewareTestSuite) TestSSASToken() {
-	req, err := http.NewRequest("GET", s.server.URL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/", s.server.URL), nil)
 	require.NotNil(s.T(), req, "req not created; ", err)
 
 	s.ad = auth.AuthData{}

--- a/bcda/responseutils/v2/writer.go
+++ b/bcda/responseutils/v2/writer.go
@@ -1,0 +1,206 @@
+package responseutils
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/CMSgov/bcda-app/conf"
+
+	"github.com/google/fhir/go/jsonformat"
+
+	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
+	fhirdatatypes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
+	fhirmodelCR "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
+	fhirmodelCS "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/capability_statement_go_proto"
+	fhirmodelOO "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/operation_outcome_go_proto"
+	fhirvaluesets "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/valuesets_go_proto"
+)
+
+var marshaller *jsonformat.Marshaller
+
+func init() {
+	var err error
+
+	// Ensure that we write the serialized FHIR resources as a single line.
+	// Needed to comply with the NDJSON format that we are using.
+	marshaller, err = jsonformat.NewMarshaller(false, "", "", jsonformat.R4)
+	if err != nil {
+		log.Fatalf("Failed to create marshaller %s", err)
+	}
+}
+
+type ResponseWriter struct{}
+
+func NewResponseWriter() ResponseWriter {
+	return ResponseWriter{}
+}
+
+func (r ResponseWriter) Exception(w http.ResponseWriter, statusCode int, errType, errMsg string) {
+	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, errType, errMsg)
+	WriteError(oo, w, statusCode)
+}
+
+func (r ResponseWriter) NotFound(w http.ResponseWriter, statusCode int, errType, errMsg string) {
+	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_NOT_FOUND, errType, errMsg)
+	WriteError(oo, w, statusCode)
+}
+
+func CreateOpOutcome(severity fhircodes.IssueSeverityCode_Value, code fhircodes.IssueTypeCode_Value,
+	detailsCode, detailsDisplay string) *fhirmodelOO.OperationOutcome {
+
+	return &fhirmodelOO.OperationOutcome{
+		Issue: []*fhirmodelOO.OperationOutcome_Issue{
+			{
+				Severity: &fhirmodelOO.OperationOutcome_Issue_SeverityCode{Value: severity},
+				Code:     &fhirmodelOO.OperationOutcome_Issue_CodeType{Value: code},
+				Details: &fhirdatatypes.CodeableConcept{
+					Coding: []*fhirdatatypes.Coding{
+						{
+							Code: &fhirdatatypes.Code{Value: detailsCode},
+							System: &fhirdatatypes.Uri{
+								Value: "http://hl7.org/fhir/ValueSet/operation-outcome",
+							},
+							Display: &fhirdatatypes.String{Value: detailsDisplay},
+						},
+					},
+					Text: &fhirdatatypes.String{Value: detailsDisplay},
+				},
+			},
+		},
+	}
+}
+
+func WriteError(outcome *fhirmodelOO.OperationOutcome, w http.ResponseWriter, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, err := WriteOperationOutcome(w, outcome)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func WriteOperationOutcome(w io.Writer, outcome *fhirmodelOO.OperationOutcome) (int, error) {
+	resource := &fhirmodelCR.ContainedResource{
+		OneofResource: &fhirmodelCR.ContainedResource_OperationOutcome{OperationOutcome: outcome},
+	}
+	outcomeJSON, err := marshaller.Marshal(resource)
+	if err != nil {
+		return -1, err
+	}
+
+	return w.Write(outcomeJSON)
+}
+
+func CreateCapabilityStatement(reldate time.Time, relversion, baseurl string) *fhirmodelCS.CapabilityStatement {
+	bbServer := conf.GetEnv("BB_SERVER_LOCATION")
+	statement := &fhirmodelCS.CapabilityStatement{
+		Status: &fhirmodelCS.CapabilityStatement_StatusCode{Value: fhircodes.PublicationStatusCode_ACTIVE},
+		Date: &fhirdatatypes.DateTime{
+			ValueUs:   reldate.UTC().UnixNano() / int64(time.Microsecond),
+			Timezone:  time.UTC.String(),
+			Precision: fhirdatatypes.DateTime_SECOND,
+		},
+		Publisher: &fhirdatatypes.String{Value: "Centers for Medicare & Medicaid Services"},
+		Kind:      &fhirmodelCS.CapabilityStatement_KindCode{Value: fhircodes.CapabilityStatementKindCode_INSTANCE},
+		Instantiates: []*fhirdatatypes.Canonical{
+			{Value: bbServer + "/baseDstu3/metadata/"},
+			{Value: "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data"},
+		},
+		Software: &fhirmodelCS.CapabilityStatement_Software{
+			Name:    &fhirdatatypes.String{Value: "Beneficiary Claims Data API"},
+			Version: &fhirdatatypes.String{Value: relversion},
+			ReleaseDate: &fhirdatatypes.DateTime{
+				ValueUs:   reldate.UTC().UnixNano() / int64(time.Microsecond),
+				Timezone:  time.UTC.String(),
+				Precision: fhirdatatypes.DateTime_SECOND,
+			},
+		},
+		Implementation: &fhirmodelCS.CapabilityStatement_Implementation{
+			Description: &fhirdatatypes.String{Value: "The Beneficiary Claims Data API (BCDA) enables Accountable Care Organizations (ACOs) participating in the Shared Savings Program to retrieve Medicare Part A, Part B, and Part D claims data for their prospectively assigned or assignable beneficiaries."},
+			Url:         &fhirdatatypes.Url{Value: baseurl},
+		},
+		FhirVersion: &fhirmodelCS.CapabilityStatement_FhirVersionCode{Value: fhircodes.FHIRVersionCode_V_3_0_1},
+		Format: []*fhirmodelCS.CapabilityStatement_FormatCode{
+			{Value: "application/json"},
+			{Value: "application/fhir+json"},
+		},
+		Rest: []*fhirmodelCS.CapabilityStatement_Rest{
+			{
+				Mode: &fhirmodelCS.CapabilityStatement_Rest_ModeCode{Value: fhircodes.RestfulCapabilityModeCode_SERVER},
+				Security: &fhirmodelCS.CapabilityStatement_Rest_Security{
+					Cors: &fhirdatatypes.Boolean{Value: true},
+					Service: []*fhirdatatypes.CodeableConcept{
+						{
+							Coding: []*fhirdatatypes.Coding{
+								{
+									Display: &fhirdatatypes.String{Value: "OAuth"},
+									Code:    &fhirdatatypes.Code{Value: "OAuth"},
+									System:  &fhirdatatypes.Uri{Value: "http://terminology.hl7.org/CodeSystem/restful-security-service"},
+								},
+							},
+							Text: &fhirdatatypes.String{Value: "OAuth"},
+						},
+					},
+					Extension: []*fhirdatatypes.Extension{
+						{
+							Url: &fhirdatatypes.Uri{Value: "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"},
+							Extension: []*fhirdatatypes.Extension{
+								{
+									Url: &fhirdatatypes.Uri{Value: "token"},
+									Value: &fhirdatatypes.Extension_ValueX{
+										Choice: &fhirdatatypes.Extension_ValueX_Uri{
+											Uri: &fhirdatatypes.Uri{Value: baseurl + "/auth/token"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Interaction: []*fhirmodelCS.CapabilityStatement_Rest_SystemInteraction{
+					{
+						Code: &fhirmodelCS.CapabilityStatement_Rest_SystemInteraction_CodeType{Value: fhirvaluesets.SystemRestfulInteractionValueSet_BATCH},
+					},
+					{
+						Code: &fhirmodelCS.CapabilityStatement_Rest_SystemInteraction_CodeType{Value: fhirvaluesets.SystemRestfulInteractionValueSet_SEARCH_SYSTEM},
+					},
+				},
+				Operation: []*fhirmodelCS.CapabilityStatement_Rest_Resource_Operation{
+					{
+						Name: &fhirdatatypes.String{Value: "patient-export"},
+						Definition: &fhirdatatypes.Canonical{
+							Value: "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export",
+						},
+					},
+					{
+						Name: &fhirdatatypes.String{Value: "group-export"},
+						Definition: &fhirdatatypes.Canonical{
+							Value: "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export",
+						},
+					},
+				},
+			},
+		},
+	}
+	return statement
+}
+func WriteCapabilityStatement(statement *fhirmodelCS.CapabilityStatement, w http.ResponseWriter) {
+	resource := &fhirmodelCR.ContainedResource{
+		OneofResource: &fhirmodelCR.ContainedResource_CapabilityStatement{CapabilityStatement: statement},
+	}
+	statementJSON, err := marshaller.Marshal(resource)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(statementJSON)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/bcda/responseutils/v2/writer_test.go
+++ b/bcda/responseutils/v2/writer_test.go
@@ -1,0 +1,132 @@
+package responseutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	responseutils "github.com/CMSgov/bcda-app/bcda/responseutils"
+	"github.com/google/fhir/go/jsonformat"
+	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
+	fhirmodelCR "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
+	fhirmodelCS "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/capability_statement_go_proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResponseUtilsWriterTestSuite struct {
+	suite.Suite
+	rr           *httptest.ResponseRecorder
+	unmarshaller *jsonformat.Unmarshaller
+}
+
+func (s *ResponseUtilsWriterTestSuite) SetupTest() {
+	var err error
+	s.rr = httptest.NewRecorder()
+	s.unmarshaller, err = jsonformat.NewUnmarshaller("UTC", jsonformat.R4)
+	assert.NoError(s.T(), err)
+}
+
+func TestResponseUtilsWriterTestSuite(t *testing.T) {
+	suite.Run(t, new(ResponseUtilsWriterTestSuite))
+}
+func (s *ResponseUtilsWriterTestSuite) TestResponseWriterException() {
+	rw := NewResponseWriter()
+	rw.Exception(s.rr, http.StatusAccepted, responseutils.RequestErr, "TestResponseWriterExcepton")
+
+	res, err := s.unmarshaller.Unmarshal(s.rr.Body.Bytes())
+	assert.NoError(s.T(), err)
+	cr := res.(*fhirmodelCR.ContainedResource)
+	respOO := cr.GetOperationOutcome()
+
+	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+	assert.Equal(s.T(), fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Coding[0].Display.Value)
+	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Text.Value)
+	assert.Equal(s.T(), responseutils.RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+}
+
+func (s *ResponseUtilsWriterTestSuite) TestResponseWriterNotFound() {
+	rw := NewResponseWriter()
+
+	rw.NotFound(s.rr, http.StatusAccepted, responseutils.RequestErr, "TestResponseWriterNotFound")
+
+	res, err := s.unmarshaller.Unmarshal(s.rr.Body.Bytes())
+	assert.NoError(s.T(), err)
+	cr := res.(*fhirmodelCR.ContainedResource)
+	respOO := cr.GetOperationOutcome()
+
+	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+	assert.Equal(s.T(), fhircodes.IssueTypeCode_NOT_FOUND, respOO.Issue[0].Code.Value)
+	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Coding[0].Display.Value)
+	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Text.Value)
+	assert.Equal(s.T(), responseutils.RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+}
+
+func (s *ResponseUtilsWriterTestSuite) TestCreateOpOutcome() {
+	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, "TestCreateOpOutcome")
+	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, oo.Issue[0].Severity.Value)
+	assert.Equal(s.T(), fhircodes.IssueTypeCode_EXCEPTION, oo.Issue[0].Code.Value)
+	assert.Equal(s.T(), "TestCreateOpOutcome", oo.Issue[0].Details.Coding[0].Display.Value)
+	assert.Equal(s.T(), "TestCreateOpOutcome", oo.Issue[0].Details.Text.Value)
+	assert.Equal(s.T(), responseutils.RequestErr, oo.Issue[0].Details.Coding[0].Code.Value)
+}
+
+func (s *ResponseUtilsWriterTestSuite) TestWriteError() {
+	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.RequestErr, "TestCreateOpOutcome")
+	WriteError(oo, s.rr, http.StatusAccepted)
+
+	res, err := s.unmarshaller.Unmarshal(s.rr.Body.Bytes())
+	assert.NoError(s.T(), err)
+	cr := res.(*fhirmodelCR.ContainedResource)
+	respOO := cr.GetOperationOutcome()
+
+	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+	assert.Equal(s.T(), oo.Issue[0].Severity, respOO.Issue[0].Severity)
+	assert.Equal(s.T(), fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+	assert.Equal(s.T(), oo.Issue[0].Code, respOO.Issue[0].Code)
+	assert.Equal(s.T(), "TestCreateOpOutcome", respOO.Issue[0].Details.Coding[0].Display.Value)
+	assert.Equal(s.T(), oo.Issue[0].Details.Coding[0].Display, respOO.Issue[0].Details.Coding[0].Display)
+	assert.Equal(s.T(), "TestCreateOpOutcome", respOO.Issue[0].Details.Text.Value)
+	assert.Equal(s.T(), oo.Issue[0].Details.Text, respOO.Issue[0].Details.Text)
+	assert.Equal(s.T(), responseutils.RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+	assert.Equal(s.T(), oo.Issue[0].Details.Coding[0].Code, respOO.Issue[0].Details.Coding[0].Code)
+}
+
+func (s *ResponseUtilsWriterTestSuite) TestCreateCapabilityStatement() {
+	relversion := "r1"
+	baseurl := "bcda.cms.gov"
+	var cs *fhirmodelCS.CapabilityStatement = CreateCapabilityStatement(time.Now(), relversion, baseurl)
+	assert.Equal(s.T(), relversion, cs.Software.Version.Value)
+	assert.Equal(s.T(), "Beneficiary Claims Data API", cs.Software.Name.Value)
+	assert.Equal(s.T(), baseurl, cs.Implementation.Url.Value)
+	assert.Equal(s.T(), fhircodes.FHIRVersionCode_V_3_0_1, cs.FhirVersion.Value)
+}
+
+func (s *ResponseUtilsWriterTestSuite) TestWriteCapabilityStatement() {
+	relversion := "r1"
+	baseurl := "bcda.cms.gov"
+	cs := CreateCapabilityStatement(time.Now(), relversion, baseurl)
+	WriteCapabilityStatement(cs, s.rr)
+	var respCS *fhirmodelCS.CapabilityStatement
+
+	res, err := s.unmarshaller.Unmarshal(s.rr.Body.Bytes())
+	cr := res.(*fhirmodelCR.ContainedResource)
+	respCS = cr.GetCapabilityStatement()
+
+	assert.NoError(s.T(), err)
+
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	assert.Equal(s.T(), relversion, respCS.Software.Version.Value)
+	assert.Equal(s.T(), cs.Software.Version, respCS.Software.Version)
+	assert.Equal(s.T(), "Beneficiary Claims Data API", respCS.Software.Name.Value)
+	assert.Equal(s.T(), cs.Software.Name, respCS.Software.Name)
+	assert.Equal(s.T(), baseurl, respCS.Implementation.Url.Value)
+	assert.Equal(s.T(), cs.Implementation.Url, respCS.Implementation.Url)
+	assert.Equal(s.T(), fhircodes.FHIRVersionCode_V_3_0_1, respCS.FhirVersion.Value)
+	assert.Equal(s.T(), cs.FhirVersion, respCS.FhirVersion)
+}

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -27,6 +27,22 @@ func init() {
 	}
 }
 
+type ResponseWriter struct{}
+
+func NewResponseWriter() ResponseWriter {
+	return ResponseWriter{}
+}
+
+func (r ResponseWriter) Exception(w http.ResponseWriter, statusCode int, errType, errMsg string) {
+	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, errType, errMsg)
+	WriteError(oo, w, statusCode)
+}
+
+func (r ResponseWriter) NotFound(w http.ResponseWriter, statusCode int, errType, errMsg string) {
+	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_NOT_FOUND, errType, errMsg)
+	WriteError(oo, w, statusCode)
+}
+
 func CreateOpOutcome(severity fhircodes.IssueSeverityCode_Value, code fhircodes.IssueTypeCode_Value,
 	detailsCode, detailsDisplay string) *fhirmodels.OperationOutcome {
 

--- a/bcda/responseutils/writer_test.go
+++ b/bcda/responseutils/writer_test.go
@@ -30,6 +30,41 @@ func TestResponseUtilsWriterTestSuite(t *testing.T) {
 	suite.Run(t, new(ResponseUtilsWriterTestSuite))
 }
 
+func (s *ResponseUtilsWriterTestSuite) TestResponseWriterException() {
+	rw := NewResponseWriter()
+	rw.Exception(s.rr, http.StatusAccepted, RequestErr, "TestResponseWriterExcepton")
+
+	res, err := s.unmarshaller.Unmarshal(s.rr.Body.Bytes())
+	assert.NoError(s.T(), err)
+	cr := res.(*fhirmodels.ContainedResource)
+	respOO := cr.GetOperationOutcome()
+
+	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+	assert.Equal(s.T(), fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Coding[0].Display.Value)
+	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Text.Value)
+	assert.Equal(s.T(), RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+}
+
+func (s *ResponseUtilsWriterTestSuite) TestResponseWriterNotFound() {
+	rw := NewResponseWriter()
+
+	rw.NotFound(s.rr, http.StatusAccepted, RequestErr, "TestResponseWriterNotFound")
+
+	res, err := s.unmarshaller.Unmarshal(s.rr.Body.Bytes())
+	assert.NoError(s.T(), err)
+	cr := res.(*fhirmodels.ContainedResource)
+	respOO := cr.GetOperationOutcome()
+
+	assert.Equal(s.T(), http.StatusAccepted, s.rr.Code)
+	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+	assert.Equal(s.T(), fhircodes.IssueTypeCode_NOT_FOUND, respOO.Issue[0].Code.Value)
+	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Coding[0].Display.Value)
+	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Text.Value)
+	assert.Equal(s.T(), RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+}
+
 func (s *ResponseUtilsWriterTestSuite) TestCreateOpOutcome() {
 	oo := CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, RequestErr, "TestCreateOpOutcome")
 	assert.Equal(s.T(), fhircodes.IssueSeverityCode_ERROR, oo.Issue[0].Severity.Value)

--- a/bcda/web/middleware/middleware_test.go
+++ b/bcda/web/middleware/middleware_test.go
@@ -153,6 +153,5 @@ func (s *MiddlewareTestSuite) TestACOEnabled() {
 func testRequest(rp RequestParameters, cmsid string) *http.Request {
 	ctx := context.WithValue(context.Background(), auth.AuthDataContextKey, auth.AuthData{CMSID: cmsid})
 	ctx = NewRequestParametersContext(ctx, rp)
-	// Since we're supplying the request parameters in the context, the actual req URL does not matter
-	return httptest.NewRequest("GET", "/api/v1/metadata", nil).WithContext(ctx)
+	return httptest.NewRequest("GET", "/api/v1/Patient", nil).WithContext(ctx)
 }

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -173,7 +173,7 @@ func getKeys(kv map[string]struct{}) []string {
 	return keys
 }
 
-var versionExp = regexp.MustCompile(`\/api\/(v[0-9]+)\/.*`)
+var versionExp = regexp.MustCompile(`\/api\/(v\d+)\/`)
 
 func getVersion(path string) (string, error) {
 	parts := versionExp.FindStringSubmatch(path)

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -173,7 +173,7 @@ func getKeys(kv map[string]struct{}) []string {
 	return keys
 }
 
-var versionExp = regexp.MustCompile(`\/api\/(.*)\/[Patient|Group].*`)
+var versionExp = regexp.MustCompile(`\/api\/(v[0-9]+)\/.*`)
 
 func getVersion(path string) (string, error) {
 	parts := versionExp.FindStringSubmatch(path)

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -44,7 +44,7 @@ func NewAPIRouter() http.Handler {
 		r.Get("/", userGuideRedirect)
 		r.Get(`/{:(user_guide|encryption|decryption_walkthrough).html}`, userGuideRedirect)
 	} else {
-		// Apply rate limiting on prodcution only
+		// Apply rate limiting on production only
 		requestValidators = append(requestValidators, middleware.CheckConcurrentJobs)
 	}
 

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -76,7 +76,7 @@ func (s *RouterTestSuite) TestDefaultProdRoute() {
 	}
 	// Need a new router because the one in the test setup does not use the environment variable set in this test.
 	s.apiRouter = NewAPIRouter()
-	res := s.getAPIRoute("/")
+	res := s.getAPIRoute("/v1/")
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 
 	err = conf.UnsetEnv(s.T(), "DEPLOYMENT_TARGET")

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -4653,7 +4653,7 @@
 							"",
 							"",
 							"pm.test(\"Issue details text is Invalid Resource Type\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.include(\"Invalid resource type\")",
+							"    pm.expect(respJson.issue[0].details.text).to.include(\"invalid resource type\")",
 							"});"
 						],
 						"type": "text/javascript"
@@ -4728,7 +4728,7 @@
 							"});",
 							"",
 							"pm.test(\"Issue details text is Invalid Resource Type\", function() {",
-							"    pm.expect(respJson.issue[0].details.text).to.include(\"Invalid resource type\")",
+							"    pm.expect(respJson.issue[0].details.text).to.include(\"invalid resource type\")",
 							"});"
 						],
 						"type": "text/javascript"


### PR DESCRIPTION
### Fixes [BCDA-4649](https://jira.cms.gov/browse/BCDA-4649)

Currently, the API uses fhir `stu3` as its response type for both `v1` and `v2` of our API. However, since BFD has moved its response for their `v2` to fhir `R4` we want to do the same for when we create Error Responses.

### Proposed Changes

Identify when requests are being made via `v1` or v2` and use the correct response writer. Create a new writer for `v2` that integrates with the `R4` fhir spec and builds the responses appropriately.

### Change Details

- Create `v2` writer.go in `responseutils` that creates responses using the correct fhir library.
- Move the creating of error responses to both `v1` and `v2` writer files and, therefore, removing fhir library access away from the `requests.go` file.
- Create and interface in requests.go that will satisfy the responsewriter methods we are using.
- Update and add testing where needed.
- Update middleware package to properly deduce API version and load the appropriate responseutility
Note: The auth middleware methods will default to the `v1` response writer because the auth middleware is also used in routes (like the data router) that do not contain version information. This should be changed and updated in the future.
- Update `.../_version` to not respond with a fhir body

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

`v2` calls now build responses using the R4 fhir library spec. Note that there are some differences in there besides the severity and type codes. Things have moved a little bit and certain fields have been removed (i.e. `AcceptUnknown`).
 
### Feedback Requested

This is the solution I came up with. Since the errors we create using the severity and type code are just binary at this point the `ResponseWriter` is still small. However, if these error types ever get larger we will have to add more ResponseWriter error build methods. I dont see this happening but I think its important to note.