### PR TITLE
Increase timeout for initializing unit test DB container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ unit-test-db:
 	docker-compose -f docker-compose.test.yml up -d db-unit-test
 	
 	# Wait for the database to be ready
-	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 75
+	docker-compose -f docker-compose.wait-for-it.yml run --rm wait wait-for-it -h db-unit-test -p 5432 -t 120
 	
 	# Perform migrations to ensure matching schemas
 	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db-unit-test:5432/bcda_test?sslmode=disable&x-migrations-table=schema_migrations_bcda" -path /go/src/github.com/CMSgov/bcda-app/db/migrations/bcda up


### PR DESCRIPTION
The time it takes to initialize the unit test DB container has increased, largely due to the heavy parallelization occurring during CI in Jenkins.  This results in flaky CI, causing unit tests to fail sporadically.

### Change Details

- Increased the unit test DB init to 120 seconds

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Successful execution in Jenkins occurred [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/2697/).

### Feedback Requested

Please review.
