### PR TITLE
BCDA-4801: Update ALR Swagger Text

### DIFF
--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -43,6 +43,8 @@ func init() {
 
 	Start FHIR STU3 data export for all supported resource types
 
+	Initiates a job to collect Assignment List Report data for your ACO. Supported resource types are Patient, Coverage, Group, Risk Assessment, Observation, and Covid Episode.
+
 	Produces:
 	- application/fhir+json
 

--- a/bcda/api/v2/api.go
+++ b/bcda/api/v2/api.go
@@ -14,8 +14,8 @@ import (
 
 	api "github.com/CMSgov/bcda-app/bcda/api"
 	"github.com/CMSgov/bcda-app/bcda/constants"
-	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/CMSgov/bcda-app/bcda/service"
+	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
 )
@@ -54,6 +54,8 @@ func init() {
 	swagger:route GET /api/v1/alr/$export alrData alrRequest
 
 	Start FHIR R4 data export for all supported resource types
+
+	Initiates a job to collect Assignment List Report data for your ACO. Supported resource types are Patient, Coverage, Group, Risk Assessment, Observation, and Covid Episode.
 
 	Produces:
 	- application/fhir+json


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [BCDA-4801](https://jira.cms.gov/browse/BCDA-4801)
Our Swagger documentation for ALR doesn't specify supported resource types, just whether they are FHIR R4 or STU3. 

### Proposed Changes
Include supported resource types that are returned by the v1 and v2 ALR endpoints

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
Language updated on both v1 and v2 Swagger pages:
_"Initiates a job to collect Assignment List Report data for your ACO. Supported resource types are Patient, Coverage, Group, Risk Assessment, Observation, and Covid Episode."_


### Feedback Requested
Is there any other supporting language we'd want to add for these ALR endpoints?