### PR TITLE
Add opensbx postman collection for website/customer testing.

### DIFF
--- a/test/postman_test/OPENSBX_BCDA_API.postman_collection.json
+++ b/test/postman_test/OPENSBX_BCDA_API.postman_collection.json
@@ -1,0 +1,455 @@
+{
+	"info": {
+		"_postman_id": "822c9ece-c7f0-4241-b5cf-83247225a0b2",
+		"name": "BCDA Service",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "26533169"
+	},
+	"item": [
+		{
+			"name": "v1",
+			"item": [
+				{
+					"name": "/Group",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/fhir+json",
+								"type": "text"
+							},
+							{
+								"key": "Prefer",
+								"value": "respond-async",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v1/Group/all/$export",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v1",
+								"Group",
+								"all",
+								"$export"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Patient",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/fhir+json",
+								"type": "text"
+							},
+							{
+								"key": "Prefer",
+								"value": "respond-async",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v1/Patient/$export",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v1",
+								"Patient",
+								"$export"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Metadata",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v1/metadata",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v1",
+								"metadata"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Jobs",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v1/jobs/{{jobId}}",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v1",
+								"jobs",
+								"{{jobId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Attribution_Status Copy",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v1/attribution_status",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v1",
+								"attribution_status"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "v2",
+			"item": [
+				{
+					"name": "/Group",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/fhir+json",
+								"type": "text"
+							},
+							{
+								"key": "Prefer",
+								"value": "respond-async",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v2/Group/all/$export",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v2",
+								"Group",
+								"all",
+								"$export"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Patient",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/fhir+json",
+								"type": "text"
+							},
+							{
+								"key": "Prefer",
+								"value": "respond-async",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v2/Patient/$export",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v2",
+								"Patient",
+								"$export"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Metadata",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v2/metadata",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v2",
+								"metadata"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Jobs",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v2/jobs/{{jobId}}",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v2",
+								"jobs",
+								"{{jobId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/Attribution_Status",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://sandbox.bcda.cms.gov/api/v2/attribution_status",
+							"protocol": "https",
+							"host": [
+								"sandbox",
+								"bcda",
+								"cms",
+								"gov"
+							],
+							"path": [
+								"api",
+								"v2",
+								"attribution_status"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Get Token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{clientSecret}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{clientId}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Prefer",
+						"value": "respond-async",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/fhir+json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "https://sandbox.bcda.cms.gov/auth/token",
+					"protocol": "https",
+					"host": [
+						"sandbox",
+						"bcda",
+						"cms",
+						"gov"
+					],
+					"path": [
+						"auth",
+						"token"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-xxx

## 🛠 Changes

added a postman collection that contains BCDA API endpoints and basic setup for customers to test/try.

## ℹ️ Context for reviewers

BCDA doesn't have a postman collection available to try on the website.

## ✅ Acceptance Validation

built/tested in postman.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
