### PR TITLE
BCDA-7135: bcda api logging improvements

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -530,8 +530,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	}
 
 	if newJob.ID != 0 {
-		ctx = logging.SetCtxLogger(ctx, "job_id", newJob.ID)
-		logger = logging.GetCtxLogger(ctx)
+		ctx, logger = logging.SetCtxLogger(ctx, "job_id", newJob.ID)
 	}
 
 	// request a fake patient in order to acquire the bundle's lastUpdated metadata

--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -160,7 +160,7 @@ func (h *Handler) JobsStatus(w http.ResponseWriter, r *http.Request) {
 		statusTypes []models.JobStatus
 		err         error
 	)
-	logger := logging.GetLogEntry(r.Context())
+	logger := logging.GetCtxLogger(r.Context())
 	statusTypes = models.AllJobStatuses // default request to retrieve jobs with all statuses
 	params, ok := r.URL.Query()["_status"]
 	if ok {
@@ -223,7 +223,7 @@ func (h *Handler) validateStatuses(statusTypes []models.JobStatus) error {
 }
 
 func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
-	logger := logging.GetLogEntry(r.Context())
+	logger := logging.GetCtxLogger(r.Context())
 	jobIDStr := chi.URLParam(r, "jobID")
 
 	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
@@ -320,7 +320,7 @@ func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
-	logger := logging.GetLogEntry(r.Context())
+	logger := logging.GetCtxLogger(r.Context())
 	jobIDStr := chi.URLParam(r, "jobID")
 
 	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
@@ -405,7 +405,7 @@ func (h *Handler) AttributionStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) getAttributionFileStatus(ctx context.Context, CMSID string, fileType models.CCLFFileType) (*AttributionFileStatus, error) {
-	logger := logging.GetLogEntry(ctx)
+	logger := logging.GetCtxLogger(ctx)
 	cclfFile, err := h.Svc.GetLatestCCLFFile(ctx, CMSID, fileType)
 	if err != nil {
 		logger.Error(err)
@@ -434,7 +434,7 @@ func (h *Handler) getAttributionFileStatus(ctx context.Context, CMSID string, fi
 func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType service.RequestType) {
 	// Create context to encapsulate the entire workflow. In the future, we can define child context's for timing.
 	ctx := r.Context()
-	logger := logging.GetLogEntry(r.Context())
+	logger := logging.GetCtxLogger(r.Context())
 
 	var (
 		ad  auth.AuthData
@@ -530,8 +530,8 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	}
 
 	if newJob.ID != 0 {
-		logging.LogEntrySetField(ctx, "job_id", newJob.ID)
-		logger = logging.GetLogEntry(r.Context())
+		ctx = logging.SetCtxLogger(ctx, "job_id", newJob.ID)
+		logger = logging.GetCtxLogger(ctx)
 	}
 
 	// request a fake patient in order to acquire the bundle's lastUpdated metadata

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -140,7 +140,7 @@ func (s *RequestsTestSuite) TestRunoutEnabled() {
 
 			req := s.genGroupRequest("runout", middleware.RequestParameters{})
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 			w := httptest.NewRecorder()
 			h.BulkGroupRequest(w, req)
 
@@ -223,7 +223,7 @@ func (s *RequestsTestSuite) TestJobsStatusV1() {
 			rr := httptest.NewRecorder()
 			req := s.genGetJobsRequest(apiVersionOne, tt.statuses)
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 			h.JobsStatus(rr, req)
 
 			unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.STU3)
@@ -317,7 +317,7 @@ func (s *RequestsTestSuite) TestJobsStatusV2() {
 			rr := httptest.NewRecorder()
 			req := s.genGetJobsRequest(apiVersionTwo, tt.statuses)
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 			h.JobsStatus(rr, req)
 
 			unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.R4)
@@ -539,7 +539,7 @@ func (s *RequestsTestSuite) TestDataTypeAuthorization() {
 			}))
 
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": test.cmsId, "request_id": uuid.NewRandom().String()})
-			r = r.WithContext(context.WithValue(r.Context(), logging.CommonLogCtxKey, newLogEntry))
+			r = r.WithContext(context.WithValue(r.Context(), logging.CtxLoggerKey, newLogEntry))
 
 			r = r.WithContext(middleware.NewRequestParametersContext(r.Context(), middleware.RequestParameters{
 				Since:         time.Date(2000, 01, 01, 00, 00, 00, 00, time.UTC),
@@ -653,7 +653,7 @@ func (s *RequestsTestSuite) TestJobStatus() {
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	req = req.WithContext(ctx)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry))
 	w := httptest.NewRecorder()
 	h.JobStatus(w, req)
 	s.Equal(http.StatusOK, w.Code)
@@ -710,10 +710,9 @@ func (s *RequestsTestSuite) TestJobFailedStatus() {
 			rctx.URLParams.Add("jobID", "1")
 
 			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-
 			req = req.WithContext(ctx)
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry))
 
 			w := httptest.NewRecorder()
 			h.JobStatus(w, req)
@@ -764,7 +763,7 @@ func (s *RequestsTestSuite) genGroupRequest(groupID string, rp middleware.Reques
 	ctx = context.WithValue(ctx, auth.AuthDataContextKey, ad)
 	ctx = middleware.NewRequestParametersContext(ctx, rp)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	ctx = context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry)
+	ctx = context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry)
 	req = req.WithContext(ctx)
 
 	return req
@@ -777,7 +776,7 @@ func (s *RequestsTestSuite) genPatientRequest(rp middleware.RequestParameters) *
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
 	ctx = middleware.NewRequestParametersContext(ctx, rp)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	ctx = context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry)
+	ctx = context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry)
 	return req.WithContext(ctx)
 }
 
