### PR TITLE
BCDA-7126 BCDA: Improve coverage for "bcda/suppression/suppression.go"

### DIFF
--- a/bcda/constants/test_constants.go
+++ b/bcda/constants/test_constants.go
@@ -35,6 +35,7 @@ const TestSynthMedFilesPath = "synthetic1800MedicareFiles/test/"
 const TestFakePath = "/src/github.com/CMSgov/bcda-app/conf/FAKE"
 const TestConfPath = "/src/github.com/CMSgov/bcda-app/conf/test"
 const TestSuppressBadPath = "T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000009"
+const TestSuppressBadDeletePath = "T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420"
 const JobsFilePath = "jobs/1"
 const AuthTokenPath = "/auth/token"  // #nosec - G101 credentials for unit testing
 const TokenPath = "/token"           // #nosec - G101 credentials for unit testing

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -213,7 +213,6 @@ func importSuppressionMetadata(metadata *optout.OptOutFilenameMetadata, importFu
 		headTrailStart, headTrailEnd = 0, 15
 		err                          error
 	)
-
 	suppressionMetaFile := optout.OptOutFile{
 		Name:         metadata.Name,
 		Timestamp:    metadata.Timestamp,

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -345,41 +345,11 @@ func (s *SuppressionTestSuite) TestCleanupSuppression() {
 	}
 }
 
