### PR TITLE
BCDA-4695: Fixing the remaining reference to crosswalk.

### DIFF
--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -47,13 +47,13 @@ go clean
 echo "Building bcda binary..." 
 go build -ldflags "-X github.com/CMSgov/bcda-app/bcda/constants.Version=$VERSION"
 echo "Packaging bcda binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bin/bcda swaggerui=/etc/sv/api models/fhir/alr/hcc_crosswalk.tsv=/etc/sv/api/hcc_crosswalk.tsv models/fhir/alr/hcc_crosswalk.tsv=/etc/sv/nfs/hcc_crosswalk.tsv
+fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bin/bcda swaggerui=/etc/sv/api models/fhir/alr/utils/hcc_crosswalk.tsv=/etc/sv/api/hcc_crosswalk.tsv models/fhir/alr/utils/hcc_crosswalk.tsv=/etc/sv/nfs/hcc_crosswalk.tsv
 cd ../bcdaworker
 go clean
 echo "Building bcdaworker..."
 go build -ldflags "-X github.com/CMSgov/bcda-app/bcda/constants.Version=$VERSION"
 echo "Packaging bcdaworker binary into RPM..."
-fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bin/bcdaworker ../bcda/models/fhir/alr/hcc_crosswalk.tsv=/etc/sv/worker/hcc_crosswalk.tsv
+fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bin/bcdaworker ../bcda/models/fhir/alr/utils/hcc_crosswalk.tsv=/etc/sv/worker/hcc_crosswalk.tsv
 
 #Sign RPMs
 echo "Importing GPG Key files"


### PR DESCRIPTION
### Fixes [BCDA-4695](https://jira.cms.gov/browse/BCDA-4695)
This is a followup to PR: https://github.com/CMSgov/bcda-app/pull/723
There were additional location to update path to crosswalk in build_and_package.sh.
### Proposed Changes
Update the remaining paths to the crosswalk in build_and_package.
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
Updates to build_and_package.sh is correct.