### PR TITLE
BCDA-6819: update 401 error handling for /auth/token endpoint

### DIFF
--- a/bcda/auth/api.go
+++ b/bcda/auth/api.go
@@ -57,6 +57,14 @@ func GetAuthToken(w http.ResponseWriter, r *http.Request) {
 			log.API.Errorf("Error making access token - %s | HTTPS Status Code: %v", err.Error(), http.StatusInternalServerError)
 
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		case *customErrors.SSASErrorUnauthorized:
+			log.API.Errorf("Error making access token - %s | HTTPS Status Code: %v", err.Error(), http.StatusUnauthorized)
+
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		case *customErrors.SSASErrorBadRequest:
+			log.API.Errorf("Error making access token - %s | HTTPS Status Code: %v", err.Error(), http.StatusBadRequest)
+
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		default:
 			log.API.Errorf("Error making access token - %s | HTTPS Status Code: %v", err.Error(), http.StatusUnauthorized)
 

--- a/bcda/auth/api_test.go
+++ b/bcda/auth/api_test.go
@@ -76,6 +76,8 @@ func (s *AuthAPITestSuite) TestGetAuthTokenErrorSwitchCases() {
 	}{
 		{"Token Request Timeout Error Return 503", &customErrors.RequestTimeoutError{Err: errors.New(errorHappened), Msg: errMsg}, 503, "1"},
 		{"Token Unexpected SSAS Error Return 500", &customErrors.UnexpectedSSASError{Err: errors.New(errorHappened), Msg: errMsg}, 500, constants.EmptyString},
+		{"Token Unauthorized SSAS Error Return 401", &customErrors.SSASErrorUnauthorized{Err: errors.New(errorHappened), Msg: errMsg}, 401, constants.EmptyString},
+		{"Token Bad Request SSAS Error Return 400", &customErrors.SSASErrorBadRequest{Err: errors.New(errorHappened), Msg: errMsg}, 400, constants.EmptyString},
 		{"Token Internal Parsing Error Return 500", &customErrors.InternalParsingError{Err: errors.New(errorHappened), Msg: errMsg}, 500, constants.EmptyString},
 		{"Token Default Error Return 401", errors.New(errorHappened), 401, constants.EmptyString},
 	}

--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -319,7 +319,14 @@ func (c *SSASClient) GetToken(credentials Credentials) (string, error) {
 		if err != nil {
 			return "", &customErrors.UnexpectedSSASError{Err: err, SsasStatusCode: resp.StatusCode, Msg: "Cannot read response body, token request failed;"}
 		} else {
-			return "", &customErrors.UnexpectedSSASError{Err: err, SsasStatusCode: resp.StatusCode, Msg: fmt.Sprintf("%s, Response Body: %s", constants.TokenRequestUnexpectedErr, string(b))}
+			switch resp.StatusCode {
+			case 401:
+				return "", &customErrors.SSASErrorUnauthorized{Err: err, SsasStatusCode: resp.StatusCode, Msg: fmt.Sprintf("%s, Response Body: %s", constants.TokenRequestUnexpectedErr, string(b))}
+			case 400:
+				return "", &customErrors.SSASErrorBadRequest{Err: err, SsasStatusCode: resp.StatusCode, Msg: fmt.Sprintf("%s, Response Body: %s", constants.TokenRequestUnexpectedErr, string(b))}
+			default:
+				return "", &customErrors.UnexpectedSSASError{Err: err, SsasStatusCode: resp.StatusCode, Msg: fmt.Sprintf("%s, Response Body: %s", constants.TokenRequestUnexpectedErr, string(b))}
+			}
 		}
 	}
 

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -439,7 +439,7 @@ func (s *SSASClientTestSuite) TestGetToken() {
 	}{
 		{"Active Credentials", testUtils.MakeTestServerWithValidTokenRequest(), constants.FiveHundredSeconds, []byte(token), nil, []byte(constants.ExpiresInDefault)},
 		{"Token Request Timed Out", testUtils.MakeTestServerWithTokenRequestTimeout(), constants.FiveSeconds, []byte(nil), &customErrors.RequestTimeoutError{Msg: constants.EmptyString, Err: nil}, []byte(nil)},
-		{"Invalid Credentials", testUtils.MakeTestServerWithInvalidTokenRequest(), constants.FiveHundredSeconds, []byte(nil), &customErrors.UnexpectedSSASError{Msg: constants.EmptyString, Err: nil}, []byte(nil)},
+		{"Invalid Credentials", testUtils.MakeTestServerWithInvalidTokenRequest(), constants.FiveHundredSeconds, []byte(nil), &customErrors.SSASErrorUnauthorized{Msg: constants.EmptyString, Err: nil}, []byte(nil)},
 	}
 
 	for _, tt := range tests {

--- a/bcda/errors/errors.go
+++ b/bcda/errors/errors.go
@@ -57,6 +57,26 @@ func (e *UnexpectedSSASError) Error() string {
 	return fmt.Sprintf("Unexpected SSAS Error encountered - %s. Status Code: %v, Err: %s", e.Msg, e.SsasStatusCode, e.Err)
 }
 
+type SSASErrorUnauthorized struct {
+	Err            error
+	Msg            string
+	SsasStatusCode int
+}
+
+func (e *SSASErrorUnauthorized) Error() string {
+	return fmt.Sprintf("Unexpected SSAS Error encountered - %s. Status Code: %v, Err: %s", e.Msg, e.SsasStatusCode, e.Err)
+}
+
+type SSASErrorBadRequest struct {
+	Err            error
+	Msg            string
+	SsasStatusCode int
+}
+
+func (e *SSASErrorBadRequest) Error() string {
+	return fmt.Sprintf("Unexpected SSAS Error encountered - %s. Status Code: %v, Err: %s", e.Msg, e.SsasStatusCode, e.Err)
+}
+
 type ExpiredTokenError struct {
 	Err error
 	Msg string


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-6819

## 🛠 Changes

/auth/token endpoint will return 401, 400, or 500 statuses given a 401, 400, or 500 HTTP error from bcda-ssas. 

## ℹ️ Context for reviewers

**Comments**: I learned that Go does not have Enums as a built-in type, but const can be used in its place and key/value pairs in go maps have to be of the same type. I initially looked into those to try and circumvent lots of switches/nested if/else statements.
 
**Call-out**: 

1. This ticket has not requested handling of 403s. Is that something that we should consider at this time or put into a future ticket?
2. bcda/auth/api.go line 68 will default to a 401 response. Based on the ticket, it sounds like that should return a 500 instead. Could I get a second pair of eyes on that section?

## ✅ Acceptance Validation

Unit tests have been updated but needs manual testing (setting up postman)

## 🔒 Security Implications

- [ ] New data is stored or transmitted.
  <!-- What data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] This change introduces new software dependencies.
  <!-- List the new dependencies and briefly note relevant security impacts -->

- [ ] This change impacts security controls or alters supporting software.
  <!-- What security controls or supporting software are affected? -->

- [ ] A [security checklist](https://confluence.cms.gov/display/BCDA/Security+Checklists) is completed for this change.
  <!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] More team discussion required to evaluate security implications.
  <!-- Use this if you are unsure how this change may impact system security
       and would like to solicit the team's feedback. Provide some context. -->
