### PR TITLE
BCDA-3607 Parallelized Smoke Test and Fix Bulk Lite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ postman:
 	# and if needed a token.
 	# Use env=local to bring up a local version of the app and test against it
 	# For example: make postman env=test token=<MY_TOKEN>
-	$(eval BLACKLIST_CLIENT_ID=$(shell docker-compose exec api env | grep BLACKLIST_CLIENT_ID | cut -d'=' -f2))
-	$(eval BLACKLIST_CLIENT_SECRET=$(shell docker-compose exec api env | grep BLACKLIST_CLIENT_SECRET | cut -d'=' -f2))
+	$(eval BLACKLIST_CLIENT_ID=$(shell docker-compose exec -T api env | grep BLACKLIST_CLIENT_ID | cut -d'=' -f2))
+	$(eval BLACKLIST_CLIENT_SECRET=$(shell docker-compose exec -T api env | grep BLACKLIST_CLIENT_SECRET | cut -d'=' -f2))
 
 	# Set up valid client credentials
 	$(eval ACO_CMS_ID = A9994)
@@ -140,10 +140,10 @@ docker-build:
 docker-bootstrap: docker-build documentation load-fixtures
 
 api-shell:
-	docker-compose exec api bash
+	docker-compose exec -T api bash
 
 worker-shell:
-	docker-compose exec worker bash
+	docker-compose exec -T worker bash
 
 debug-api:
 	docker-compose start db queue worker

--- a/test/smoke_test/bulk_data_requests.sh
+++ b/test/smoke_test/bulk_data_requests.sh
@@ -3,45 +3,58 @@
 # This script is intended to be run from within the Docker "smoke_test" container
 #
 set -e
-echo "Running EOB"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=ExplanationOfBenefit
-echo "Running Patient"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient
-echo "Running Coverage"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage
-echo "Running Patient All"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient
-echo "Running Patient, Coverage, EOB (explicitly)"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage,ExplanationOfBenefit
-echo "Running Patient, Coverage"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage
-echo "Running Patient, EOB"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,ExplanationOfBenefit
-echo "Running Coverage, EOB"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage,ExplanationOfBenefit
-echo "Running Group All"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/all
 
-echo "Running EOB v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=ExplanationOfBenefit -apiVersion=v2
-echo "Running Patient v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient -apiVersion=v2
-echo "Running Coverage v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage -apiVersion=v2
-echo "Running Patient v2 All"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -apiVersion=v2
-echo "Running Patient v2 Patient, Coverage, EOB (explicitly)"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage,ExplanationOfBenefit -apiVersion=v2
-echo "Running Patient, Coverage v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage -apiVersion=v2
-echo "Running Patient, EOB v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,ExplanationOfBenefit -apiVersion=v2
-echo "Running Coverage, EOB v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage,ExplanationOfBenefit -apiVersion=v2
-echo "Running Group All v2"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/all -apiVersion=v2
+PIDS=()
 
-echo "Running Group Runout (EOB resource)"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/runout -resourceType=ExplanationOfBenefit
-echo "Running Group Runout v2 (EOB resource)"
-go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/runout -resourceType=ExplanationOfBenefit -apiVersion=v2
+echo "Running EOB" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=ExplanationOfBenefit && \
+echo "Running Patient" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient && \
+echo "Running Coverage" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage && \
+echo "Running Patient All" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient &
+PIDS+=($!)
+echo "Running Patient, Coverage, EOB (explicitly)" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage,ExplanationOfBenefit && \
+echo "Running Patient, Coverage" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage && \
+echo "Running Patient, EOB" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,ExplanationOfBenefit && \
+echo "Running Coverage, EOB" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage,ExplanationOfBenefit &
+PIDS+=($!)
+
+echo "Running EOB v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=ExplanationOfBenefit -apiVersion=v2 && \
+echo "Running Patient v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient -apiVersion=v2 && \
+echo "Running Coverage v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage -apiVersion=v2 && \
+echo "Running Patient v2 All" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -apiVersion=v2 &
+PIDS+=($!)
+echo "Running Patient v2 Patient, Coverage, EOB (explicitly)" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage,ExplanationOfBenefit -apiVersion=v2 && \
+echo "Running Patient, Coverage v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,Coverage -apiVersion=v2 && \
+echo "Running Patient, EOB v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Patient,ExplanationOfBenefit -apiVersion=v2 && \
+echo "Running Coverage, EOB v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient -resourceType=Coverage,ExplanationOfBenefit -apiVersion=v2 &
+PIDS+=($!)
+
+echo "Running Group All" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/all && \
+echo "Running Group All v2" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/all -apiVersion=v2 && \
+echo "Running Group Runout (EOB resource)" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/runout -resourceType=ExplanationOfBenefit && \
+echo "Running Group Runout v2 (EOB resource)" && \
+go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/runout -resourceType=ExplanationOfBenefit -apiVersion=v2 &
+PIDS+=($!)
+
+for PID in "${PIDS[@]}"; do
+   wait "$PID"
+done
+

--- a/test/smoke_test/bulk_data_requests_lite.sh
+++ b/test/smoke_test/bulk_data_requests_lite.sh
@@ -3,10 +3,20 @@
 # This script is intended to be run from within the Docker "smoke_test" container
 #
 set -e
-echo "Running Patient All"
+
+PIDS=()
+
+echo "Running Patient All" && \
 go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Patient &