@@ -787,7 +786,7 @@ func (s *RequestsTestSuite) genASRequest() *http.Request {
 	ad := auth.AuthData{ACOID: s.acoID.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	ctx = context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry)
+	ctx = context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry)
 	return req.WithContext(ctx)
 }
 

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -15,12 +15,14 @@ import (
 	"time"
 
 	"github.com/go-testfixtures/testfixtures/v3"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database/databasetest"
+	logging "github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -137,6 +139,8 @@ func (s *RequestsTestSuite) TestRunoutEnabled() {
 			h.Svc = mockSvc
 
 			req := s.genGroupRequest("runout", middleware.RequestParameters{})
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 			w := httptest.NewRecorder()
 			h.BulkGroupRequest(w, req)
 
@@ -218,6 +222,8 @@ func (s *RequestsTestSuite) TestJobsStatusV1() {
 
 			rr := httptest.NewRecorder()
 			req := s.genGetJobsRequest(apiVersionOne, tt.statuses)
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 			h.JobsStatus(rr, req)
 
 			unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.STU3)
@@ -310,6 +316,8 @@ func (s *RequestsTestSuite) TestJobsStatusV2() {
 
 			rr := httptest.NewRecorder()
 			req := s.genGetJobsRequest(apiVersionTwo, tt.statuses)
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 			h.JobsStatus(rr, req)
 
 			unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.R4)
@@ -530,6 +538,9 @@ func (s *RequestsTestSuite) TestDataTypeAuthorization() {
 				CMSID: test.cmsId,
 			}))
 
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": test.cmsId, "request_id": uuid.NewRandom().String()})
+			r = r.WithContext(context.WithValue(r.Context(), logging.CommonLogCtxKey, newLogEntry))
+
 			r = r.WithContext(middleware.NewRequestParametersContext(r.Context(), middleware.RequestParameters{
 				Since:         time.Date(2000, 01, 01, 00, 00, 00, 00, time.UTC),
 				ResourceTypes: test.resources,
@@ -641,7 +652,8 @@ func (s *RequestsTestSuite) TestJobStatus() {
 
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	req = req.WithContext(ctx)
-
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry))
 	w := httptest.NewRecorder()
 	h.JobStatus(w, req)
 	s.Equal(http.StatusOK, w.Code)
@@ -698,7 +710,10 @@ func (s *RequestsTestSuite) TestJobFailedStatus() {
 			rctx.URLParams.Add("jobID", "1")
 
 			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+
 			req = req.WithContext(ctx)
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry))
 
 			w := httptest.NewRecorder()
 			h.JobStatus(w, req)
@@ -748,7 +763,8 @@ func (s *RequestsTestSuite) genGroupRequest(groupID string, rp middleware.Reques
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	ctx = context.WithValue(ctx, auth.AuthDataContextKey, ad)
 	ctx = middleware.NewRequestParametersContext(ctx, rp)
-
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	ctx = context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry)
 	req = req.WithContext(ctx)
 
 	return req
@@ -758,10 +774,10 @@ func (s *RequestsTestSuite) genPatientRequest(rp middleware.RequestParameters) *
 	req := httptest.NewRequest("GET", "http://bcda.cms.gov/api/v1/Patient/$export", nil)
 	aco := postgrestest.GetACOByUUID(s.T(), s.db, s.acoID)
 	ad := auth.AuthData{ACOID: s.acoID.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
-
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
 	ctx = middleware.NewRequestParametersContext(ctx, rp)
-
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	ctx = context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry)
 	return req.WithContext(ctx)
 }
 
