### PR TITLE
bcda-4723 Feature: Increase wait-for-it timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ load-fixtures:
 
 	docker-compose up -d db queue
 	echo "Wait for databases to be ready..."
-	docker run --rm --network bcda-app-net willwill/wait-for-it db:5432 -t 75
-	docker run --rm --network bcda-app-net willwill/wait-for-it queue:5432 -t 75
+	docker run --rm --network bcda-app-net willwill/wait-for-it db:5432 -t 100
+	docker run --rm --network bcda-app-net willwill/wait-for-it queue:5432 -t 100
 
 	# Initialize schemas
 	docker run --rm -v ${PWD}/db/migrations:/migrations --network bcda-app-net migrate/migrate -path=/migrations/bcda/ -database 'postgres://postgres:toor@db:5432/bcda?sslmode=disable&x-migrations-table=schema_migrations_bcda' up
@@ -105,8 +105,8 @@ load-fixtures:
 
 	# Ensure components are started as expected
 	docker-compose up -d api worker ssas
-	docker run --rm --network bcda-app-net willwill/wait-for-it api:3000 -t 75
-	docker run --rm --network bcda-app-net willwill/wait-for-it ssas:3003 -t 75
+	docker run --rm --network bcda-app-net willwill/wait-for-it api:3000 -t 100
+	docker run --rm --network bcda-app-net willwill/wait-for-it ssas:3003 -t 100
 
 	# Additional fixtures for postman+ssas
 	docker-compose run db psql -v ON_ERROR_STOP=1 "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /var/db/postman_fixtures.sql


### PR DESCRIPTION
### Fixes [BCDA-4723](https://jira.cms.gov/browse/BCDA-4723)

The `wait-for-it` timeout in our Makefile for bringing up our services in containers has been increased in the recent past to `75 seconds`. However, there have still been a few instances of the boot process timing out due to not allowing enough time for the container to start up.

### Change Details

- Increase the `wait-for-it` timeout to 100 seconds for the databases, the api, and the ssas api.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Continue to observe the deployment and running of our smoke tests (that use our docker containers) and see if further timeouts appear.

### Feedback Requested

General feedback always appreciated.