### PR TITLE
Add CI Status Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beneficiary Claims Data API
 
-[![Build Status](https://travis-ci.org/CMSgov/bcda-app.svg?branch=master)](https://travis-ci.org/CMSgov/bcda-app)
+[![Build Status](https://github.com/CMSgov/bcda-app/actions/workflows/ci-workflow.yml/badge.svg?branch=master)](https://github.com/CMSgov/bcda-app/actions?query=branch%3Amaster)
 
 ## Dependencies
 


### PR DESCRIPTION
The CI status badge on the repo's `README` is referencing the deprecated Travis CI status.  It should be replaced to show the CI Workflow from Github Actions.

### Change Details

- Replaced the Build Status badge to reflect the CI Workflow from Github Actions

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

New Status Badge shows the status of the CI Workflow from `master` branch:

<img width="443" alt="Screen Shot 2021-07-19 at 6 59 07 PM" src="https://user-images.githubusercontent.com/37818548/126238053-fb38b316-58fe-4e91-855c-035b0f9eb4c1.png">


### Feedback Requested

Please review.

