### PR TITLE
BCDA-4456: Remove duplicate calls to SSAS /introspect endpoint

### DIFF
--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -86,8 +86,8 @@ func AuthorizeAccess(tokenString string) (*jwt.Token, AuthData, error) {
 	}
 
 	claims, ok := token.Claims.(*CommonClaims)
-	if !ok {
-		// This is already validated by VerifyToken so in theory it's unreachable code.
+	if !ok || !token.Valid {
+		// These should already trigger an error within VerifyToken, so in theory it's unreachable code.
 		return nil, ad, errors.New("invalid ssas claims")
 	}
 

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -85,11 +85,9 @@ func AuthorizeAccess(tokenString string) (*jwt.Token, AuthData, error) {
 		return nil, ad, err
 	}
 
-	// Maybe split this back out to ensure that we don't start failing requests that used to succeed...
-	// except it's only in this specific scenario that it fails. otherwise it continues to getAuthDataFromClaims
-	// and returns an error anyways, so we're probably good to continue with this approach.
 	claims, ok := token.Claims.(*CommonClaims)
-	if !ok || !token.Valid {
+	if !ok {
+		// This is already validated by VerifyToken so in theory it's unreachable code.
 		return nil, ad, errors.New("invalid ssas claims")
 	}
 

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/go-chi/chi/v5"
+	"github.com/pkg/errors"
 
 	"github.com/CMSgov/bcda-app/bcda/database"
 	customErrors "github.com/CMSgov/bcda-app/bcda/errors"
@@ -58,7 +59,7 @@ func ParseToken(next http.Handler) http.Handler {
 
 		tokenString := authSubmatches[1]
 
-		token, ad, err := GetProvider().AuthorizeAccess(tokenString)
+		token, ad, err := AuthorizeAccess(tokenString)
 		if err != nil {
 			handleTokenVerificationError(w, rw, err)
 			return
@@ -68,6 +69,48 @@ func ParseToken(next http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, AuthDataContextKey, ad)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// AuthorizeAccess asserts that a base64 encoded token string is valid for accessing the BCDA API.
+func AuthorizeAccess(tokenString string) (*jwt.Token, AuthData, error) {
+	tknEvent := event{op: "AuthorizeAccess"}
+	operationStarted(tknEvent)
+	token, err := GetProvider().VerifyToken(tokenString)
+
+	var ad AuthData
+
+	if err != nil {
+		tknEvent.help = fmt.Sprintf("VerifyToken failed in AuthorizeAccess; %s", err.Error())
+		operationFailed(tknEvent)
+		return nil, ad, err
+	}
+
+	// Maybe split this back out to ensure that we don't start failing requests that used to succeed...
+	// except it's only in this specific scenario that it fails. otherwise it continues to getAuthDataFromClaims
+	// and returns an error anyways, so we're probably good to continue with this approach.
+	claims, ok := token.Claims.(*CommonClaims)
+	if !ok || !token.Valid {
+		return nil, ad, errors.New("invalid ssas claims")
+	}
+
+	switch claims.Issuer {
+	case "ssas":
+		ad, err = GetProvider().getAuthDataFromClaims(claims)
+		if err != nil {
+			tknEvent.help = fmt.Sprintf("failed getting AuthData; %s", err.Error())
+			operationFailed(tknEvent)
+			return nil, ad, err
+		}
+	default:
+		tknEvent.help = fmt.Sprintf("Unsupported claims issuer; %s", claims.Issuer)
+		operationFailed(tknEvent)
+		msg := fmt.Sprintf("Claim issuer '%s' is not supported", claims.Issuer)
+		err := &customErrors.UnsupportedClaimsIssuerError{Err: errors.New(msg), Msg: msg}
+		return nil, ad, err
+	}
+
+	operationSucceeded(tknEvent)
+	return token, ad, nil
 }
 
 func handleTokenVerificationError(w http.ResponseWriter, rw fhirResponseWriter, err error) {

--- a/bcda/auth/mock_provider.go
+++ b/bcda/auth/mock_provider.go
@@ -12,20 +12,6 @@ type MockProvider struct {
 	mock.Mock
 }
 
-// AuthorizeAccess provides a mock function with given fields: tokenString
-func (_m *MockProvider) AuthorizeAccess(tokenString string) error {
-	ret := _m.Called(tokenString)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(tokenString)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // GetVersion provides a mock function with given fields:
 func (_m *MockProvider) GetVersion() (string, error) {
 	ret := _m.Called()

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -86,7 +86,7 @@ type Provider interface {
 
 	// TODO refactor input to be AuthData
 	// AuthorizeAccess asserts that a base64 encoded token string is valid for accessing the BCDA API
-	AuthorizeAccess(tokenString string) error
+	AuthorizeAccess(tokenString string) (*jwt.Token, AuthData, error)
 
 	// VerifyToken decodes a base64 encoded token string into a structured token
 	VerifyToken(tokenString string) (*jwt.Token, error)

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -84,10 +84,6 @@ type Provider interface {
 	// RevokeAccessToken a specific access token identified in a base64 encoded token string
 	RevokeAccessToken(tokenString string) error
 
-	// TODO refactor input to be AuthData
-	// AuthorizeAccess asserts that a base64 encoded token string is valid for accessing the BCDA API
-	AuthorizeAccess(tokenString string) (*jwt.Token, AuthData, error)
-
 	// VerifyToken decodes a base64 encoded token string into a structured token
 	VerifyToken(tokenString string) (*jwt.Token, error)
 

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -274,7 +274,7 @@ func (s *SSASPluginTestSuite) TestAuthorizeAccessErrIsNilWhenHappyPath() {
 	c, err := client.NewSSASClient()
 	require.NotNil(s.T(), c, sSasClientErrorMsg, err)
 	s.p = SSASPlugin{client: c, repository: s.r}
-	err = s.p.AuthorizeAccess(tokenString)
+	_, _, err = AuthorizeAccess(tokenString)
 	require.Nil(s.T(), err)
 }
 
@@ -289,7 +289,7 @@ func (s *SSASPluginTestSuite) TestAuthorizeAccessErrISReturnedWhenVerifyTokenChe
 	s.p = SSASPlugin{client: c, repository: s.r}
 
 	invalidTokenString := ""
-	err = s.p.AuthorizeAccess(invalidTokenString)
+	_, _, err = AuthorizeAccess(invalidTokenString)
 	assert.EqualError(s.T(), err, "Requestor Data Error encountered - unable to parse provided tokenString to jwt.token. Err: token contains an invalid number of segments")
 }
 
@@ -360,7 +360,7 @@ func (s *SSASPluginTestSuite) TestAuthorizeAccessErrIsReturnedWhenGetAuthDataFro
 	require.NotNil(s.T(), c, sSasClientErrorMsg, err)
 	s.p = SSASPlugin{client: c, repository: s.r}
 
-	err = s.p.AuthorizeAccess(ts)
+	_, _, err = AuthorizeAccess(ts)
 	assert.EqualError(s.T(), err, "can't decode data claim ac; invalid character 'a' looking for beginning of value")
 }
 

--- a/bcda/errors/errors.go
+++ b/bcda/errors/errors.go
@@ -85,12 +85,3 @@ type ExpiredTokenError struct {
 func (e *ExpiredTokenError) Error() string {
 	return fmt.Sprintf("Expired Token Error encountered - %s. Err: %s", e.Msg, e.Err)
 }
-
-type UnsupportedClaimsIssuerError struct {
-	Err error
-	Msg string
-}
-
-func (e *UnsupportedClaimsIssuerError) Error() string {
-	return fmt.Sprintf("Unsupported Claims Issuer Error encountered - %s. Err: %s", e.Msg, e.Err)
-}

--- a/bcda/errors/errors.go
+++ b/bcda/errors/errors.go
@@ -85,3 +85,12 @@ type ExpiredTokenError struct {
 func (e *ExpiredTokenError) Error() string {
 	return fmt.Sprintf("Expired Token Error encountered - %s. Err: %s", e.Msg, e.Err)
 }
+
+type UnsupportedClaimsIssuerError struct {
+	Err error
+	Msg string
+}
+
+func (e *UnsupportedClaimsIssuerError) Error() string {
+	return fmt.Sprintf("Unsupported Claims Issuer Error encountered - %s. Err: %s", e.Msg, e.Err)
+}

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -344,12 +344,11 @@ func createConfigsForACOBlacklistingScenarios(s *RouterTestSuite) (configs []str
 
 func setExpectedMockCalls(s *RouterTestSuite, mock *auth.MockProvider, token *jwt.Token, aco models.ACO, bearerString string, cmsID string) {
 	mock.On("VerifyToken", bearerString).Return(token, nil)
-	mock.On("AuthorizeAccess", token.Raw).Return(nil)
 	mock.On("getAuthDataFromClaims", token.Claims).Return(createExpectedAuthData(cmsID, aco), nil)
 	auth.SetMockProvider(s.T(), mock)
 }
 
-//integration test, requires connection to postgres db
+// integration test, requires connection to postgres db
 // TestBlacklistedACOs ensures that we return 403 FORBIDDEN when a call is made from a blacklisted ACO.
 func (s *RouterTestSuite) TestBlacklistedACOReturn403WhenACOBlacklisted() {
 	// Use a new router to ensure that v2 endpoints are active


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-4456

## 🛠 Changes

- Rely on ParseToken for token parsing and validation, if it is provided
- Remove validation logic from `RequireTokenAuth` (only check if token has been pre-validated and stored in the request context)
- Instead of deleting the `AuthorizeAccess` method...
  - Merge validation logic from `ParseToken` to `AuthorizeAccess` and clean up unreachable code

i.e. flow before and after for authorized endpoints:

```
# Before
--> ParseToken (validation logic) 
--> RequireTokenAuth (confirm token exists) 
    --> calls AuthorizeAccess (validation logic)

# After
--> ParseToken
    --> calls AuthorizeAccess (validation logic)
--> RequireTokenAuth (confirm token exists)
```

## ℹ️ Context for reviewers

### Current Logic

---

Currently, token middleware is handled through two functions (ParseToken and RequireTokenAuth).

- Unauthenticated endpoints use ParseToken
- Authenticated endpoints use both ParseToken and RequireTokenAuth

→ **ParseToken** method checks if a token was provided in the headers:

- If a token is provided, parse + validate it and store it in the request context.
- If no token is provided, do not return an error (continue with the request.) 

→ **RequireTokenAuth** method checks that a token was stored in the request context.

- If a token is stored, validate it (again).
- If no token is stored, return a 401 Unauthorized error.

Since ParseToken is _guaranteed_ to be called before RequireTokenAuth, this means that every request to an endpoint requiring authorization will make duplicate calls to:

- the SSAS /introspect endpoint
- the `getAuthDataFromClaims` function, which makes database calls

### New Logic

---

This PR removes the validation from RequireTokenAuth. If the token is stored in the request context, _it has already been validated by ParseToken_ and does not need to be re-validated.

Instead of removing AuthorizeAccess entirely, I have merged the existing validation logic in `ParseToken` with the logic in `AuthorizeAccess`. They essentially do the same thing with minor differences.

## ✅ Acceptance Validation

Existing unit and integration tests (with a fake/live SSAS server) verify the expected authorization behavior of the BCDA API. I have only updated the mocks to reflect that RequireTokenAuth no longer makes any calls to the validation methods.

Note that the auth module logs do not reach Splunk, so it is not possible to fully verify whether the error conditions in RequireTokenAuth have ever been reached in production. However, since validation already happens in ParseToken, it is expected that the token validation in RequireTokenAuth _always succeeds_.

## 🔒 Security Implications

This change is not expected to impact the functionality of the authorization layer. Reviewers should confirm this.

- [ ] New data is stored or transmitted.
  <!-- What data are we storing or transmitting? Is the data considered PII/PHI? -->
- [ ] This change introduces new software dependencies.
  <!-- List the new dependencies and briefly note relevant security impacts -->
- [ ] This change impacts security controls or alters supporting software.
  <!-- What security controls or supporting software are affected? -->
- [ ] A [security checklist](https://confluence.cms.gov/display/BCDA/Security+Checklists) is completed for this change.
  <!-- If yes, provide a link to the security checklist in Confluence here. -->
- [ ] More team discussion required to evaluate security implications.
  <!-- Use this if you are unsure how this change may impact system security
       and would like to solicit the team's feedback. Provide some context. -->
