### PR TITLE
BCDA-7211: adding migration to update filename for paca test aco

### DIFF
--- a/db/migrations/manual/20230628-update-paca-cclf-filename.sql
+++ b/db/migrations/manual/20230628-update-paca-cclf-filename.sql
@@ -1,0 +1,8 @@
+-- This is a manual migration to update one of the two CCLF files in cclf_files for PACA ACO in Prod.
+-- Both files currently have the 'ZC8Y23' format and the CCLF8 file should have the 'ZC8R23' format for successful smoke test pipeline runs.
+
+
+-- update the CCLF8 to use R instead of Y in ZC8(R|Y)23
+BEGIN;
+UPDATE cclf_files SET name = 'T.BCD.TEST993.ZC8R23.D230427.T1057310' WHERE id = 33721;
+COMMIT;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7211

## 🛠 Changes

adding db update to change CCLF filename so smoketest "refresh" step applies to both CCLF filetypes.

## ℹ️ Context for reviewers

smoke test pipeline failing because of refresh step + paca cclf filename. 

## ✅ Acceptance Validation

ran migration with `rollback` to make sure syntax is correct.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
