### PR TITLE
BCDA-4695: Fixing build and package fail issue due to crosswalk.tsv move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ unit-test-db:
 	docker-compose -f docker-compose.test.yml up -d db-unit-test
 	
 	# Wait for the database to be ready
-	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 60
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 75
 	
 	# Perform migrations to ensure matching schemas
 	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db-unit-test:5432/bcda_test?sslmode=disable&x-migrations-table=schema_migrations_bcda" -path /go/src/github.com/CMSgov/bcda-app/db/migrations/bcda up
@@ -85,7 +85,7 @@ load-fixtures:
 
 	docker-compose up -d db queue
 	echo "Wait for databases to be ready..."
-	docker-compose -f docker-compose.wait-for-it.yml run --rm wait sh -c "wait-for-it -h db -p 5432 -t 60 && wait-for-it -h queue -p 5432 -t 60"
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait sh -c "wait-for-it -h db -p 5432 -t 75 && wait-for-it -h queue -p 5432 -t 75"
 
 	# Initialize schemas
 	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable&x-migrations-table=schema_migrations_bcda" -path /go/src/github.com/CMSgov/bcda-app/db/migrations/bcda up
@@ -102,7 +102,7 @@ load-fixtures:
 
 	# Ensure components are started as expected
 	docker-compose up -d api worker ssas
-	docker-compose -f docker-compose.wait-for-it.yml run --rm wait sh -c "wait-for-it -h api -p 3000 -t 60 && wait-for-it -h ssas -p 3003 -t 60"
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait sh -c "wait-for-it -h api -p 3000 -t 75 && wait-for-it -h ssas -p 3003 -t 75"
 
 	# Additional fixtures for postman+ssas
 	docker-compose run db psql -v ON_ERROR_STOP=1 "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /var/db/postman_fixtures.sql

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -35,7 +35,8 @@ then
   exit 1
 fi
 
-if [ ! -f ../bcda/models/fhir/alr/hcc_crosswalk.tsv ]
+#TODO: This file should live in worker S3 mount dir. Perhaps remove this.
+if [ ! -f ../bcda/models/fhir/alr/utils/hcc_crosswalk.tsv ]
 then
   echo "Crosswalk file must exist prior to creating package."
   exit 1


### PR DESCRIPTION
### Fixes [BCDA-4695](https://jira.cms.gov/browse/BCDA-4695)
Build and Package was failing during the deployment process because of two things:
1. The wait-for-it timer, which is used to wait for the DB to become available before moving to the next make process, was too short and erroring out during unit-test
2. Crosswalk.tsv is a required file, but the file was moved during a refactor.
### Proposed Changes
Up the wait-for-it timer to 75 seconds, and updated the path of the crosswalk.
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
Updates to build_and_package.sh and Makefile is correct.