### PR TITLE
BCDA-7354: Support multiple BB client certificates

### DIFF
--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -202,6 +202,18 @@ func (s *BBTestSuite) TestNewBlueButtonClientInvalidCAFile() {
 	assert.EqualError(err, "could not append CA certificate(s)")
 }
 
+func (s *BBTestSuite) TestNewBlueButtonClientMultipleCaFiles() {
+	origCertFile := conf.GetEnv("BB_CLIENT_CA_FILE")
+	defer conf.SetEnv(s.T(), "BB_CLIENT_CA_FILE", origCertFile)
+
+	assert := assert.New(s.T())
+
+	conf.SetEnv(s.T(), "BB_CLIENT_CA_FILE", "../../shared_files/localhost.crt,../../shared_files/localhost.crt")
+	bbc, err := client.NewBlueButtonClient(client.NewConfig(""))
+	assert.NotNil(bbc)
+	assert.Nil(err)
+}
+
 func (s *BBTestSuite) TestGetDefaultParams() {
 	params := client.GetDefaultParams()
 	assert.Equal(s.T(), "application/fhir+json", params.Get("_format"))


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7354

## 🛠 Changes

- Update application to support reading multiple files from `BB_CLIENT_CA_FILE`

## ℹ️ Context for reviewers

BCDA uses mutual TLS to connect to BFD, which means that 

1. we are providing a client certificate to BFD upon connection to verify our identity
2. we are verifying BFD's certificate/identity using a Certificate Authority (CA) file

BFD is renewing their server-side TLS certificates so we need to update our CA pool to support both the old and new certificates. After BFD cuts over to the new certificate, we will be able to remove the old certificate from our trusted store.

Our application currently only supports one CA certificate, so these application changes allow us to parse and include multiple certificates in the trusted certificate pool.

## ✅ Acceptance Validation

The dev environment is connected to prod-sbx. I have pushed up the environment variable changes from https://github.com/CMSgov/bcda-ops/pull/972 and observed successful smoke tests after deploying this branch to dev.

https://management.bcda.cms.gov/job/BCDA%20-%20Test%20-%20Integration%20Smoke/4924/

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