-echo "Running Group All"
+PIDS+=($!)
+echo "Running Group All" && \
 go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/all &
-echo "Running Group Runout (EOB resource)"
+PIDS+=($!)
+echo "Running Group Runout (EOB resource)" && \
 go run bcda_client.go -host=api:3000 -clientID=$CLIENT_ID -clientSecret=$CLIENT_SECRET -endpoint=Group/runout -resourceType=ExplanationOfBenefit &
-wait
+PIDS+=($!)
+
+for PID in "${PIDS[@]}"; do
+   wait "$PID"
+done
+

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -27,6 +27,6 @@ do
         if [ ${CMS_ID} = "A9996" ]; then
                 testFile=bulk_data_requests.sh
         fi
-        docker-compose -f docker-compose.test.yml run --rm -e CLIENT_ID=${CLIENT_ID} -e CLIENT_SECRET=${CLIENT_SECRET} -w /go/src/github.com/CMSgov/bcda-app/test/smoke_test tests sh ${testFile}
+        docker-compose -f docker-compose.test.yml run --rm -e CLIENT_ID=${CLIENT_ID} -e CLIENT_SECRET=${CLIENT_SECRET} -w /go/src/github.com/CMSgov/bcda-app/test/smoke_test tests bash ${testFile}
 done
 

--- a/test/smoke_test/smoke_test.sh
+++ b/test/smoke_test/smoke_test.sh
@@ -15,7 +15,6 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-PIDS=()
 for CMS_ID in "${CMS_IDs[@]}"
 do
         ACO_ID=$(docker-compose exec -T -e CMS_ID=${CMS_ID} api sh -c 'bcda create-aco --name "Smoke Test ACO" --cms-id ${CMS_ID}' | tail -n1 | tr -d '\r')
@@ -28,10 +27,6 @@ do
         if [ ${CMS_ID} = "A9996" ]; then
                 testFile=bulk_data_requests.sh
         fi
-        docker-compose -f docker-compose.test.yml run --rm -e CLIENT_ID=${CLIENT_ID} -e CLIENT_SECRET=${CLIENT_SECRET} -w /go/src/github.com/CMSgov/bcda-app/test/smoke_test tests sh ${testFile} &
-        PIDS+=($!)
+        docker-compose -f docker-compose.test.yml run --rm -e CLIENT_ID=${CLIENT_ID} -e CLIENT_SECRET=${CLIENT_SECRET} -w /go/src/github.com/CMSgov/bcda-app/test/smoke_test tests sh ${testFile}
 done
 
-for PID in "${PIDS[@]}"; do
-   wait "$PID"
-done


### PR DESCRIPTION
### Fixes [BCDA-3607](https://jira.cms.gov/browse/BCDA-3607)
As an effort to speed up the testing and release process, it has been suggested to parallelize the smoke test. This ticket aims to parallelize a number of calls made by bcda_client.go. This ticket also explored parallelizing the integration smoke-test in jenkins.
### Proposed Changes
Bash / sh has the feature to send a task into a separate child process through "&". We can add this to the end of commands we want to parallelize. We need to ensure however that we collect the PID of that child process and wait for it specifically (e.g. wait \<PID\> not just wait). By doing this, we make sure if any of the child processes fail, the parent process will exit with a code other than 0.
### Change Details
We implemented the proposed changes mentioned above to the following files:
1. bulk_data_requests.sh 
2. bulk_data_requests_lite.sh 
To keep some order in the logs and not to over-burden local test, we removed parallelization in the smoke_test.sh.
A success run of the smoke-test does indeed return an exit code of 0, otherwise an exit code of 2.
<img width="1216" alt="Screen Shot 2021-07-02 at 12 51 35 AM" src="https://user-images.githubusercontent.com/14236737/124224814-593ca280-dad4-11eb-9fbc-323a3194a4f4.png">
<img width="1132" alt="Screen Shot 2021-07-02 at 1 31 24 AM" src="https://user-images.githubusercontent.com/14236737/124225314-3c549f00-dad5-11eb-874e-61546711f45a.png">
To simulate a true failure, we substituted one of the calls in bulk_data_requests.sh with a bogus secret.
<img width="1414" alt="Screen Shot 2021-07-02 at 1 26 07 AM" src="https://user-images.githubusercontent.com/14236737/124224996-b33d6800-dad4-11eb-990f-f737bbe01de5.png">
We have seen significant improvements in the speed of the smoke-test locally, but gains on GitHub Actions (GA) are minimal. We suspect that the VMs used for the job in GA are low in CPU cores, where parallelize jobs end up running mostly sequentially.

A proven method of improving the speed of GA is to launch our tests in separate jobs, as seen here:
https://github.com/CMSgov/bcda-app/actions/runs/991957013
One down side of this is that each job builds its own stack. We tried to leverage GA cache, but preliminary results showed that while it is faster than the current method, it's slower than just launching separate jobs, as seen here:
https://github.com/CMSgov/bcda-app/actions/runs/992333508

Finally, we discovered that Jenkins integration smoke-test is already leveraging parallelism.
https://github.com/CMSgov/bcda-ops/blob/98292470634c612ff815d26dbcd9d3f1f58b30ba/jenkins_files/Jenkinsfile.smoke_test#L504
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
The attempt to speed up smoke-test does indeed speed up locally, and there is no holes in the implementation.
### Feedback Requested
Any feedback is good feedback.
