### PR TITLE
BCDA- 5161 Adding manual DB wrangle for runout 2021

### DIFF
--- a/db/migrations/manual/20211229-runout-undo.sql
+++ b/db/migrations/manual/20211229-runout-undo.sql
@@ -6,10 +6,9 @@ DO $$
 
 DECLARE cclfids integer ARRAY;
 BEGIN
-cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2021-11-30' AND timestamp < '2022-01-01' AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
+cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2021-11-30' AND type = 1 AND timestamp < '2022-01-01' AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
 
--- This line should output all the ids that are affected. One can saved this in keybase
--- and compare when undoing
+-- Compare this output with what you may have stored in keybase
 raise notice 'Following IDs affected: %', cclfids;
 UPDATE cclf_files SET type = 0 where id = ANY(cclfids);
 END;

--- a/db/migrations/manual/20211229-runout-undo.sql
+++ b/db/migrations/manual/20211229-runout-undo.sql
@@ -1,0 +1,19 @@
+-- This is a manual DB wrangle to convert Dec CCLF attribution into runouts
+-- We will undo this and convert back to Dec CCLF once the runout for 2022 is received
+
+BEGIN;
+DO $$
+
+DECLARE cclfids integer ARRAY;
+BEGIN
+cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2021-11-30' AND timestamp < '2022-01-01' AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
+
+-- This line should output all the ids that are affected. One can saved this in keybase
+-- and compare when undoing
+raise notice 'Following IDs affected: %', cclfids;
+UPDATE cclf_files SET type = 0 where id = ANY(cclfids);
+END;
+
+$$;
+
+COMMIT;

--- a/db/migrations/manual/20211229-runout.sql
+++ b/db/migrations/manual/20211229-runout.sql
@@ -6,11 +6,10 @@ DO $$
 
 DECLARE cclfids integer ARRAY;
 BEGIN
-cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2021-11-30' AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
+cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2021-11-30' AND type = 0 AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
 -- This array should ONLY have type == 0
 
--- You can check the array matches with the array you may have stored in keybase when you ran
--- 20211229-runout.sql
+-- You can store the array in keybase and ensure the right IDs are affect when undoing this
 raise notice 'Following IDs affected: %', cclfids;
 -- value of 1 is runout, and 0 is not
 UPDATE cclf_files SET type = 1 where id = ANY(cclfids);

--- a/db/migrations/manual/20211229-runout.sql
+++ b/db/migrations/manual/20211229-runout.sql
@@ -1,0 +1,21 @@
+-- This is a manual DB wrangle to convert Dec CCLF attribution into runouts
+-- We will undo this and convert back to Dec CCLF once the runout for 2022 is received
+
+BEGIN;
+DO $$
+
+DECLARE cclfids integer ARRAY;
+BEGIN
+cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2021-11-30' AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
+-- This array should ONLY have type == 0
+
+-- You can check the array matches with the array you may have stored in keybase when you ran
+-- 20211229-runout.sql
+raise notice 'Following IDs affected: %', cclfids;
+-- value of 1 is runout, and 0 is not
+UPDATE cclf_files SET type = 1 where id = ANY(cclfids);
+END;
+
+$$;
+
+COMMIT;


### PR DESCRIPTION
### Fixes [BCDA-5161](https://jira.cms.gov/browse/BCDA-5161)
We currently do not have runout files within the 180 day window to serve to ACOs. If we ran the terraform implementation without any additional work with data, we not serve any data to your stakeholders until JAN/FEB next year when the new runouts will be available.
### Proposed Changes
To prevent no data being served, we would like to temporarily convert the DEC CCLF files into runout by changing those from 0 to 1 for the type field.  This will enable ACOs to continue to receive data based on their DEC attribution data.
### Change Details
We add two manual DB wrangle to handle this issue. One for changing DEC CCLF to runouts, and another to undo it when new runout files become available.
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
Ensure the two sql scripts are correctly written. Try running it locally and make sure it works.
### Feedback Requested
Yes!
