### PR TITLE
BCDA-5355: Disable ALR export endpoints

### DIFF
--- a/bcda/api/alr.go
+++ b/bcda/api/alr.go
@@ -10,12 +10,18 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/CMSgov/bcda-app/bcda/web/middleware"
+	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
 	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
 	"github.com/pborman/uuid"
 )
 
 func (h *Handler) alrRequest(w http.ResponseWriter, r *http.Request) {
+	if conf.GetEnv("ENABLE_ALR_ENDPOINTS") != "true" {
+		h.RespWriter.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, "Endpoint Not Found")
+		return
+	}
+
 	ctx := r.Context()
 
 	// retrieve ACO & cms_id data from the context through value

--- a/bcda/api/alr.go
+++ b/bcda/api/alr.go
@@ -10,18 +10,12 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/bcda/servicemux"
 	"github.com/CMSgov/bcda-app/bcda/web/middleware"
-	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
 	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
 	"github.com/pborman/uuid"
 )
 
 func (h *Handler) alrRequest(w http.ResponseWriter, r *http.Request) {
-	if conf.GetEnv("ENABLE_ALR_ENDPOINTS") != "true" {
-		h.RespWriter.Exception(w, http.StatusNotFound, responseutils.NotFoundErr, "Endpoint Not Found")
-		return
-	}
-
 	ctx := r.Context()
 
 	// retrieve ACO & cms_id data from the context through value

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -54,7 +54,7 @@ func NewAPIRouter() http.Handler {
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Patient/$export", v1.BulkPatientRequest))
-		if conf.GetEnv("ENABLE_ALR_ENDPOINTS") != "true" {
+		if conf.GetEnv("ENABLE_ALR_ENDPOINTS") == "true" {
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v1.ALRRequest))
 		}
 		r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Group/{groupId}/$export", v1.BulkGroupRequest))
@@ -69,7 +69,7 @@ func NewAPIRouter() http.Handler {
 		FileServer(r, "/api/v2/swagger", http.Dir("./swaggerui/v2"))
 		r.Route("/api/v2", func(r chi.Router) {
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Patient/$export", v2.BulkPatientRequest))
-			if conf.GetEnv("ENABLE_ALR_ENDPOINTS") != "true" {
+			if conf.GetEnv("ENABLE_ALR_ENDPOINTS") == "true" {
 				r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v2.ALRRequest))
 			}
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Group/{groupId}/$export", v2.BulkGroupRequest))

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -54,7 +54,9 @@ func NewAPIRouter() http.Handler {
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Patient/$export", v1.BulkPatientRequest))
-		r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v1.ALRRequest))
+		if conf.GetEnv("ENABLE_ALR_ENDPOINTS") != "true" {
+			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v1.ALRRequest))
+		}
 		r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Group/{groupId}/$export", v1.BulkGroupRequest))
 		r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Get(m.WrapHandler(constants.JOBIDPath, v1.JobStatus))
 		r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/jobs", v1.JobsStatus))
@@ -67,7 +69,9 @@ func NewAPIRouter() http.Handler {
 		FileServer(r, "/api/v2/swagger", http.Dir("./swaggerui/v2"))
 		r.Route("/api/v2", func(r chi.Router) {
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Patient/$export", v2.BulkPatientRequest))
-			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v2.ALRRequest))
+			if conf.GetEnv("ENABLE_ALR_ENDPOINTS") != "true" {
+				r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v2.ALRRequest))
+			}
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Group/{groupId}/$export", v2.BulkGroupRequest))
 			r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Get(m.WrapHandler(constants.JOBIDPath, v2.JobStatus))
 			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/jobs", v2.JobsStatus))

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -32,14 +32,20 @@ var version1ALRExportURL string = "/api/v1/alr/$export"
 
 type RouterTestSuite struct {
 	suite.Suite
-	apiRouter  http.Handler
-	dataRouter http.Handler
+	apiRouter        http.Handler
+	dataRouter       http.Handler
+	alrEnabledEnvVar string
 }
 
 func (s *RouterTestSuite) SetupTest() {
 	conf.SetEnv(s.T(), "DEBUG", "true")
+	s.alrEnabledEnvVar = conf.GetEnv("ENABLE_ALR_ENDPOINTS")
 	s.apiRouter = NewAPIRouter()
 	s.dataRouter = NewDataRouter()
+}
+
+func (s *RouterTestSuite) TearDownTest() {
+	conf.SetEnv(s.T(), "ENABLE_ALR_ENDPOINTS", s.alrEnabledEnvVar)
 }
 
 func (s *RouterTestSuite) getAPIRoute(route string) *http.Response {

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -40,6 +40,7 @@ type RouterTestSuite struct {
 func (s *RouterTestSuite) SetupTest() {
 	conf.SetEnv(s.T(), "DEBUG", "true")
 	s.alrEnabledEnvVar = conf.GetEnv("ENABLE_ALR_ENDPOINTS")
+	conf.SetEnv(s.T(), "ENABLE_ALR_ENDPOINTS", "true")
 	s.apiRouter = NewAPIRouter()
 	s.dataRouter = NewDataRouter()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       - HTTP_ONLY=true
       - BCDA_SSAS_CLIENT_ID=${BCDA_SSAS_CLIENT_ID}
       - BCDA_SSAS_SECRET=${BCDA_SSAS_SECRET}
+      - ENABLE_ALR_ENDPOINTS=false
       - SSAS_ADMIN_SIGNING_KEY_PATH=../shared_files/ssas/admin_test_signing_key.pem
       - SSAS_PUBLIC_SIGNING_KEY_PATH=../shared_files/ssas/public_test_signing_key.pem
       - SSAS_ADMIN_PORT=:3004


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-5355

## 🛠 Changes

- Disable ALR endpoints in deployed environments

## ℹ️ Context for reviewers

The ALR export endpoints were never completed and officially released, and they should be disabled to prevent confusion.

Since the default is false, I didn't add env vars for ENABLE_ALR_ENDPOINTS in our deployed environments. However, if folks feel we should have those, I can add that separately.

## ✅ Acceptance Validation

Verified locally:

```sh
bcda-app: curl -X GET 'http://localhost:3000/api/v2/alr/$export' \                                                                                                                  
                        -H "accept: application/fhir+json" \
                        -H "Prefer: respond-async" \
                        -H "Authorization: Bearer $token"
404 page not found

bcda-app: curl -X GET 'http://localhost:3000/api/v1/alr/$export' \
                        -H "accept: application/fhir+json" \ 
                        -H "Prefer: respond-async" \
                        -H "Authorization: Bearer $token"
404 page not found
```

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

