### PR TITLE
Updates to allow `make unit-test` to pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,12 @@ postman:
 	--global-var v2Disabled=false \
 	--global-var alrEnabled=true
 
-unit-test:
-	$(MAKE) unit-test-db
-	
+unit-test: unit-test-ssas unit-test-db load-fixtures-ssas
 	docker-compose -f docker-compose.test.yml build tests
 	@docker-compose -f docker-compose.test.yml run --rm tests bash scripts/unit_test.sh
+
+unit-test-ssas:
+	docker-compose up -d ssas
 
 unit-test-db:
 	# Target stands up the postgres instance needed for unit testing.


### PR DESCRIPTION
Before this running `make unit-test` on it's own would fail due to a missing external dependency. This is used by Jenkins.


### Fixes N/A

### Change Details

Include local `ssas` as a dependency of the `unit-test` make command.

