### PR TITLE
PACA-875: Manual migration to partially adjudicated runout file records.

### DIFF
--- a/db/migrations/manual/20221222-partially-adj-synthea-rel1-runout-update.sql
+++ b/db/migrations/manual/20221222-partially-adj-synthea-rel1-runout-update.sql
@@ -1,0 +1,14 @@
+-- Updating the sandbox runout files for partially adjudicated TEST99x accounts
+-- to allow runout testing.
+
+BEGIN;
+UPDATE cclf_files
+    set type=1,
+        updated_at=now(),
+        timestamp='2022-09-29',
+        performance_year=22
+    where
+        cclf_num=8
+        and name in ('T.BCD.TEST990.ZC8R21.D210929.T1834180','T.BCD.TEST991.ZC8R21.D210929.T1834180','T.BCD.TEST992.ZC8R21.D210929.T1834180')
+        and type=0;
+COMMIT;


### PR DESCRIPTION
<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [PACA-875](https://jira.cms.gov/browse/PACA-875)

Runout queries are not working for PACA test accounts in sandbox environment.  The problem appears to be caused by the type and timestamp parameter values in the runout file records.  This PR includes a manual migration that would need to be executed in the sandbox database to change these values.

### Proposed Changes

Adds manual migration file to update `type` and `timestamp` in PACA runout `cclf_files` records.

### Change Details

Adds manual migration file to update `type` and `timestamp` in PACA runout `cclf_files` records.

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database? -->

### Feedback Requested

Is this change correct for its intended purpose?
