### PR TITLE
Add nil check for resp in retry functionality for smoke tests

### DIFF
--- a/test/smoke_test/bcda_client.go
+++ b/test/smoke_test/bcda_client.go
@@ -97,7 +97,7 @@ func NewClient(accessToken string, retries int) *client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = retries
 	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		if resp.StatusCode == http.StatusUnauthorized {
+		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
 			log.Info("Access token expired. Refreshing...")
 			if err := c.updateAccessToken(); err != nil {
 				return true, fmt.Errorf("failed to update access token %s", err.Error())


### PR DESCRIPTION
### Proposed Changes

Due to longer run times in our upper environments for smoke tests we have been running into the retry logic for our tests. This has resulted in errors due to the `response` not being set.

### Change Details

Check if `resp` is set before and fall back to the default retry policy.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Smoke tests pass on dev

### Feedback Requested

Let me know if I missed something