### PR TITLE
Remove trailing slash from base url in requests test

### DIFF
--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -472,7 +472,7 @@ func (s *RequestsTestSuite) TestDataTypeAuthorization() {
 		"ClaimResponse":        {Adjudicated: false, PreAdjudicated: true},
 	}
 
-	h := NewHandler(dataTypeMap, "/v2/fhir/", "v2")
+	h := NewHandler(dataTypeMap, "/v2/fhir", "v2")
 
 	// Use a mock to ensure that this test does not generate artifacts in the queue for other tests
 	mockEnq := &queueing.MockEnqueuer{}


### PR DESCRIPTION
### Fixes [BCDA-xxx](https://jira.cms.gov/browse/BCDA-xxx)

Builds have been failing due failing unit tests in `requests_test.go`. This coincides with a BFD update to their java package. The error we are seeing is a 400 with a body of `reason: Ambiguous URI empty segment`. Looking at the request uri we are using to contact the bluebutton client it was shown to have a bad uri: `...v2/fhir//Patient...`. The extra slash must have been ignored in the past version of the java BFD was using and the upgraded version is now throwing a new error.

### Change Details

Removed the trailing slash in the base url being used in the test.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Tests are now passing.

### Feedback Requested

Let me know if that theory about the java change is incorrect and just a Red Herring.