### PR TITLE
BCDA-5795 Increase timeout to 5 seconds for SSAS http client

### DIFF
--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -51,8 +51,8 @@ func NewSSASClient() (*SSASClient, error) {
 
 	var timeout int
 	if timeout, err = strconv.Atoi(conf.GetEnv("SSAS_TIMEOUT_MS")); err != nil {
-		log.SSAS.Info("Could not get SSAS timeout from environment variable; using default value of 500.")
-		timeout = 500
+		log.SSAS.Info("Could not get SSAS timeout from environment variable; using default value of 5000.")
+		timeout = 5000
 	}
 
 	ssasURL := conf.GetEnv("SSAS_URL")


### PR DESCRIPTION
### Fixes [BCDA-5795](https://jira.cms.gov/browse/BCDA-5795)

Increasing the timeout on the client side for SSAS api requests
