### PR TITLE
Removed printing config into log for service and db

### DIFF
--- a/bcda/database/config.go
+++ b/bcda/database/config.go
@@ -31,6 +31,5 @@ func LoadConfig() (cfg *Config, err error) {
 		return nil, errors.New("invalid config, QueueDatabaseURL must be set")
 	}
 
-	logrus.Infof("Successfully loaded config %+v.", cfg)
 	return cfg, nil
 }

--- a/bcda/database/config.go
+++ b/bcda/database/config.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/CMSgov/bcda-app/conf"
-	"github.com/sirupsen/logrus"
+	"github.com/CMSgov/bcda-app/log"
 )
 
 type Config struct {
@@ -30,6 +30,8 @@ func LoadConfig() (cfg *Config, err error) {
 	if cfg.QueueDatabaseURL == "" {
 		return nil, errors.New("invalid config, QueueDatabaseURL must be set")
 	}
+
+	log.API.Info("Successfully loaded configuration for Database.")
 
 	return cfg, nil
 }

--- a/bcda/service/config.go
+++ b/bcda/service/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
 )
 
 func LoadConfig() (cfg *Config, err error) {
@@ -19,6 +20,8 @@ func LoadConfig() (cfg *Config, err error) {
 	if err := cfg.ComputeFields(); err != nil {
 		return nil, err
 	}
+
+	log.API.Info("Successfully loaded configuration for Service.")
 
 	return cfg, nil
 }

--- a/bcda/service/config.go
+++ b/bcda/service/config.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/conf"
-	"github.com/sirupsen/logrus"
 )
 
 func LoadConfig() (cfg *Config, err error) {
@@ -21,7 +20,6 @@ func LoadConfig() (cfg *Config, err error) {
 		return nil, err
 	}
 
-	logrus.Infof("Successfully loaded config %+v.", cfg)
 	return cfg, nil
 }
 


### PR DESCRIPTION
### Fixes Configuration to Remove Unnecessary entries into log
When we added a new feature to better track and manage our environment variables (EV) into a single location, we had logs be created when the EV were successfully load. We are currently logging data that is better kept off.
### Proposed Changes
This is short PR to remove code that is responsible for logging configuration data.
Two files are affect:
1. config.go in database
2. config.go in service
### Change Details
Codes mentioned above have been removed.
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
All unnecessary data logged previous no longer occurs, and CI passes.