### PR TITLE
BCDA-7135: bcdaworker logging improvements

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -23,7 +23,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
-	logging "github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	responseutils "github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -160,7 +159,7 @@ func (h *Handler) JobsStatus(w http.ResponseWriter, r *http.Request) {
 		statusTypes []models.JobStatus
 		err         error
 	)
-	logger := logging.GetCtxLogger(r.Context())
+	logger := log.GetCtxLogger(r.Context())
 	statusTypes = models.AllJobStatuses // default request to retrieve jobs with all statuses
 	params, ok := r.URL.Query()["_status"]
 	if ok {
@@ -223,7 +222,7 @@ func (h *Handler) validateStatuses(statusTypes []models.JobStatus) error {
 }
 
 func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
-	logger := logging.GetCtxLogger(r.Context())
+	logger := log.GetCtxLogger(r.Context())
 	jobIDStr := chi.URLParam(r, "jobID")
 
 	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
@@ -320,7 +319,7 @@ func (h *Handler) JobStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
-	logger := logging.GetCtxLogger(r.Context())
+	logger := log.GetCtxLogger(r.Context())
 	jobIDStr := chi.URLParam(r, "jobID")
 
 	jobID, err := strconv.ParseUint(jobIDStr, 10, 64)
@@ -405,7 +404,7 @@ func (h *Handler) AttributionStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) getAttributionFileStatus(ctx context.Context, CMSID string, fileType models.CCLFFileType) (*AttributionFileStatus, error) {
-	logger := logging.GetCtxLogger(ctx)
+	logger := log.GetCtxLogger(ctx)
 	cclfFile, err := h.Svc.GetLatestCCLFFile(ctx, CMSID, fileType)
 	if err != nil {
 		logger.Error(err)
@@ -434,7 +433,7 @@ func (h *Handler) getAttributionFileStatus(ctx context.Context, CMSID string, fi
 func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType service.RequestType) {
 	// Create context to encapsulate the entire workflow. In the future, we can define child context's for timing.
 	ctx := r.Context()
-	logger := logging.GetCtxLogger(r.Context())
+	logger := log.GetCtxLogger(r.Context())
 
 	var (
 		ad  auth.AuthData
@@ -530,7 +529,8 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 	}
 
 	if newJob.ID != 0 {
-		ctx, logger = logging.SetCtxLogger(ctx, "job_id", newJob.ID)
+		ctx, logger = log.SetCtxLogger(ctx, "job_id", newJob.ID)
+		logger.Info("job id created")
 	}
 
 	// request a fake patient in order to acquire the bundle's lastUpdated metadata

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database/databasetest"
-	logging "github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -140,7 +139,7 @@ func (s *RequestsTestSuite) TestRunoutEnabled() {
 
 			req := s.genGroupRequest("runout", middleware.RequestParameters{})
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 			w := httptest.NewRecorder()
 			h.BulkGroupRequest(w, req)
 
@@ -223,7 +222,7 @@ func (s *RequestsTestSuite) TestJobsStatusV1() {
 			rr := httptest.NewRecorder()
 			req := s.genGetJobsRequest(apiVersionOne, tt.statuses)
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 			h.JobsStatus(rr, req)
 
 			unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.STU3)
@@ -317,7 +316,7 @@ func (s *RequestsTestSuite) TestJobsStatusV2() {
 			rr := httptest.NewRecorder()
 			req := s.genGetJobsRequest(apiVersionTwo, tt.statuses)
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 			h.JobsStatus(rr, req)
 
 			unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.R4)
@@ -539,7 +538,7 @@ func (s *RequestsTestSuite) TestDataTypeAuthorization() {
 			}))
 
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": test.cmsId, "request_id": uuid.NewRandom().String()})
-			r = r.WithContext(context.WithValue(r.Context(), logging.CtxLoggerKey, newLogEntry))
+			r = r.WithContext(context.WithValue(r.Context(), log.CtxLoggerKey, newLogEntry))
 
 			r = r.WithContext(middleware.NewRequestParametersContext(r.Context(), middleware.RequestParameters{
 				Since:         time.Date(2000, 01, 01, 00, 00, 00, 00, time.UTC),
@@ -653,7 +652,7 @@ func (s *RequestsTestSuite) TestJobStatus() {
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	req = req.WithContext(ctx)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(ctx, log.CtxLoggerKey, newLogEntry))
 	w := httptest.NewRecorder()
 	h.JobStatus(w, req)
 	s.Equal(http.StatusOK, w.Code)
@@ -712,7 +711,7 @@ func (s *RequestsTestSuite) TestJobFailedStatus() {
 			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 			req = req.WithContext(ctx)
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(ctx, log.CtxLoggerKey, newLogEntry))
 
 			w := httptest.NewRecorder()
 			h.JobStatus(w, req)
@@ -763,7 +762,7 @@ func (s *RequestsTestSuite) genGroupRequest(groupID string, rp middleware.Reques
 	ctx = context.WithValue(ctx, auth.AuthDataContextKey, ad)
 	ctx = middleware.NewRequestParametersContext(ctx, rp)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	ctx = context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry)
+	ctx = context.WithValue(ctx, log.CtxLoggerKey, newLogEntry)
 	req = req.WithContext(ctx)
 
 	return req
@@ -776,7 +775,7 @@ func (s *RequestsTestSuite) genPatientRequest(rp middleware.RequestParameters) *
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
 	ctx = middleware.NewRequestParametersContext(ctx, rp)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	ctx = context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry)
+	ctx = context.WithValue(ctx, log.CtxLoggerKey, newLogEntry)
 	return req.WithContext(ctx)
 }
 
@@ -786,7 +785,7 @@ func (s *RequestsTestSuite) genASRequest() *http.Request {
 	ad := auth.AuthData{ACOID: s.acoID.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
 	ctx := context.WithValue(req.Context(), auth.AuthDataContextKey, ad)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	ctx = context.WithValue(ctx, logging.CtxLoggerKey, newLogEntry)
+	ctx = context.WithValue(ctx, log.CtxLoggerKey, newLogEntry)
 	return req.WithContext(ctx)
 }
 
@@ -811,8 +810,8 @@ func (s *RequestsTestSuite) genGetJobsRequest(version string, statuses []models.
 	return req.WithContext(ctx)
 }
 
-func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *logging.StructuredLoggerEntry {
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *log.StructuredLoggerEntry {
 	var lggr logrus.Logger
-	newLogEntry := &logging.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	newLogEntry := &log.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
 	return newLogEntry
 }

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
 	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
 )
 
 const (
@@ -97,7 +97,7 @@ func (s *APITestSuite) TestJobStatusBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -301,7 +301,7 @@ func (s *APITestSuite) TestDeleteJobBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -453,7 +453,7 @@ func (s *APITestSuite) TestJobsStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -473,7 +473,7 @@ func (s *APITestSuite) TestJobsStatusNotFound() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	JobsStatus(rr, req)
@@ -485,7 +485,7 @@ func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -505,7 +505,7 @@ func (s *APITestSuite) TestJobsStatusWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -525,7 +525,7 @@ func (s *APITestSuite) TestJobsStatusWithStatuses() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -553,7 +553,7 @@ func (s *APITestSuite) TestGetAttributionStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	AttributionStatus(rr, req)
@@ -581,7 +581,7 @@ func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http
 	rctx.URLParams.Add("jobID", fmt.Sprint(jobID))
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	ad := s.makeContextValues(acoID)
 	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 }
@@ -610,8 +610,8 @@ func getOperationOutcome(t *testing.T, data []byte) *fhirmodels.OperationOutcome
 	return container.(*fhirmodels.ContainedResource).GetOperationOutcome()
 }
 
-func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *logging.StructuredLoggerEntry {
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *log.StructuredLoggerEntry {
 	var lggr logrus.Logger
-	newLogEntry := &logging.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	newLogEntry := &log.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
 	return newLogEntry
 }

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -111,7 +110,7 @@ func (s *APITestSuite) TestJobStatusBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 
 			JobStatus(rr, req)
 
@@ -304,7 +303,7 @@ func (s *APITestSuite) TestJobsStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -324,7 +323,7 @@ func (s *APITestSuite) TestJobsStatusNotFound() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	JobsStatus(rr, req)
@@ -336,7 +335,7 @@ func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -356,7 +355,7 @@ func (s *APITestSuite) TestJobsStatusWithStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -376,7 +375,7 @@ func (s *APITestSuite) TestJobsStatusWithStatuses() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	j := models.Job{
@@ -413,7 +412,7 @@ func (s *APITestSuite) TestDeleteJobBadInputs() {
 			ad := s.makeContextValues(acoUnderTest)
 			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 			JobStatus(rr, req)
 
 			respOO := getOperationOutcome(t, rr.Body.Bytes())
@@ -454,7 +453,7 @@ func (s *APITestSuite) TestDeleteJob() {
 			rr := httptest.NewRecorder()
 
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-			req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 
 			DeleteJob(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
@@ -581,7 +580,7 @@ func (s *APITestSuite) TestResourceTypes() {
 				req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 				req = req.WithContext(middleware.NewRequestParametersContext(req.Context(), rp))
 				newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-				req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+				req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 
 				handler(rr, req)
 				assert.Equal(t, tt.statusCode, rr.Code)
@@ -599,7 +598,7 @@ func (s *APITestSuite) TestGetAttributionStatus() {
 	ad := s.makeContextValues(acoUnderTest)
 	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	rr := httptest.NewRecorder()
 
 	AttributionStatus(rr, req)
@@ -633,7 +632,7 @@ func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	ad := s.makeContextValues(acoID)
 	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
-	req = req.WithContext(context.WithValue(req.Context(), logging.CtxLoggerKey, newLogEntry))
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
 	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
 }
 
@@ -657,8 +656,8 @@ func getOperationOutcome(t *testing.T, data []byte) *fhiroo.OperationOutcome {
 	return container.(*fhirresources.ContainedResource).GetOperationOutcome()
 }
 
-func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *logging.StructuredLoggerEntry {
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *log.StructuredLoggerEntry {
 	var lggr logrus.Logger
-	newLogEntry := &logging.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	newLogEntry := &log.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
 	return newLogEntry
 }

--- a/bcda/cclf/metrics/metrics.go
+++ b/bcda/cclf/metrics/metrics.go
@@ -14,17 +14,18 @@ import (
 
 // Timer provides methods for timing methods.
 // Typical Usage scenario:
-//		timer := metrics.GetTimer()
-//		defer timer.Close()
-//		ctx := metrics.NewContext(ctx, timer)
-// 		ctx, close := metrics.NewParent(ctx)
-// 		defer close()
-// 		close1 := metrics.NewChild(ctx, "Ingest #1")
-// 		// Perform Ingest #1 call
-// 		close1()
-// 		close2 := metrics.NewChild(ctx, "Ingest #2")
-// 		// Perform Ingest #2 call
-// 		close2()
+//
+//	timer := metrics.GetTimer()
+//	defer timer.Close()
+//	ctx := metrics.NewContext(ctx, timer)
+//	ctx, close := metrics.NewParent(ctx)
+//	defer close()
+//	close1 := metrics.NewChild(ctx, "Ingest #1")
+//	// Perform Ingest #1 call
+//	close1()
+//	close2 := metrics.NewChild(ctx, "Ingest #2")
+//	// Perform Ingest #2 call
+//	close2()
 type Timer interface {
 	// new creates a new timer and embeds it into the returned context.
 	// To start timing methods, caller should start with this call
@@ -146,7 +147,7 @@ type noopTimer struct {
 }
 
 func (t *noopTimer) new(parentCtx context.Context, name string) (ctx context.Context, close func()) {
-	return context.Background(), noop
+	return parentCtx, noop
 }
 
 func (t *noopTimer) newChild(parentCtx context.Context, name string) (close func()) {

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -30,7 +30,7 @@ type StructuredLogger struct {
 }
 
 func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
-	entry := &StructuredLoggerEntry{Logger: l.Logger}
+	entry := &log.StructuredLoggerEntry{Logger: l.Logger}
 	logFields := logrus.Fields{}
 
 	logFields["ts"] = time.Now().UTC().Format(time.RFC1123)
@@ -71,22 +71,6 @@ type StructuredLoggerEntry struct {
 	Logger logrus.FieldLogger
 }
 
-func (l *StructuredLoggerEntry) Write(status int, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"resp_status": status, "resp_bytes_length": bytes,
-		"resp_elapsed_ms": float64(elapsed.Nanoseconds()) / 1000000.0,
-	})
-
-	l.Logger.Infoln("request complete")
-}
-
-func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"stack": string(stack),
-		"panic": fmt.Sprintf("%+v", v),
-	})
-}
-
 type ResourceTypeLogger struct {
 	Repository models.JobKeyRepository
 }
@@ -101,7 +85,7 @@ func (rl *ResourceTypeLogger) LogJobResourceType(next http.Handler) http.Handler
 			return
 		}
 		// Note: could split this out into a function for adding to the context log
-		entry, ok := middleware.GetLogEntry(r).(*StructuredLoggerEntry)
+		entry, ok := middleware.GetLogEntry(r).(*log.StructuredLoggerEntry)
 		if !ok {
 			log.API.Error("Incorrect type of logger used in request context")
 			return
@@ -138,12 +122,6 @@ func Redact(uri string) string {
 	return uri
 }
 
-// type to create context.Contest key
-type CtxLoggerKeyType string
-
-// context.Context key to set/get logrus.FieldLogger value within request context
-const CtxLoggerKey CtxLoggerKeyType = "ctxLogger"
-
 // NewCtxLogger adds new key value pair of {CtxLoggerKey: logrus.FieldLogger} to the requests context
 func NewCtxLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -152,28 +130,8 @@ func NewCtxLogger(next http.Handler) http.Handler {
 		if ad, ok := r.Context().Value(auth.AuthDataContextKey).(auth.AuthData); ok {
 			logFields["cms_id"] = ad.CMSID
 		}
-		newLogEntry := &StructuredLoggerEntry{Logger: log.API.WithFields(logFields)}
-		r = r.WithContext(context.WithValue(r.Context(), CtxLoggerKey, newLogEntry))
+		newLogEntry := &log.StructuredLoggerEntry{Logger: log.API.WithFields(logFields)}
+		r = r.WithContext(context.WithValue(r.Context(), log.CtxLoggerKey, newLogEntry))
 		next.ServeHTTP(w, r)
 	})
-}
-
-// Gets the logrus.FieldLogger from a context
-func GetCtxLogger(ctx context.Context) logrus.FieldLogger {
-	entry := ctx.Value(CtxLoggerKey).(*StructuredLoggerEntry)
-	return entry.Logger
-}
-
-// Appends additional or creates new logrus.Fields to a logrus.FieldLogger within a context
-func SetCtxLogger(ctx context.Context, key string, value interface{}) (context.Context, logrus.FieldLogger) {
-	if entry, ok := ctx.Value(CtxLoggerKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithField(key, value)
-		nCtx := context.WithValue(ctx, CtxLoggerKey, entry)
-		return nCtx, entry.Logger
-	}
-
-	var lggr logrus.Logger
-	newLogEntry := &StructuredLoggerEntry{Logger: lggr.WithField(key, value)}
-	nCtx := context.WithValue(ctx, CtxLoggerKey, newLogEntry)
-	return nCtx, newLogEntry.Logger
 }

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -183,7 +183,7 @@ func TestLoggingMiddlewareTestSuite(t *testing.T) {
 
 type mockLogger struct {
 	Logger logrus.FieldLogger
-	entry  *logging.StructuredLoggerEntry
+	entry  *log.StructuredLoggerEntry
 }
 
 func (l *mockLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
@@ -219,7 +219,7 @@ func TestResourceTypeLogging(t *testing.T) {
 			repository.On("GetJobKey", testUtils.CtxMatcher, mock.MatchedBy(func(i interface{}) bool { return true }), constants.TestBlobFileName).Return(nil, errors.New("expected error"))
 		}
 
-		entry := &logging.StructuredLoggerEntry{Logger: log.Request}
+		entry := &log.StructuredLoggerEntry{Logger: log.Request}
 
 		logger := logging.ResourceTypeLogger{
 			Repository: repository,
@@ -244,7 +244,7 @@ func TestResourceTypeLogging(t *testing.T) {
 func TestMiddlewareLogCtx(t *testing.T) {
 
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		val := r.Context().Value(logging.CtxLoggerKey).(*logging.StructuredLoggerEntry)
+		val := r.Context().Value(log.CtxLoggerKey).(*log.StructuredLoggerEntry)
 		if val == nil {
 			t.Error("no log context")
 		}
@@ -259,9 +259,9 @@ func TestMiddlewareLogCtx(t *testing.T) {
 
 func TestSetCtxLogger(t *testing.T) {
 	ctx := context.Background()
-	ctx, _ = logging.SetCtxLogger(ctx, "request_id", "123456")
-	ctx, _ = logging.SetCtxLogger(ctx, "cms_id", "A0000")
-	ctxEntryAppend := ctx.Value(logging.CtxLoggerKey).(*logging.StructuredLoggerEntry)
+	ctx, _ = log.SetCtxLogger(ctx, "request_id", "123456")
+	ctx, _ = log.SetCtxLogger(ctx, "cms_id", "A0000")
+	ctxEntryAppend := ctx.Value(log.CtxLoggerKey).(*log.StructuredLoggerEntry)
 	entry := ctxEntryAppend.Logger.WithField("test", "entry")
 
 	if cmsId, ok := entry.Data["cms_id"]; ok {

--- a/bcdaworker/queueing/manager/que.go
+++ b/bcdaworker/queueing/manager/que.go
@@ -15,6 +15,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcdaworker/repository/postgres"
 	"github.com/CMSgov/bcda-app/bcdaworker/worker"
 	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
 	"github.com/bgentry/que-go"
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
@@ -113,37 +114,43 @@ func (q *queue) processJob(job *que.Job) error {
 		return nil
 	}
 
+	ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
+	ctx, logger := log.SetCtxLogger(ctx, "job_id", jobArgs.ID)
+
 	exportJob, err := q.worker.ValidateJob(ctx, jobArgs)
 	if goerrors.Is(err, worker.ErrParentJobCancelled) {
 		// ACK the job because we do not need to work on queue jobs associated with a cancelled parent job
-		q.log.Warnf("queJob %d associated with a cancelled parent Job %d. Removing queuejob from que.", job.ID, jobArgs.ID)
+		logger.Warnf("Removing queuejob from que; parent job %d cancelled.", jobArgs.ID)
 		return nil
 	} else if goerrors.Is(err, worker.ErrNoBasePathSet) {
 		// Data is corrupted, we cannot work on this job.
-		q.log.Warnf("Job %d does not contain valid base path. Removing queuejob from que.", jobArgs.ID)
+		logger.Warnf("Job does not contain valid base path; removing queuejob from que.")
 		return nil
 	} else if goerrors.Is(err, worker.ErrParentJobNotFound) {
 		// Based on the current backoff delay (j.ErrorCount^4 + 3 seconds), this should've given
 		// us plenty of headroom to ensure that the parent job will never be found.
 		maxNotFoundRetries := int32(utils.GetEnvInt("BCDA_WORKER_MAX_JOB_NOT_FOUND_RETRIES", 3))
 		if job.ErrorCount >= maxNotFoundRetries {
-			q.log.Errorf("No job found for ID: %d acoID: %s. Retries exhausted. Removing job from queue.", jobArgs.ID,
-				jobArgs.ACOID)
+			logger.Errorf("No job found. Retries exhausted. Removing job from queue.")
 			// By returning a nil error response, we're singaling to que-go to remove this job from the jobqueue.
 			return nil
 		}
 
-		q.log.Warnf("No job found for ID: %d acoID: %s. Will retry.", jobArgs.ID, jobArgs.ACOID)
+		logger.Warnf("No job found, retrying")
 		return errors.Wrap(repository.ErrJobNotFound, "could not retrieve job from database")
 	} else if err != nil {
-		return errors.Wrap(err, "failed to validate job")
+		err := errors.Wrap(err, "failed to validate job")
+		logger.Error(err)
+		return err
 	}
 
 	// start a goroutine that will periodically check the status of the parent job
 	go checkIfCancelled(ctx, q.repository, cancel, uint(jobArgs.ID), 15)
 
 	if err := q.worker.ProcessJob(ctx, *exportJob, jobArgs); err != nil {
-		return errors.Wrap(err, "failed to process job")
+		err := errors.Wrap(err, "failed to process job")
+		logger.Error(err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
…worker uses ctx to pass logger

## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7135

## 🛠 Changes

- The bcda worker.go and que.go will utilize context to create and pass around log fields.
- ields cmsID and jobID have been renamed to cms_id and job_id to for consistency and querying
- log strings have been modified so that field values are in their own individual fields instead of the free text msg field
- common logging components have been moved to log/logger.go and import names updated
- add a single `logger.info()` in `requests.go/bulkrequest()` so that job ID and request ID can be correlated

## ℹ️ Context for reviewers

The BCDA worker does not use the initial request context when processing jobs. It does use the Job ID, which is a common identifier that we can use to query events on. When we use the request_id in splunk we can view related events for the job and use the job ID to query events further. This requires the addition of one informational log event when the job ID is created.

The que.go file has been modified so that when we create our context for the job processing, it uses it to pass around log fields to other function calls. This has eliminated the need to declare the fields repeatedly when we use WithFields({...}) and removed redundant or unnecessary log calls.

## ✅ Acceptance Validation

Tests updated and passing, tested app running locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