@@ -769,9 +785,9 @@ func (s *RequestsTestSuite) genASRequest() *http.Request {
 	req := httptest.NewRequest("GET", "http://bcda.cms.gov/api/v1/attribution_status", nil)
 	aco := postgrestest.GetACOByUUID(s.T(), s.db, s.acoID)
 	ad := auth.AuthData{ACOID: s.acoID.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
-
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
-
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	ctx = context.WithValue(ctx, logging.CommonLogCtxKey, newLogEntry)
 	return req.WithContext(ctx)
 }
 
@@ -794,4 +810,10 @@ func (s *RequestsTestSuite) genGetJobsRequest(version string, statuses []models.
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
 
 	return req.WithContext(ctx)
+}
+
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *logging.StructuredLoggerEntry {
+	var lggr logrus.Logger
+	newLogEntry := &logging.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	return newLogEntry
 }

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -97,7 +97,7 @@ func (s *APITestSuite) TestJobStatusBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -301,7 +301,7 @@ func (s *APITestSuite) TestDeleteJobBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -453,7 +453,7 @@ func (s *APITestSuite) TestJobsStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -473,7 +473,7 @@ func (s *APITestSuite) TestJobsStatusNotFound() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	JobsStatus(rr, req)
@@ -485,7 +485,7 @@ func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -505,7 +505,7 @@ func (s *APITestSuite) TestJobsStatusWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -525,7 +525,7 @@ func (s *APITestSuite) TestJobsStatusWithStatuses() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -553,7 +553,7 @@ func (s *APITestSuite) TestGetAttributionStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	AttributionStatus(rr, req)
@@ -581,7 +581,7 @@ func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http
 	rctx.URLParams.Add("jobID", fmt.Sprint(jobID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	ad := s.makeContextValues(acoID)
 	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 }

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -21,6 +21,7 @@ import (
 	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/stu3/codes_go_proto"
 	fhirmodels "github.com/google/fhir/go/proto/google/fhir/proto/stu3/resources_go_proto"
 	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -94,6 +96,8 @@ func (s *APITestSuite) TestJobStatusBadInputs() {
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -296,6 +300,8 @@ func (s *APITestSuite) TestDeleteJobBadInputs() {
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -446,6 +452,8 @@ func (s *APITestSuite) TestJobsStatus() {
 	req := httptest.NewRequest("GET", "/api/v1/jobs", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -464,6 +472,8 @@ func (s *APITestSuite) TestJobsStatusNotFound() {
 	req := httptest.NewRequest("GET", "/api/v1/jobs", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	JobsStatus(rr, req)
@@ -474,6 +484,8 @@ func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
 	req := httptest.NewRequest("GET", "/api/v1/jobs?_status=Failed", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -492,6 +504,8 @@ func (s *APITestSuite) TestJobsStatusWithStatus() {
 	req := httptest.NewRequest("GET", "/api/v1/jobs?_status=Failed", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -510,6 +524,8 @@ func (s *APITestSuite) TestJobsStatusWithStatuses() {
 	req := httptest.NewRequest("GET", "/api/v1/jobs?_status=Completed,Failed", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -536,6 +552,8 @@ func (s *APITestSuite) TestGetAttributionStatus() {
 	req := httptest.NewRequest("GET", "/api/v1/attribution_status", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	AttributionStatus(rr, req)
@@ -562,6 +580,8 @@ func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("jobID", fmt.Sprint(jobID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	ad := s.makeContextValues(acoID)
 	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 }
@@ -588,4 +608,10 @@ func getOperationOutcome(t *testing.T, data []byte) *fhirmodels.OperationOutcome
 	container, err := unmarshaller.Unmarshal(data)
 	assert.NoError(t, err)
 	return container.(*fhirmodels.ContainedResource).GetOperationOutcome()
+}
+
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *logging.StructuredLoggerEntry {
+	var lggr logrus.Logger
+	newLogEntry := &logging.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	return newLogEntry
 }

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -27,6 +28,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcdaworker/queueing"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
+	"github.com/sirupsen/logrus"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/fhir/go/fhirversion"
@@ -108,6 +110,8 @@ func (s *APITestSuite) TestJobStatusBadInputs() {
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -299,6 +303,8 @@ func (s *APITestSuite) TestJobsStatus() {
 	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -317,6 +323,8 @@ func (s *APITestSuite) TestJobsStatusNotFound() {
 	req := httptest.NewRequest("GET", "/api/v2/jobs", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	JobsStatus(rr, req)
@@ -327,6 +335,8 @@ func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
 	req := httptest.NewRequest("GET", "/api/v2/jobs?_status=Failed", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -345,6 +355,8 @@ func (s *APITestSuite) TestJobsStatusWithStatus() {
 	req := httptest.NewRequest("GET", "/api/v2/jobs?_status=Failed", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -363,6 +375,8 @@ func (s *APITestSuite) TestJobsStatusWithStatuses() {
 	req := httptest.NewRequest("GET", "/api/v2/jobs?_status=Completed,Failed", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -398,7 +412,8 @@ func (s *APITestSuite) TestDeleteJobBadInputs() {
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
-
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 			JobStatus(rr, req)
 
 			respOO := getOperationOutcome(t, rr.Body.Bytes())
@@ -437,6 +452,9 @@ func (s *APITestSuite) TestDeleteJob() {
 
 			req := s.createJobStatusRequest(acoUnderTest, j.ID)
 			rr := httptest.NewRecorder()
+
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 
 			DeleteJob(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
@@ -562,6 +580,8 @@ func (s *APITestSuite) TestResourceTypes() {
 				ad := s.getAuthData()
 				req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 				req = req.WithContext(middleware.NewRequestParametersContext(req.Context(), rp))
+				newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+				req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 
 				handler(rr, req)
 				assert.Equal(t, tt.statusCode, rr.Code)
@@ -578,6 +598,8 @@ func (s *APITestSuite) TestGetAttributionStatus() {
 	req := httptest.NewRequest("GET", "/api/v2/attribution_status", nil)
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	AttributionStatus(rr, req)
@@ -610,6 +632,8 @@ func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http
 	rctx.URLParams.Add("jobID", fmt.Sprint(jobID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	ad := s.makeContextValues(acoID)
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
 	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 }
 
@@ -631,4 +655,10 @@ func getOperationOutcome(t *testing.T, data []byte) *fhiroo.OperationOutcome {
 	container, err := unmarshaller.Unmarshal(data)
 	assert.NoError(t, err)
 	return container.(*fhirresources.ContainedResource).GetOperationOutcome()
+}
+
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *logging.StructuredLoggerEntry {
+	var lggr logrus.Logger
+	newLogEntry := &logging.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	return newLogEntry
 }

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -111,7 +111,7 @@ func (s *APITestSuite) TestJobStatusBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -304,7 +304,7 @@ func (s *APITestSuite) TestJobsStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -324,7 +324,7 @@ func (s *APITestSuite) TestJobsStatusNotFound() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	JobsStatus(rr, req)
@@ -336,7 +336,7 @@ func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -356,7 +356,7 @@ func (s *APITestSuite) TestJobsStatusWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -376,7 +376,7 @@ func (s *APITestSuite) TestJobsStatusWithStatuses() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -413,7 +413,7 @@ func (s *APITestSuite) TestDeleteJobBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 			JobStatus(rr, req)
 
 			respOO := getOperationOutcome(t, rr.Body.Bytes())
@@ -454,7 +454,7 @@ func (s *APITestSuite) TestDeleteJob() {
 			rr := httptest.NewRecorder()
 
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 
 			DeleteJob(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
@@ -581,7 +581,7 @@ func (s *APITestSuite) TestResourceTypes() {
 				req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 				req = req.WithContext(middleware.NewRequestParametersContext(req.Context(), rp))
 				newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-				req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+				req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 
 				handler(rr, req)
 				assert.Equal(t, tt.statusCode, rr.Code)
@@ -599,7 +599,7 @@ func (s *APITestSuite) TestGetAttributionStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	AttributionStatus(rr, req)
@@ -633,7 +633,7 @@ func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	ad := s.makeContextValues(acoID)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CommonLogCtxKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
 	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 }
 

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -165,15 +165,15 @@ func GetCtxLogger(ctx context.Context) logrus.FieldLogger {
 }
 
 // Appends additional or creates new logrus.Fields to a logrus.FieldLogger within a context
-func SetCtxLogger(ctx context.Context, key string, value interface{}) context.Context {
+func SetCtxLogger(ctx context.Context, key string, value interface{}) (context.Context, logrus.FieldLogger) {
 	if entry, ok := ctx.Value(CtxLoggerKey).(*StructuredLoggerEntry); ok {
 		entry.Logger = entry.Logger.WithField(key, value)
 		nCtx := context.WithValue(ctx, CtxLoggerKey, entry)
-		return nCtx
+		return nCtx, entry.Logger
 	}
 
 	var lggr logrus.Logger
 	newLogEntry := &StructuredLoggerEntry{Logger: lggr.WithField(key, value)}
 	nCtx := context.WithValue(ctx, CtxLoggerKey, newLogEntry)
-	return nCtx
+	return nCtx, newLogEntry.Logger
 }

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -138,9 +138,9 @@ func Redact(uri string) string {
 	return uri
 }
 
-type commonLogCtxKeyType string
+type CommonLogCtxKeyType string
 
-const commonLogCtxKey commonLogCtxKeyType = "commonLog"
+const CommonLogCtxKey CommonLogCtxKeyType = "commonLog"
 
 func NewCommonLogFields(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -149,15 +149,14 @@ func NewCommonLogFields(next http.Handler) http.Handler {
 		if ad, ok := r.Context().Value(auth.AuthDataContextKey).(auth.AuthData); ok {
 			logFields["cms_id"] = ad.CMSID
 		}
-		r = r.WithContext(context.WithValue(r.Context(), commonLogCtxKey, logFields))
+		r = r.WithContext(context.WithValue(r.Context(), CommonLogCtxKey, logFields))
 		next.ServeHTTP(w, r)
 	})
 }
 
 func GetLogFields(ctx context.Context) logrus.Fields {
-	logFields, ok := ctx.Value(commonLogCtxKey).(logrus.Fields)
+	logFields, ok := ctx.Value(CommonLogCtxKey).(logrus.Fields)
 	if !ok {
-		// Log this issue
 		return logrus.Fields{}
 	}
 	return logFields

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -240,3 +240,24 @@ func TestResourceTypeLogging(t *testing.T) {
 		}
 	}
 }
+
+func TestMiddlewareLogCtx(t *testing.T) {
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		val := r.Context().Value(logging.CommonLogCtxKey).(logrus.Fields)
+		if val == nil {
+			t.Error("no log context")
+		}
+		if val["cms_id"] == nil {
+			t.Error("no cms_id value")
+		}
+		if val["request_id"] == nil {
+			t.Error("no request_id value")
+		}
+	})
+
+	handlerToTest := contextToken(middleware.RequestID(logging.NewCommonLogFields(nextHandler)))
+	req := httptest.NewRequest("GET", "http://testing", nil)
+	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
+
+}

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -244,24 +244,24 @@ func TestResourceTypeLogging(t *testing.T) {
 func TestMiddlewareLogCtx(t *testing.T) {
 
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		val := r.Context().Value(logging.CommonLogCtxKey).(*logging.StructuredLoggerEntry)
+		val := r.Context().Value(logging.CtxLoggerKey).(*logging.StructuredLoggerEntry)
 		if val == nil {
 			t.Error("no log context")
 		}
 
 	})
 
-	handlerToTest := contextToken(middleware.RequestID(logging.NewCommonLogFields(nextHandler)))
+	handlerToTest := contextToken(middleware.RequestID(logging.NewCtxLogger(nextHandler)))
 	req := httptest.NewRequest("GET", "http://testing", nil)
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
 
 }
 
-func TestLogEntrySetField(t *testing.T) {
+func TestSetCtxLogger(t *testing.T) {
 	ctx := context.Background()
-	ctx = logging.LogEntrySetField(ctx, "request_id", "123456")
-	ctx = logging.LogEntrySetField(ctx, "cms_id", "A0000")
-	ctxEntryAppend := ctx.Value(logging.CommonLogCtxKey).(*logging.StructuredLoggerEntry)
+	ctx = logging.SetCtxLogger(ctx, "request_id", "123456")
+	ctx = logging.SetCtxLogger(ctx, "cms_id", "A0000")
+	ctxEntryAppend := ctx.Value(logging.CtxLoggerKey).(*logging.StructuredLoggerEntry)
 	entry := ctxEntryAppend.Logger.WithField("test", "entry")
 
 	if cmsId, ok := entry.Data["cms_id"]; ok {

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -263,13 +263,19 @@ func TestLogEntrySetField(t *testing.T) {
 	ctx = logging.LogEntrySetField(ctx, "cms_id", "A0000")
 	ctxEntryAppend := ctx.Value(logging.CommonLogCtxKey).(*logging.StructuredLoggerEntry)
 	entry := ctxEntryAppend.Logger.WithField("test", "entry")
-	if entry == nil {
-		t.Errorf("entry should not be nil")
+
+	if cmsId, ok := entry.Data["cms_id"]; ok {
+		if cmsId != "A0000" {
+			t.Errorf("unexpected value for cms_id")
+		}
+	} else {
+		t.Errorf("key cms_id does not exist")
 	}
-	if entry.Data["cms_id"] != "A0000" {
-		t.Errorf("unexpected value for cms_id")
-	}
-	if entry.Data["request_id"] != "123456" {
-		t.Errorf("unexpected value for request_id")
+	if reqId, ok := entry.Data["request_id"]; ok {
+		if reqId != "123456" {
+			t.Errorf("unexpected value for request_id")
+		}
+	} else {
+		t.Errorf("key request_id does not exist")
 	}
 }

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -259,8 +259,8 @@ func TestMiddlewareLogCtx(t *testing.T) {
 
 func TestSetCtxLogger(t *testing.T) {
 	ctx := context.Background()
-	ctx = logging.SetCtxLogger(ctx, "request_id", "123456")
-	ctx = logging.SetCtxLogger(ctx, "cms_id", "A0000")
+	ctx, _ = logging.SetCtxLogger(ctx, "request_id", "123456")
+	ctx, _ = logging.SetCtxLogger(ctx, "cms_id", "A0000")
 	ctxEntryAppend := ctx.Value(logging.CtxLoggerKey).(*logging.StructuredLoggerEntry)
 	entry := ctxEntryAppend.Logger.WithField("test", "entry")
 

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -30,7 +30,7 @@ var commonAuth = []func(http.Handler) http.Handler{
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCommonLogFields)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui/v1"))
@@ -88,7 +88,7 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	return auth.NewAuthRouter(gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCommonLogFields)
+	return auth.NewAuthRouter(gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 }
 
 func NewDataRouter() http.Handler {
@@ -97,7 +97,7 @@ func NewDataRouter() http.Handler {
 	resourceTypeLogger := &logging.ResourceTypeLogger{
 		Repository: postgres.NewRepository(database.Connection),
 	}
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCommonLogFields)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 	r.With(append(
 		commonAuth,
 		auth.RequireTokenJobMatch,
@@ -109,7 +109,7 @@ func NewDataRouter() http.Handler {
 func NewHTTPRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.NewCommonLogFields)
+	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.NewCtxLogger)
 	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		url := "https://" + req.Host + req.URL.String()
 		http.Redirect(w, req, url, http.StatusMovedPermanently)

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -30,7 +30,7 @@ var commonAuth = []func(http.Handler) http.Handler{
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCommonLogFields)
 
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui/v1"))
@@ -88,7 +88,7 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	return auth.NewAuthRouter(gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose)
+	return auth.NewAuthRouter(gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCommonLogFields)
 }
 
 func NewDataRouter() http.Handler {
@@ -97,7 +97,7 @@ func NewDataRouter() http.Handler {
 	resourceTypeLogger := &logging.ResourceTypeLogger{
 		Repository: postgres.NewRepository(database.Connection),
 	}
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCommonLogFields)
 	r.With(append(
 		commonAuth,
 		auth.RequireTokenJobMatch,
@@ -109,7 +109,7 @@ func NewDataRouter() http.Handler {
 func NewHTTPRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(gcmw.RequestID, middleware.ConnectionClose)
+	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.NewCommonLogFields)
 	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		url := "https://" + req.Host + req.URL.String()
 		http.Redirect(w, req, url, http.StatusMovedPermanently)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7135

## 🛠 Changes

- added new middleware in logging.go that adds request ID and the cms ID to the context for next handler
- updated requests.go logging statements to utilize logger that is passed via context

## ℹ️ Context for reviewers

Updating the request processing to add a logger to the context via middleware. Request ID and CMS ID can be used in future logging calls and new fields can be added to the requests context logger as needed.

Looked into database logging to possibility be included in this PR, but database is using the default `logrus.logger`. Creating a separate ticket to address that. 

## ✅ Acceptance Validation

Current tests pass, new test added, and ran locally to check logs & context values.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