-func (s *SuppressionTestSuite) TestCleanupSuppression_Bad() {
+func (s *SuppressionTestSuite) TestCleanupSuppression_RenameFileError() {
 	assert := assert.New(s.T())
 	var suppresslist []*optout.OptOutFilenameMetadata
 
-	//new use cases
-	conf.SetEnv(s.T(), "PENDING_DELETION_DIR", "\n")
-	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
-	metadata1 := &optout.OptOutFilenameMetadata{
-		Name:         constants.TestSuppressBadPath,
-		Timestamp:    fileTime,
-		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000009"),
-		Imported:     false,
-		DeliveryDate: fileTime,
-	}
-
-	//
-	metadata2 := &optout.OptOutFilenameMetadata{
-		Name:         "T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420",
-		Timestamp:    fileTime,
-		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420"),
-		Imported:     true,
-		DeliveryDate: time.Now(),
-	}
-
-	suppresslist = []*optout.OptOutFilenameMetadata{metadata1, metadata2}
-	err := cleanupSuppression(suppresslist)
-	assert.EqualError(err, "2 files could not be cleaned up")
-
-}
-
-func (s *SuppressionTestSuite) TestCleanupSuppression_Bad2() {
-	assert := assert.New(s.T())
-	var suppresslist []*optout.OptOutFilenameMetadata
-
-	//new use cases
+	//Induce an error when attempting to rename file
 	conf.SetEnv(s.T(), "PENDING_DELETION_DIR", "\n")
 	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
 	metadata1 := &optout.OptOutFilenameMetadata{

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -2,9 +2,9 @@ package suppression
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,12 +30,13 @@ type SuppressionTestSuite struct {
 }
 
 func (s *SuppressionTestSuite) SetupSuite() {
-	dir, err := ioutil.TempDir("", "*")
+	dir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		log.Fatal(err)
 	}
 	s.pendingDeletionDir = dir
 	testUtils.SetPendingDeletionDir(s.Suite, dir)
+
 }
 
 func (s *SuppressionTestSuite) SetupTest() {
@@ -70,7 +71,7 @@ func (s *SuppressionTestSuite) TestImportSuppression() {
 
 	suppressionFile := postgrestest.GetSuppressionFileByName(s.T(), db, metadata.Name)[0]
 	assert.Equal(constants.TestSuppressMetaFileName, suppressionFile.Name)
-	assert.Equal(fileTime.Format("010203040506"), suppressionFile.Timestamp.Format("010203040506"))
+	assert.Equal(fileTime.Format("010203040506"), suppressionFile.Timestamp.UTC().Format("010203040506"))
 	assert.Equal(constants.ImportComplete, suppressionFile.ImportStatus)
 
 	suppressions := postgrestest.GetSuppressionsByFileID(s.T(), db, suppressionFile.ID)
@@ -99,7 +100,7 @@ func (s *SuppressionTestSuite) TestImportSuppression() {
 
 	suppressionFile = postgrestest.GetSuppressionFileByName(s.T(), db, metadata.Name)[0]
 	assert.Equal("T#EFT.ON.ACO.NGD1800.DPRF.D190816.T0241390", suppressionFile.Name)
-	assert.Equal(fileTime.Format("010203040506"), suppressionFile.Timestamp.Format("010203040506"))
+	assert.Equal(fileTime.Format("010203040506"), suppressionFile.Timestamp.UTC().Format("010203040506"))
 
 	suppressions = postgrestest.GetSuppressionsByFileID(s.T(), db, suppressionFile.ID)
 	assert.Len(suppressions, 250)
@@ -187,53 +188,9 @@ func (s *SuppressionTestSuite) TestValidate() {
 	assert.EqualError(err, "incorrect number of records found from file: '"+metadata.FilePath+"'. Expected record count: 5, Actual record count: 4")
 }
 
-func (s *SuppressionTestSuite) TestGetSuppressionFileMetadata() {
-	assert := assert.New(s.T())
-	var suppresslist []*optout.OptOutFilenameMetadata
-	var skipped int
-
-	filePath := filepath.Join(s.basePath, constants.TestSynthMedFilesPath)
-	err := filepath.Walk(filePath, getSuppressionFileMetadata(&suppresslist, &skipped))
-	assert.Nil(err)
-	assert.Equal(2, len(suppresslist))
-	assert.Equal(0, skipped)
-
-	suppresslist = []*optout.OptOutFilenameMetadata{}
-	skipped = 0
-	filePath = filepath.Join(s.basePath, "suppressionfile_BadFileNames/")
-	err = filepath.Walk(filePath, getSuppressionFileMetadata(&suppresslist, &skipped))
-	assert.Nil(err)
-	assert.Equal(0, len(suppresslist))
-	assert.Equal(2, skipped)
-
-	suppresslist = []*optout.OptOutFilenameMetadata{}
-	skipped = 0
-	filePath = filepath.Join(s.basePath, constants.TestSynthMedFilesPath)
-	err = filepath.Walk(filePath, getSuppressionFileMetadata(&suppresslist, &skipped))
-	assert.Nil(err)
-	modtimeAfter := time.Now().Truncate(time.Second)
-	// check current value and change mod time
-	for _, f := range suppresslist {
-		fInfo, _ := os.Stat(f.FilePath)
-		assert.Equal(fInfo.ModTime().Format("010203040506"), f.DeliveryDate.Format("010203040506"))
-
-		err = os.Chtimes(f.FilePath, modtimeAfter, modtimeAfter)
-		if err != nil {
-			s.FailNow(constants.TestChangeTimeErr, err)
-		}
-	}
-
-	suppresslist = []*optout.OptOutFilenameMetadata{}
-	filePath = filepath.Join(s.basePath, constants.TestSynthMedFilesPath)
-	err = filepath.Walk(filePath, getSuppressionFileMetadata(&suppresslist, &skipped))
-	assert.Nil(err)
-	for _, f := range suppresslist {
-		assert.Equal(modtimeAfter.Format("010203040506"), f.DeliveryDate.Format("010203040506"))
-	}
-}
-
 func (s *SuppressionTestSuite) TestGetSuppressionFileMetadata_TimeChange() {
 	assert := assert.New(s.T())
+	testUtils.SetPendingDeletionDir(s.Suite, s.pendingDeletionDir)
 	var suppresslist []*optout.OptOutFilenameMetadata
 	var skipped int
 	folderPath := filepath.Join(s.basePath, "suppressionfile_BadFileNames/")
@@ -257,6 +214,7 @@ func (s *SuppressionTestSuite) TestGetSuppressionFileMetadata_TimeChange() {
 
 	timeChange := origTime.Add(-(time.Hour * 73)).Truncate(time.Second)
 	err = os.Chtimes(filePath, timeChange, timeChange)
+
 	if err != nil {
 		s.FailNow(constants.TestChangeTimeErr, err)
 	}
@@ -271,6 +229,24 @@ func (s *SuppressionTestSuite) TestGetSuppressionFileMetadata_TimeChange() {
 	// assert that this file is not still here.
 	_, err = os.Open(filePath)
 	assert.EqualError(err, fmt.Sprintf("open %s: no such file or directory", filePath))
+
+	//Utilize the other bad file, but set an invalid pending deletion directory.
+	filePath = filepath.Join(folderPath, constants.TestSuppressBadDeletePath)
+	_, err = os.Open(filePath)
+	assert.Nil(err)
+
+	timeChange = origTime.Add(-(time.Hour * 73)).Truncate(time.Second)
+	err = os.Chtimes(filePath, timeChange, timeChange)
+
+	if err != nil {
+		s.FailNow(constants.TestChangeTimeErr, err)
+	}
+
+	suppresslist = []*optout.OptOutFilenameMetadata{}
+	conf.SetEnv(s.T(), "PENDING_DELETION_DIR", "\n")
+	err = filepath.Walk(folderPath, getSuppressionFileMetadata(&suppresslist, &skipped))
+	assert.Equal(true, strings.Contains(err.Error(), "error moving unknown file"))
+
 }
 
 func (s *SuppressionTestSuite) TestCleanupSuppression() {
@@ -310,7 +286,7 @@ func (s *SuppressionTestSuite) TestCleanupSuppression() {
 	err := cleanupSuppression(suppresslist)
 	assert.Nil(err)
 
-	files, err := ioutil.ReadDir(conf.GetEnv("PENDING_DELETION_DIR"))
+	files, err := os.ReadDir(conf.GetEnv("PENDING_DELETION_DIR"))
 	if err != nil {
 		s.FailNow("failed to read directory: %s", conf.GetEnv("PENDING_DELETION_DIR"), err)
 	}
@@ -322,5 +298,110 @@ func (s *SuppressionTestSuite) TestCleanupSuppression() {
 			err = fmt.Errorf("unknown file moved %s", file.Name())
 			s.FailNow("test files did not correctly cleanup", err)
 		}
+	}
+}
+
+func (s *SuppressionTestSuite) TestCleanupSuppression_Bad() {
+	assert := assert.New(s.T())
+	var suppresslist []*optout.OptOutFilenameMetadata
+
+	//new use cases
+	conf.SetEnv(s.T(), "PENDING_DELETION_DIR", "\n")
+	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
+	metadata1 := &optout.OptOutFilenameMetadata{
+		Name:         constants.TestSuppressBadPath,
+		Timestamp:    fileTime,
+		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000009"),
+		Imported:     false,
+		DeliveryDate: fileTime,
+	}
+
+	//
+	metadata2 := &optout.OptOutFilenameMetadata{
+		Name:         "T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420",
+		Timestamp:    fileTime,
+		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420"),
+		Imported:     true,
+		DeliveryDate: time.Now(),
+	}
+
+	suppresslist = []*optout.OptOutFilenameMetadata{metadata1, metadata2}
+	err := cleanupSuppression(suppresslist)
+	assert.EqualError(err, "2 files could not be cleaned up")
+
+}
+
+func (s *SuppressionTestSuite) TestCleanupSuppression_Bad2() {
+	assert := assert.New(s.T())
+	var suppresslist []*optout.OptOutFilenameMetadata
+
+	//new use cases
+	conf.SetEnv(s.T(), "PENDING_DELETION_DIR", "\n")
+	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
+	metadata1 := &optout.OptOutFilenameMetadata{
+		Name:         constants.TestSuppressBadPath,
+		Timestamp:    fileTime,
+		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000009"),
+		Imported:     false,
+		DeliveryDate: fileTime,
+	}
+
+	suppresslist = []*optout.OptOutFilenameMetadata{metadata1}
+	err := cleanupSuppression(suppresslist)
+	assert.EqualError(err, "1 files could not be cleaned up")
+
+}
+
+func (s *SuppressionTestSuite) TestImportSuppressionDirectoryTable() {
+	assert := assert.New(s.T())
+	db := database.Connection
+
+	tests := []struct {
+		name           string
+		directory      string
+		success        int
+		failure        int
+		skipped        int
+		errorExpected  bool
+		errMessage     string
+		deleteFiles    bool
+		insertCarriage bool
+	}{
+		{name: "Valid test", directory: "../../shared_files/synthetic1800MedicareFiles/test2/", success: 2, failure: 0, skipped: 0, errorExpected: false, errMessage: "", deleteFiles: true},
+		{name: "Import failure", directory: "../../shared_files/suppressionfile_BadHeader/", success: 0, failure: 1, skipped: 0, errorExpected: true, errMessage: "one or more suppression files failed to import correctly", deleteFiles: false},
+		{name: "Skipped import", directory: "../../shared_files/suppressionfile_BadFileNames/", success: 0, failure: 0, skipped: 2, errorExpected: false, errMessage: "", deleteFiles: false},
+		{name: "Carriage char in path", directory: "../../shared_files/suppressionfile_BadFileNames/", success: 0, failure: 0, skipped: 0, errorExpected: true, errMessage: "no such file or directory", deleteFiles: false, insertCarriage: true},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+
+			path, cleanup := testUtils.CopyToTemporaryDirectory(s.T(), tt.directory)
+			defer cleanup()
+			if tt.insertCarriage {
+				path += "\n"
+			}
+
+			success, failure, skipped, err := ImportSuppressionDirectory(path)
+			if tt.errorExpected {
+				assert.Equal(true, strings.Contains(err.Error(), tt.errMessage))
+			} else {
+				assert.Nil(err)
+			}
+			assert.Equal(tt.success, success)
+			assert.Equal(tt.failure, failure)
+			assert.Equal(tt.skipped, skipped)
+
+			if tt.deleteFiles {
+				fs := postgrestest.GetSuppressionFileByName(s.T(), db,
+					"T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000010",
+					"T#EFT.ON.ACO.NGD1800.DPRF.D190816.T0241391")
+				assert.Len(fs, 2)
+				for _, f := range fs {
+					postgrestest.DeleteSuppressionFileByID(s.T(), db, f.ID)
+				}
+			}
+
+		})
 	}
 }

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -345,6 +345,36 @@ func (s *SuppressionTestSuite) TestCleanupSuppression() {
 	}
 }
 
+func (s *SuppressionTestSuite) TestCleanupSuppression_Bad() {
+	assert := assert.New(s.T())
+	var suppresslist []*optout.OptOutFilenameMetadata
+
+	//new use cases
+	conf.SetEnv(s.T(), "PENDING_DELETION_DIR", "\n")
+	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
+	metadata1 := &optout.OptOutFilenameMetadata{
+		Name:         constants.TestSuppressBadPath,
+		Timestamp:    fileTime,
+		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.FRPD.D191220.T1000009"),
+		Imported:     false,
+		DeliveryDate: fileTime,
+	}
+
+	//
+	metadata2 := &optout.OptOutFilenameMetadata{
+		Name:         "T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420",
+		Timestamp:    fileTime,
+		FilePath:     filepath.Join(s.basePath, "suppressionfile_BadFileNames/T#EFT.ON.ACO.NGD1800.DPRF.D190117.T9909420"),
+		Imported:     true,
+		DeliveryDate: time.Now(),
+	}
+
+	suppresslist = []*optout.OptOutFilenameMetadata{metadata1, metadata2}
+	err := cleanupSuppression(suppresslist)
+	assert.EqualError(err, "2 files could not be cleaned up")
+
+}
+
 func (s *SuppressionTestSuite) TestCleanupSuppression_RenameFileError() {
 	assert := assert.New(s.T())
 	var suppresslist []*optout.OptOutFilenameMetadata


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7126

## 🛠 Changes

Removed outdated package in suppression.go (ioutil)
Updated unit tests for suppression.go to get to 95.2% statement coverage. 

## ℹ️ Context for reviewers

In addition to the new tests, of which coverage is primarily added by implementing tests for the ImportSuppressionDirectory function, existing tests are modified to utilize UTC as the standard date format in case someone runs the tests locally (instead of on docker, where the default time is UTC). Future improvements to coverage on this file can be made by implementing a means to mock the repository. This would enable leaving only ~2 statements uncovered. 

## ✅ Acceptance Validation

![image](https://github.com/CMSgov/bcda-app/assets/120701369/b75050f6-4a0d-441a-ac2b-3722868f5744)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
