### PR TITLE
BCDA-7446 - update content-type header for OperationOutcome responses to fhir+json

### DIFF
--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -783,8 +783,12 @@ func (s *RequestsTestSuite) TestJobStatusErrorHandling() {
 			h.JobStatus(w, req)
 			s.Equal(tt.responseHeader, w.Code)
 			switch tt.responseHeader {
-			case http.StatusOK, http.StatusBadRequest, http.StatusNotFound, http.StatusGone:
+			case http.StatusBadRequest, http.StatusNotFound, http.StatusGone:
+				s.Equal(constants.FHIRJsonContentType, w.Header().Get("Content-Type"))
+			case http.StatusOK:
 				s.Equal(constants.JsonContentType, w.Header().Get("Content-Type"))
+			case http.StatusAccepted:
+				s.Equal("", w.Header().Get("Content-Type"))
 			}
 
 		})

--- a/bcda/responseutils/v2/writer.go
+++ b/bcda/responseutils/v2/writer.go
@@ -161,8 +161,9 @@ func CreateOpOutcome(severity fhircodes.IssueSeverityCode_Value, code fhircodes.
 }
 
 func WriteError(outcome *fhirmodelOO.OperationOutcome, w http.ResponseWriter, code int) {
-
-	w.Header().Set(constants.ContentType, constants.JsonContentType)
+	//Write application/fhir+json header on OperationOutcome responses
+	//https://build.fhir.org/ig/HL7/bulk-data/export.html#response---error-status-1
+	w.Header().Set(constants.ContentType, constants.FHIRJsonContentType)
 	w.WriteHeader(code)
 	_, err := WriteOperationOutcome(w, outcome)
 	if err != nil {

--- a/bcda/responseutils/v2/writer_test.go
+++ b/bcda/responseutils/v2/writer_test.go
@@ -52,6 +52,8 @@ func (s *ResponseUtilsWriterTestSuite) TestResponseWriterException() {
 	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Coding[0].Display.Value)
 	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Text.Value)
 	assert.Equal(s.T(), responseutils.RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+	assert.Equal(s.T(), constants.FHIRJsonContentType, s.rr.Header().Get("Content-Type"))
+
 }
 
 func (s *ResponseUtilsWriterTestSuite) TestResponseWriterNotFound() {
@@ -70,6 +72,8 @@ func (s *ResponseUtilsWriterTestSuite) TestResponseWriterNotFound() {
 	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Coding[0].Display.Value)
 	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Text.Value)
 	assert.Equal(s.T(), responseutils.RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+	assert.Equal(s.T(), constants.FHIRJsonContentType, s.rr.Header().Get("Content-Type"))
+
 }
 
 func (s *ResponseUtilsWriterTestSuite) TestCreateOpOutcome() {

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -158,7 +158,7 @@ func CreateOpOutcome(severity fhircodes.IssueSeverityCode_Value, code fhircodes.
 }
 
 func WriteError(outcome *fhirmodels.OperationOutcome, w http.ResponseWriter, code int) {
-	w.Header().Set(constants.ContentType, constants.JsonContentType)
+	w.Header().Set(constants.ContentType, constants.FHIRJsonContentType)
 	if code == http.StatusServiceUnavailable {
 		includeRetryAfterHeader(w)
 	}

--- a/bcda/responseutils/writer_test.go
+++ b/bcda/responseutils/writer_test.go
@@ -51,6 +51,8 @@ func (s *ResponseUtilsWriterTestSuite) TestResponseWriterException() {
 	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Coding[0].Display.Value)
 	assert.Equal(s.T(), "TestResponseWriterExcepton", respOO.Issue[0].Details.Text.Value)
 	assert.Equal(s.T(), RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+	assert.Equal(s.T(), constants.FHIRJsonContentType, s.rr.Header().Get("Content-Type"))
+
 }
 
 func (s *ResponseUtilsWriterTestSuite) TestResponseWriterNotFound() {
@@ -69,6 +71,7 @@ func (s *ResponseUtilsWriterTestSuite) TestResponseWriterNotFound() {
 	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Coding[0].Display.Value)
 	assert.Equal(s.T(), "TestResponseWriterNotFound", respOO.Issue[0].Details.Text.Value)
 	assert.Equal(s.T(), RequestErr, respOO.Issue[0].Details.Coding[0].Code.Value)
+	assert.Equal(s.T(), constants.FHIRJsonContentType, s.rr.Header().Get("Content-Type"))
 }
 
 func (s *ResponseUtilsWriterTestSuite) TestCreateOpOutcome() {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7446

## 🛠 Changes
Changed Content-Type header for OperationOutcome error responses from application/json to application/fhir+json in both v1+v2 of the BCDA API

## ℹ️ Context for reviewers
From: https://build.fhir.org/ig/HL7/bulk-data/export.html#response---error-status-1
According to the Bulk FHIR Export IG, OperationOutcome responses should respond with Content-Type of application/fhir+json. This is a one line change that will enhance the conformance of the BCDA application with respect to the bulk FHIR IG. 
![image](https://github.com/CMSgov/bcda-app/assets/120701369/f655aa43-aa47-4498-9180-31a6fae8fd90)


## ✅ Acceptance Validation

Unit test on requests.api updated to check for the applicable content-type header in the case of an OperationOutcome response.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
