### PR TITLE
ci-fix: remove usql from tools.go, as latest version breaks go.mod (0…

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -15,7 +15,6 @@ import (
 	// test dependencies
 	_ "github.com/securego/gosec/cmd/gosec"
 	_ "github.com/tsenart/vegeta"
-	_ "github.com/xo/usql"
 	_ "gotest.tools/gotestsum"
 	// end test dependencies
 )


### PR DESCRIPTION
….14.0)

## 🎫 Ticket


## 🛠 Changes

tools.go no longer installs `usql`.

## ℹ️ Context for reviewers

CI workflow was installing the latest version of https://github.com/xo/usql while building the test docker image. This resulted in an error in the CI workflow with `afero` being reported as an unneeded requirement and causing an error: `cmd/go: get: panic: internal error: can't find reason for requirement`.
## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] New data is stored or transmitted.
  <!-- What data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] This change introduces new software dependencies.
  <!-- List the new dependencies and briefly note relevant security impacts -->

- [ ] This change impacts security controls or alters supporting software.
  <!-- What security controls or supporting software are affected? -->

- [ ] A [security checklist](https://confluence.cms.gov/display/BCDA/Security+Checklists) is completed for this change.
  <!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] More team discussion required to evaluate security implications.
  <!-- Use this if you are unsure how this change may impact system security
       and would like to solicit the team's feedback. Provide some context. -->
