### PR TITLE
BCDA-3047: Use Github PAT over HTTPS instead of SSH Key

### DIFF
--- a/ops/Jenkinsfile.build_trigger
+++ b/ops/Jenkinsfile.build_trigger
@@ -37,7 +37,8 @@ pipeline {
             relativeTargetDir: 'bcda-app'
           ]],
           userRemoteConfigs: [[
-            url: 'git@github.com:CMSgov/bcda-app.git'
+            url: 'https://github.com/CMSgov/bcda-app.git',
+            credentialsId: 'GITHUB_CREDS'
           ]]
         ])
         script {


### PR DESCRIPTION


### Fixes [BCDA-3047](https://jira.cms.gov/browse/BCDA-3047)

BCDA currently uses SSH Keys to integrate with Github from Jenkins, which relies on the SSH key to be stored on the Jenkins volume.  To simplify the migration to the new contract, the strategy will be updated to use Personal Access Tokens to integrate with Github (which is identical to the strategy being used on the DPC project).  
This should be considered an enhancement, as the tokens will be stored in Jenkins Credential Management System as opposed to a nebulous location on the Jenkins volume.

### Proposed Changes

We should migrate to use Personal Access Tokens to integrate with Github from Jenkins.

### Change Details

- Added a new Personal Access Token to the BCDA Jenkins Credential Management System
- Updated the Checkout Strategies for all relevant Jenkins jobs to ensure that it is using the new credential

### Security Implications

- [ ] new software dependencies
- [x] security controls or supporting software altered
> Access is technically not being altered, it is simply being modified.  There are two mechanisms for interacting securely with Github: via SSH key or via personal access token over HTTPS.  Both offer a standard level of security when pulling code from Github.  In this modification, we are ensuring that migration to the new contract can take place by simply updating the Personal Access Token in the Jenkins Credential Management System (as opposed to setting up a new SSH key to be stored on the Jenkins volume).  
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

A successful build in Jenkins was performed with a sample job [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/2781/).

### Feedback Requested

Please review.
