### PR TITLE
BCDA-todo: Split opt out utilities into a separate module

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -111,27 +111,6 @@ type CCLFBeneficiary struct {
 	BlueButtonID string
 }
 
-type SuppressionFile struct {
-	ID           uint
-	Name         string
-	Timestamp    time.Time
-	ImportStatus string
-}
-
-type Suppression struct {
-	ID                  uint
-	FileID              uint
-	MBI                 string
-	SourceCode          string
-	EffectiveDt         time.Time
-	PrefIndicator       string
-	SAMHSASourceCode    string
-	SAMHSAEffectiveDt   time.Time
-	SAMHSAPrefIndicator string
-	ACOCMSID            string
-	BeneficiaryLinkKey  int
-}
-
 type JobEnqueueArgs struct {
 	ID              int
 	ACOID           string

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/log"
+	"github.com/CMSgov/bcda-app/optout"
 
 	"github.com/CMSgov/bcda-app/bcda/utils"
 
@@ -24,22 +23,13 @@ import (
 	"github.com/CMSgov/bcda-app/conf"
 )
 
-type suppressionFileMetadata struct {
-	name         string
-	timestamp    time.Time
-	filePath     string
-	imported     bool
-	deliveryDate time.Time
-	fileID       uint
-}
-
 const (
 	headerCode  = "HDR_BENEDATASHR"
 	trailerCode = "TRL_BENEDATASHR"
 )
 
 func ImportSuppressionDirectory(filePath string) (success, failure, skipped int, err error) {
-	var suppresslist []*suppressionFileMetadata
+	var suppresslist []*optout.SuppressionFileMetadata
 
 	err = filepath.Walk(filePath, getSuppressionFileMetadata(&suppresslist, &skipped))
 	if err != nil {
@@ -63,7 +53,7 @@ func ImportSuppressionDirectory(filePath string) (success, failure, skipped int,
 				log.API.Errorf("Failed to import suppression file: %s ", metadata)
 				failure++
 			} else {
-				metadata.imported = true
+				metadata.Imported = true
 				success++
 			}
 		}
@@ -82,7 +72,7 @@ func ImportSuppressionDirectory(filePath string) (success, failure, skipped int,
 	return success, failure, skipped, err
 }
 
-func getSuppressionFileMetadata(suppresslist *[]*suppressionFileMetadata, skipped *int) filepath.WalkFunc {
+func getSuppressionFileMetadata(suppresslist *[]*optout.SuppressionFileMetadata, skipped *int) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			var fileName = "nil"
@@ -99,19 +89,21 @@ func getSuppressionFileMetadata(suppresslist *[]*suppressionFileMetadata, skippe
 			return nil
 		}
 
-		metadata, err := parseMetadata(info.Name())
-		metadata.filePath = path
-		metadata.deliveryDate = info.ModTime()
+		metadata, err := optout.ParseMetadata(info.Name())
+		metadata.FilePath = path
+		metadata.DeliveryDate = info.ModTime()
 		if err != nil {
+			log.API.Error(err)
+
 			// skipping files with a bad name.  An unknown file in this dir isn't a blocker
 			fmt.Printf("Unknown file found: %s.\n", metadata)
 			log.API.Errorf("Unknown file found: %s", metadata)
 			*skipped = *skipped + 1
 
 			deleteThreshold := time.Hour * time.Duration(utils.GetEnvInt("BCDA_ETL_FILE_ARCHIVE_THRESHOLD_HR", 72))
-			if metadata.deliveryDate.Add(deleteThreshold).Before(time.Now()) {
+			if metadata.DeliveryDate.Add(deleteThreshold).Before(time.Now()) {
 				newpath := fmt.Sprintf("%s/%s", conf.GetEnv("PENDING_DELETION_DIR"), info.Name())
-				err = os.Rename(metadata.filePath, newpath)
+				err = os.Rename(metadata.FilePath, newpath)
 				if err != nil {
 					fmt.Printf("Error moving unknown file %s to pending deletion dir.\n", metadata)
 					err = fmt.Errorf("error moving unknown file %s to pending deletion dir", metadata)
@@ -126,39 +118,11 @@ func getSuppressionFileMetadata(suppresslist *[]*suppressionFileMetadata, skippe
 	}
 }
 
-func parseMetadata(filename string) (suppressionFileMetadata, error) {
-	var metadata suppressionFileMetadata
-	// Beneficiary Data Sharing Preferences File sent by 1-800-Medicare: P#EFT.ON.ACO.NGD1800.DPRF.Dyymmdd.Thhmmsst
-	// Prefix: T = test, P = prod;
-	filenameRegexp := regexp.MustCompile(`((P|T)\#EFT)\.ON\.ACO\.NGD1800\.DPRF\.(D\d{6}\.T\d{6})\d`)
-	filenameMatches := filenameRegexp.FindStringSubmatch(filename)
-	if len(filenameMatches) < 4 {
-		fmt.Printf("Invalid filename for file: %s.\n", filename)
-		err := fmt.Errorf("invalid filename for file: %s", filename)
-		log.API.Error(err)
-		return metadata, err
-	}
-
-	filenameDate := filenameMatches[3]
-	t, err := time.Parse("D060102.T150405", filenameDate)
-	if err != nil || t.IsZero() {
-		fmt.Printf("Failed to parse date '%s' from file: %s.\n", filenameDate, filename)
-		err = errors.Wrapf(err, "failed to parse date '%s' from file: %s", filenameDate, filename)
-		log.API.Error(err)
-		return metadata, err
-	}
-
-	metadata.timestamp = t
-	metadata.name = filenameMatches[0]
-
-	return metadata, nil
-}
-
-func validate(metadata *suppressionFileMetadata) error {
+func validate(metadata *optout.SuppressionFileMetadata) error {
 	fmt.Printf("Validating suppression file %s...\n", metadata)
 	log.API.Infof("Validating suppression file %s...", metadata)
 
-	f, err := os.Open(metadata.filePath)
+	f, err := os.Open(metadata.FilePath)
 	if err != nil {
 		fmt.Printf("Could not read file %s.\n", metadata)
 		err = errors.Wrapf(err, "could not read file %s", metadata)
@@ -180,8 +144,8 @@ func validate(metadata *suppressionFileMetadata) error {
 		if count == 0 {
 			if metaInfo != headerCode {
 				// invalid file header found
-				fmt.Printf("Invalid file header for file: %s.\n", metadata.filePath)
-				err := fmt.Errorf("invalid file header for file: %s", metadata.filePath)
+				fmt.Printf("Invalid file header for file: %s.\n", metadata.FilePath)
+				err := fmt.Errorf("invalid file header for file: %s", metadata.FilePath)
 				log.API.Error(err)
 				return err
 			}
@@ -195,16 +159,16 @@ func validate(metadata *suppressionFileMetadata) error {
 			// trailer info
 			expectedCount, err := strconv.Atoi(string(bytes.TrimSpace(b[recCountStart:recCountEnd])))
 			if err != nil {
-				fmt.Printf("Failed to parse record count from file: %s.\n", metadata.filePath)
-				err = fmt.Errorf("failed to parse record count from file: %s", metadata.filePath)
+				fmt.Printf("Failed to parse record count from file: %s.\n", metadata.FilePath)
+				err = fmt.Errorf("failed to parse record count from file: %s", metadata.FilePath)
 				log.API.Error(err)
 				return err
 			}
 			// subtract the single count from the header
 			count--
 			if count != expectedCount {
-				fmt.Printf("Incorrect number of records found from file: '%s'. Expected record count: %d, Actual record count: %d.\n", metadata.filePath, expectedCount, count)
-				err = fmt.Errorf("incorrect number of records found from file: '%s'. Expected record count: %d, Actual record count: %d", metadata.filePath, expectedCount, count)
+				fmt.Printf("Incorrect number of records found from file: '%s'. Expected record count: %d, Actual record count: %d.\n", metadata.FilePath, expectedCount, count)
+				err = fmt.Errorf("incorrect number of records found from file: '%s'. Expected record count: %d, Actual record count: %d", metadata.FilePath, expectedCount, count)
 				log.API.Error(err)
 				return err
 			}
@@ -215,58 +179,13 @@ func validate(metadata *suppressionFileMetadata) error {
 	return nil
 }
 
-func importSuppressionData(metadata *suppressionFileMetadata) error {
+func importSuppressionData(metadata *optout.SuppressionFileMetadata) error {
 	err := importSuppressionMetadata(metadata, func(fileID uint, b []byte, r models.Repository) error {
-		var (
-			mbiStart, mbiEnd                             = 0, 11
-			lKeyStart, lKeyEnd                           = 11, 21
-			effectiveDtStart, effectiveDtEnd             = 354, 362
-			sourceCdeStart, sourceCdeEnd                 = 362, 367
-			prefIndtorStart, prefIndtorEnd               = 368, 369
-			samhsaEffectiveDtStart, samhsaEffectiveDtEnd = 369, 377
-			samhsaSourceCdeStart, samhsaSourceCdeEnd     = 377, 382
-			samhsaPrefIndtorStart, samhsaPrefIndtorEnd   = 383, 384
-			acoIdStart, acoIdEnd                         = 384, 389
-		)
-		ds := string(bytes.TrimSpace(b[effectiveDtStart:effectiveDtEnd]))
-		dt, err := convertDt(ds)
-		if err != nil {
-			fmt.Printf("Failed to parse the effective date '%s' from file: %s.\n", ds, metadata.filePath)
-			err = errors.Wrapf(err, "failed to parse the effective date '%s' from file: %s", ds, metadata.filePath)
-			log.API.Error(err)
-			return err
-		}
-		ds = string(bytes.TrimSpace(b[samhsaEffectiveDtStart:samhsaEffectiveDtEnd]))
-		samhsaDt, err := convertDt(ds)
-		if err != nil {
-			fmt.Printf("Failed to parse the samhsa effective date '%s' from file: %s.\n", ds, metadata.filePath)
-			err = errors.Wrapf(err, "failed to parse the samhsa effective date '%s' from file: %s", ds, metadata.filePath)
-			log.API.Error(err)
-			return err
-		}
-		keyval := string(bytes.TrimSpace(b[lKeyStart:lKeyEnd]))
-		if keyval == "" {
-			keyval = "0"
-		}
-		lk, err := strconv.Atoi(keyval)
-		if err != nil {
-			fmt.Printf("Failed to parse beneficiary link key from file: %s.\n", metadata.filePath)
-			err = errors.Wrapf(err, "failed to parse beneficiary link key from file: %s", metadata.filePath)
-			log.API.Error(err)
-			return err
-		}
+		suppression, err := optout.ParseSuppressionLine(metadata, b)
 
-		suppression := models.Suppression{
-			FileID:              fileID,
-			MBI:                 string(bytes.TrimSpace(b[mbiStart:mbiEnd])),
-			SourceCode:          string(bytes.TrimSpace(b[sourceCdeStart:sourceCdeEnd])),
-			EffectiveDt:         dt,
-			PrefIndicator:       string(bytes.TrimSpace(b[prefIndtorStart:prefIndtorEnd])),
-			SAMHSASourceCode:    string(bytes.TrimSpace(b[samhsaSourceCdeStart:samhsaSourceCdeEnd])),
-			SAMHSAEffectiveDt:   samhsaDt,
-			SAMHSAPrefIndicator: string(bytes.TrimSpace(b[samhsaPrefIndtorStart:samhsaPrefIndtorEnd])),
-			BeneficiaryLinkKey:  lk,
-			ACOCMSID:            string(bytes.TrimSpace(b[acoIdStart:acoIdEnd])),
+		if err != nil {
+			log.API.Error(err)
+			return err
 		}
 
 		if err = r.CreateSuppression(context.Background(), suppression); err != nil {
@@ -279,14 +198,14 @@ func importSuppressionData(metadata *suppressionFileMetadata) error {
 	})
 
 	if err != nil {
-		updateImportStatus(metadata.fileID, constants.ImportFail)
+		updateImportStatus(metadata.FileID, optout.ImportFail)
 		return err
 	}
-	updateImportStatus(metadata.fileID, constants.ImportComplete)
+	updateImportStatus(metadata.FileID, optout.ImportComplete)
 	return nil
 }
 
-func importSuppressionMetadata(metadata *suppressionFileMetadata, importFunc func(uint, []byte, models.Repository) error) error {
+func importSuppressionMetadata(metadata *optout.SuppressionFileMetadata, importFunc func(uint, []byte, models.Repository) error) error {
 	fmt.Printf("Importing suppression file %s...\n", metadata)
 	log.API.Infof("Importing suppression file %s...", metadata)
 
@@ -295,10 +214,10 @@ func importSuppressionMetadata(metadata *suppressionFileMetadata, importFunc fun
 		err                          error
 	)
 
-	suppressionMetaFile := models.SuppressionFile{
-		Name:         metadata.name,
-		Timestamp:    metadata.timestamp,
-		ImportStatus: constants.ImportInprog,
+	suppressionMetaFile := optout.SuppressionFile{
+		Name:         metadata.Name,
+		Timestamp:    metadata.Timestamp,
+		ImportStatus: optout.ImportInprog,
 	}
 
 	db := database.Connection
@@ -312,11 +231,11 @@ func importSuppressionMetadata(metadata *suppressionFileMetadata, importFunc fun
 		return err
 	}
 
-	metadata.fileID = suppressionMetaFile.ID
+	metadata.FileID = suppressionMetaFile.ID
 
 	importStatusInterval := utils.GetEnvInt("SUPPRESS_IMPORT_STATUS_RECORDS_INTERVAL", 1000)
 	importedCount := 0
-	f, err := os.Open(metadata.filePath)
+	f, err := os.Open(metadata.FilePath)
 	if err != nil {
 		fmt.Printf("Could not read file %s.\n", metadata)
 		err = errors.Wrapf(err, "could not read file %s", metadata)
@@ -352,18 +271,18 @@ func importSuppressionMetadata(metadata *suppressionFileMetadata, importFunc fun
 	return nil
 }
 
-func cleanupSuppression(suppresslist []*suppressionFileMetadata) error {
+func cleanupSuppression(suppresslist []*optout.SuppressionFileMetadata) error {
 	errCount := 0
 	for _, suppressionFile := range suppresslist {
 		fmt.Printf("Cleaning up file %s.\n", suppressionFile)
 		log.API.Infof("Cleaning up file %s", suppressionFile)
-		newpath := fmt.Sprintf("%s/%s", conf.GetEnv("PENDING_DELETION_DIR"), suppressionFile.name)
-		if !suppressionFile.imported {
+		newpath := fmt.Sprintf("%s/%s", conf.GetEnv("PENDING_DELETION_DIR"), suppressionFile.Name)
+		if !suppressionFile.Imported {
 			// check the timestamp on the failed files
-			elapsed := time.Since(suppressionFile.deliveryDate).Hours()
+			elapsed := time.Since(suppressionFile.DeliveryDate).Hours()
 			deleteThreshold := utils.GetEnvInt("BCDA_ETL_FILE_ARCHIVE_THRESHOLD_HR", 72)
 			if int(elapsed) > deleteThreshold {
-				err := os.Rename(suppressionFile.filePath, newpath)
+				err := os.Rename(suppressionFile.FilePath, newpath)
 				if err != nil {
 					errCount++
 					errMsg := fmt.Sprintf("File %s failed to clean up properly: %v", suppressionFile, err)
@@ -376,7 +295,7 @@ func cleanupSuppression(suppresslist []*suppressionFileMetadata) error {
 			}
 		} else {
 			// move the successful files to the deletion dir
-			err := os.Rename(suppressionFile.filePath, newpath)
+			err := os.Rename(suppressionFile.FilePath, newpath)
 			if err != nil {
 				errCount++
 				errMsg := fmt.Sprintf("File %s failed to clean up properly: %v", suppressionFile, err)
@@ -392,24 +311,6 @@ func cleanupSuppression(suppresslist []*suppressionFileMetadata) error {
 		return fmt.Errorf("%d files could not be cleaned up", errCount)
 	}
 	return nil
-}
-
-func convertDt(s string) (time.Time, error) {
-	if s == "" {
-		return time.Time{}, nil
-	}
-	t, err := time.Parse("20060102", s)
-	if err != nil || t.IsZero() {
-		return t, err
-	}
-	return t, nil
-}
-
-func (m suppressionFileMetadata) String() string {
-	if m.filePath != "" {
-		return m.filePath
-	}
-	return m.name
 }
 
 func updateImportStatus(fileID uint, status string) {

--- a/optout/go.mod
+++ b/optout/go.mod
@@ -1,0 +1,5 @@
+module github.com/CMSgov/bcda-app/optout
+
+go 1.18
+
+require github.com/pkg/errors v0.9.1

--- a/optout/go.sum
+++ b/optout/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/optout/models.go
+++ b/optout/models.go
@@ -1,0 +1,44 @@
+package optout
+
+import "time"
+
+const ImportInprog = "In-Progress"
+const ImportComplete = "Completed"
+const ImportFail = "Failed"
+
+type SuppressionFile struct {
+	ID           uint
+	Name         string
+	Timestamp    time.Time
+	ImportStatus string
+}
+
+type SuppressionFileMetadata struct {
+	Name         string
+	Timestamp    time.Time
+	FilePath     string
+	Imported     bool
+	DeliveryDate time.Time
+	FileID       uint
+}
+
+func (m SuppressionFileMetadata) String() string {
+	if m.FilePath != "" {
+		return m.FilePath
+	}
+	return m.Name
+}
+
+type Suppression struct {
+	ID                  uint
+	FileID              uint
+	MBI                 string
+	SourceCode          string
+	EffectiveDt         time.Time
+	PrefIndicator       string
+	SAMHSASourceCode    string
+	SAMHSAEffectiveDt   time.Time
+	SAMHSAPrefIndicator string
+	ACOCMSID            string
+	BeneficiaryLinkKey  int
+}

--- a/optout/utils.go
+++ b/optout/utils.go
@@ -1,0 +1,99 @@
+package optout
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	mbiStart, mbiEnd                             = 0, 11
+	lKeyStart, lKeyEnd                           = 11, 21
+	effectiveDtStart, effectiveDtEnd             = 354, 362
+	sourceCdeStart, sourceCdeEnd                 = 362, 367
+	prefIndtorStart, prefIndtorEnd               = 368, 369
+	samhsaEffectiveDtStart, samhsaEffectiveDtEnd = 369, 377
+	samhsaSourceCdeStart, samhsaSourceCdeEnd     = 377, 382
+	samhsaPrefIndtorStart, samhsaPrefIndtorEnd   = 383, 384
+	acoIdStart, acoIdEnd                         = 384, 389
+)
+
+func ParseMetadata(filename string) (SuppressionFileMetadata, error) {
+	var metadata SuppressionFileMetadata
+	// Beneficiary Data Sharing Preferences File sent by 1-800-Medicare: P#EFT.ON.ACO.NGD1800.DPRF.Dyymmdd.Thhmmsst
+	// Prefix: T = test, P = prod;
+	filenameRegexp := regexp.MustCompile(`((P|T)\#EFT)\.ON\.ACO\.NGD1800\.DPRF\.(D\d{6}\.T\d{6})\d`)
+	filenameMatches := filenameRegexp.FindStringSubmatch(filename)
+	if len(filenameMatches) < 4 {
+		fmt.Printf("Invalid filename for file: %s.\n", filename)
+		err := fmt.Errorf("invalid filename for file: %s", filename)
+		return metadata, err
+	}
+
+	filenameDate := filenameMatches[3]
+	t, err := time.Parse("D060102.T150405", filenameDate)
+	if err != nil || t.IsZero() {
+		fmt.Printf("Failed to parse date '%s' from file: %s.\n", filenameDate, filename)
+		err = errors.Wrapf(err, "failed to parse date '%s' from file: %s", filenameDate, filename)
+		return metadata, err
+	}
+
+	metadata.Timestamp = t
+	metadata.Name = filenameMatches[0]
+
+	return metadata, nil
+}
+
+func ParseSuppressionLine(metadata *SuppressionFileMetadata, b []byte) (*Suppression, error) {
+	ds := string(bytes.TrimSpace(b[effectiveDtStart:effectiveDtEnd]))
+	dt, err := ConvertDt(ds)
+	if err != nil {
+		fmt.Printf("Failed to parse the effective date '%s' from file: %s.\n", ds, metadata.FilePath)
+		err = errors.Wrapf(err, "failed to parse the effective date '%s' from file: %s", ds, metadata.FilePath)
+		return nil, err
+	}
+	ds = string(bytes.TrimSpace(b[samhsaEffectiveDtStart:samhsaEffectiveDtEnd]))
+	samhsaDt, err := ConvertDt(ds)
+	if err != nil {
+		fmt.Printf("Failed to parse the samhsa effective date '%s' from file: %s.\n", ds, metadata.FilePath)
+		err = errors.Wrapf(err, "failed to parse the samhsa effective date '%s' from file: %s", ds, metadata.FilePath)
+		return nil, err
+	}
+	keyval := string(bytes.TrimSpace(b[lKeyStart:lKeyEnd]))
+	if keyval == "" {
+		keyval = "0"
+	}
+	lk, err := strconv.Atoi(keyval)
+	if err != nil {
+		fmt.Printf("Failed to parse beneficiary link key from file: %s.\n", metadata.FilePath)
+		err = errors.Wrapf(err, "failed to parse beneficiary link key from file: %s", metadata.FilePath)
+		return nil, err
+	}
+
+	return &Suppression{
+		MBI:                 string(bytes.TrimSpace(b[mbiStart:mbiEnd])),
+		SourceCode:          string(bytes.TrimSpace(b[sourceCdeStart:sourceCdeEnd])),
+		EffectiveDt:         dt,
+		PrefIndicator:       string(bytes.TrimSpace(b[prefIndtorStart:prefIndtorEnd])),
+		SAMHSASourceCode:    string(bytes.TrimSpace(b[samhsaSourceCdeStart:samhsaSourceCdeEnd])),
+		SAMHSAEffectiveDt:   samhsaDt,
+		SAMHSAPrefIndicator: string(bytes.TrimSpace(b[samhsaPrefIndtorStart:samhsaPrefIndtorEnd])),
+		BeneficiaryLinkKey:  lk,
+		ACOCMSID:            string(bytes.TrimSpace(b[acoIdStart:acoIdEnd])),
+	}, nil
+}
+
+func ConvertDt(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse("20060102", s)
+	if err != nil || t.IsZero() {
+		return t, err
+	}
+	return t, nil
+}

--- a/optout/utils_test.go
+++ b/optout/utils_test.go
@@ -1,0 +1,52 @@
+package optout
+
+import (
+	"time"
+
+	"github.com/CMSgov/bcda-app/bcda/testUtils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type OptOutTestSuite struct {
+	suite.Suite
+	basePath string
+	cleanup  func()
+}
+
+func (s *OptOutTestSuite) SetupTest() {
+	s.basePath, s.cleanup = testUtils.CopyToTemporaryDirectory(s.T(), "../shared_files/")
+}
+
+func (s *OptOutTestSuite) TestParseMetadata() {
+	assert := assert.New(s.T())
+
+	// positive
+	expTime, _ := time.Parse(time.RFC3339, "2018-11-20T20:13:01Z")
+	metadata, err := ParseMetadata("blah/T#EFT.ON.ACO.NGD1800.DPRF.D181120.T2013010")
+	assert.Equal("T#EFT.ON.ACO.NGD1800.DPRF.D181120.T2013010", metadata.Name)
+	assert.Equal(expTime.Format("010203040506"), metadata.Timestamp.Format("010203040506"))
+	assert.Nil(err)
+
+	// change the name and timestamp
+	expTime, _ = time.Parse(time.RFC3339, "2019-12-20T21:09:42Z")
+	metadata, err = ParseMetadata("blah/T#EFT.ON.ACO.NGD1800.DPRF.D191220.T2109420")
+	assert.Equal("T#EFT.ON.ACO.NGD1800.DPRF.D191220.T2109420", metadata.Name)
+	assert.Equal(expTime.Format("010203040506"), metadata.Timestamp.Format("010203040506"))
+	assert.Nil(err)
+}
+
+func (s *OptOutTestSuite) TestParseMetadata_InvalidFilename() {
+	assert := assert.New(s.T())
+
+	// invalid file name
+	_, err := ParseMetadata("/path/to/file")
+	assert.EqualError(err, "invalid filename for file: /path/to/file")
+
+	_, err = ParseMetadata("/path/T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000010")
+	assert.EqualError(err, "invalid filename for file: /path/T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000010")
+
+	// invalid date
+	_, err = ParseMetadata("/path/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420")
+	assert.EqualError(err, "failed to parse date 'D190117.T990942' from file: /path/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420: parsing time \"D190117.T990942\": hour out of range")
+}

--- a/optout/utils_test.go
+++ b/optout/utils_test.go
@@ -2,24 +2,15 @@ package optout
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/constants"
-	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
 type OptOutTestSuite struct {
 	suite.Suite
-	basePath string
-	cleanup  func()
-}
-
-func (s *OptOutTestSuite) SetupTest() {
-	s.basePath, s.cleanup = testUtils.CopyToTemporaryDirectory(s.T(), "../shared_files/")
 }
 
 func (s *OptOutTestSuite) TestParseMetadata() {
@@ -63,8 +54,8 @@ func (s *OptOutTestSuite) TestParseSuppressionLine_Success() {
 	line := []byte("5SJ0A00AA001847800005John                          Mitchell                      Doe                                     198203218702 E Fake St.                                        Apt. 63L                                               Region                                                 Las Vegas                               NV423139954M20190618201907011-800TY201907011-800TNT9992WeCare Medical                                                        ")
 	metadata := &SuppressionFileMetadata{
 		Timestamp:    fileTime,
-		FilePath:     filepath.Join(s.basePath, "synthetic1800MedicareFiles/test/T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000009"),
-		Name:         constants.TestSuppressMetaFileName,
+		FilePath:     "full-fake-filename",
+		Name:         "fake-filename",
 		DeliveryDate: time.Now(),
 	}
 

--- a/optout/utils_test.go
+++ b/optout/utils_test.go
@@ -1,8 +1,12 @@
 package optout
 
 import (
+	"fmt"
+	"path/filepath"
+	"testing"
 	"time"
 
+	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -36,7 +40,7 @@ func (s *OptOutTestSuite) TestParseMetadata() {
 	assert.Nil(err)
 }
 
-func (s *OptOutTestSuite) TestParseMetadata_InvalidFilename() {
+func (s *OptOutTestSuite) TestParseMetadata_InvalidData() {
 	assert := assert.New(s.T())
 
 	// invalid file name
@@ -49,4 +53,56 @@ func (s *OptOutTestSuite) TestParseMetadata_InvalidFilename() {
 	// invalid date
 	_, err = ParseMetadata("/path/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420")
 	assert.EqualError(err, "failed to parse date 'D190117.T990942' from file: /path/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420: parsing time \"D190117.T990942\": hour out of range")
+}
+
+func (s *OptOutTestSuite) TestParseSuppressionLine_Success() {
+	assert := assert.New(s.T())
+
+	// 181120 file
+	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
+	line := []byte("5SJ0A00AA001847800005John                          Mitchell                      Doe                                     198203218702 E Fake St.                                        Apt. 63L                                               Region                                                 Las Vegas                               NV423139954M20190618201907011-800TY201907011-800TNT9992WeCare Medical                                                        ")
+	metadata := &SuppressionFileMetadata{
+		Timestamp:    fileTime,
+		FilePath:     filepath.Join(s.basePath, "synthetic1800MedicareFiles/test/T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000009"),
+		Name:         constants.TestSuppressMetaFileName,
+		DeliveryDate: time.Now(),
+	}
+
+	suppression, err := ParseSuppressionLine(metadata, line)
+	assert.Nil(err)
+	assert.Equal("5SJ0A00AA00", suppression.MBI)
+	assert.Equal("1-800", suppression.SourceCode)
+}
+
+func (s *OptOutTestSuite) TestParseSuppressionLine_InvalidData() {
+	assert := assert.New(s.T())
+	fp := "testfilepath"
+
+	tests := []struct {
+		line   string
+		expErr string
+	}{
+		{
+			"1000087481 1847800005John                          Mitchell                      Doe                                     198203218702 E Fake St.                                        Apt. 63L                                               Region                                                 Las Vegas                               NV423139954M20190618201913011-800TY201907011-800TNA9999WeCare Medical                                                        		",
+			"failed to parse the effective date '20191301' from file"},
+		{"1000087481 1847800005John                          Mitchell                      Doe                                     198203218702 E Fake St.                                        Apt. 63L                                               Region                                                 Las Vegas                               NV423139954M20190618201907011-800TY201913011-800TNA9999WeCare Medical                                                        		",
+			"failed to parse the samhsa effective date '20191301' from file"},
+		{"1000087481 18e7800005John                          Mitchell                      Doe                                     198203218702 E Fake St.                                        Apt. 63L                                               Region                                                 Las Vegas                               NV423139954M20190618201907011-800TY201907011-800TNA9999WeCare Medical                                                        		",
+			"failed to parse beneficiary link key from file"},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.line, func(t *testing.T) {
+			metadata := &SuppressionFileMetadata{
+				Timestamp:    time.Now(),
+				FilePath:     fp,
+				Name:         tt.line,
+				DeliveryDate: time.Now(),
+			}
+			suppression, err := ParseSuppressionLine(metadata, []byte(tt.line))
+			assert.Nil(suppression)
+			assert.NotNil(err)
+			assert.Contains(err.Error(), fmt.Sprintf("%s: %s", tt.expErr, fp))
+		})
+	}
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-todo

## 🛠 Changes

Create a new Golang module for optout code that can be imported separate from BCDA code. This includes:
  - All related models (SuppressionFile, Suppression, SuppressionFileMetadata)
  - Utility function for parsing metadata from filenames
  - Utility function for parsing a single line from an opt out file

## ℹ️ Context for reviewers

AB2D and DPC are currently in the process of automating data-sharing opt-out requests. It is expected that the file formats will be consistent with the existing files that BCDA receives, so a lot of the existing Go code is reusable.

DPC is likely going to follow the pre-established pattern of building lambdas in Go, so we expect that BCDA's code could be directly used as part of the lambda. This PR pulls out generic utilities that are not related to BCDA's implementation in any way (e.g. reading from the local filesystem or saving to the BCDA database.)

## ✅ Acceptance Validation

- Unit tests continue to pass
- Was able to create a new local go program and import these utilities using `go get github.com/CMSgov/bcda-app/output@7603537d5966b1d4734e1956b5d47b9c54a3f39b`.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
