### PR TITLE
BCDA-7455: Fix new beneficiary calculation for Group endpoint

### DIFF
--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -359,6 +359,9 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 	// - any beneficiaries added in 2023 are considered "new."
 	//
 	oldFileUpperBound := conditions.Since
+
+	// If the _since parameter is more recent than the latest CCLF file, set the upper bound
+	// for the older file to be prior to cclfFileNew.Timestamp.
 	if !conditions.Since.IsZero() && cclfFileNew.Timestamp.Sub(conditions.Since) < 0 {
 		oldFileUpperBound = cclfFileNew.Timestamp.Add(-1 * time.Second)
 	}

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -325,6 +325,8 @@ func (s *service) createQueueJobs(conditions RequestConditions, since time.Time,
 	return jobs, nil
 }
 
+// Returns the beneficiaries associated with the latest CCLF file for the given request conditions,
+// split between existing beneficiaries and newly-attributed beneficiaries.
 func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions RequestConditions) (newBeneficiaries, beneficiaries []*models.CCLFBeneficiary, err error) {
 
 	var (
@@ -336,7 +338,9 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 		cutoffTime = time.Now().Add(-1 * s.stdCutoffDuration)
 	}
 
-	// will get all benes between cutoff time and now, or all benes up until the attribution date
+	// Retrieve beneficiaries from either:
+	// - The newest CCLF file in the last X days (where X is the environment's configured cutoff duration)
+	// - OR the newest CCLF file prior to the requested attributionDate
 	cclfFileNew, err := s.repository.GetLatestCCLFFile(ctx, conditions.CMSID, cclf8FileNum, constants.ImportComplete,
 		cutoffTime, conditions.attributionDate, conditions.fileType)
 	if err != nil {
@@ -346,8 +350,21 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 		return nil, nil, CCLFNotFoundError{8, conditions.CMSID, conditions.fileType, cutoffTime}
 	}
 
+	// Retrieve an older CCLF file for beneficiary comparison.
+	// This should be older than cclfFileNew AND prior to the "since" parameter, if provided.
+	//
+	// e.g.
+	// - If it’s October 2023
+	// - and they request all beneficiary data “since January 1st, 2023"
+	// - any beneficiaries added in 2023 are considered "new."
+	//
+	oldFileUpperBound := cclfFileNew.Timestamp.Add(-1 * time.Second)
+	if cclfFileNew.Timestamp.Sub(conditions.Since) < 0 {
+		oldFileUpperBound = cclfFileNew.Timestamp.Add(-1 * time.Second)
+	}
+
 	cclfFileOld, err := s.repository.GetLatestCCLFFile(ctx, conditions.CMSID, cclf8FileNum, constants.ImportComplete,
-		time.Time{}, conditions.Since, models.FileTypeDefault)
+		time.Time{}, oldFileUpperBound, models.FileTypeDefault)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get old CCLF file for cmsID %s %s", conditions.CMSID, err.Error())
 	}

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -358,8 +358,8 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 	// - and they request all beneficiary data “since January 1st, 2023"
 	// - any beneficiaries added in 2023 are considered "new."
 	//
-	oldFileUpperBound := cclfFileNew.Timestamp.Add(-1 * time.Second)
-	if cclfFileNew.Timestamp.Sub(conditions.Since) < 0 {
+	oldFileUpperBound := conditions.Since
+	if !conditions.Since.IsZero() && cclfFileNew.Timestamp.Sub(conditions.Since) < 0 {
 		oldFileUpperBound = cclfFileNew.Timestamp.Add(-1 * time.Second)
 	}
 

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -1078,8 +1078,7 @@ func (s *ServiceTestSuite) TestGetACOConfigForID() {
 
 func getCCLFFile(id uint) *models.CCLFFile {
 	return &models.CCLFFile{
-		ID:        id,
-		Timestamp: time.Now(),
+		ID: id,
 	}
 }
 

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -368,7 +368,7 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 	}
 }
 
-// Integration Test
+// * Live database test *
 //
 // Given the following example scenario:
 // - CCLF File 1 (June)

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -11,7 +11,10 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/constants"
+	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/models/postgres"
+	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/pborman/uuid"
@@ -360,6 +363,62 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 
 		})
 	}
+}
+
+// Integration Test
+//
+// Given the following example scenario:
+// - CCLF File 1 (June)
+// - CCLF File 2 (July)
+// - Request made with "since" parameter later than July
+//
+// We should diff between the correct files (CCLF File 1 and CCLF File 2).
+func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries_RecentSinceParameter() {
+	assert := assert.New(s.T())
+	db := database.Connection
+
+	// Test Setup
+	postgrestest.DeleteCCLFFilesByCMSID(s.T(), db, "A0005")
+	defer postgrestest.DeleteCCLFFilesByCMSID(s.T(), db, "A0005")
+
+	acoID := "A0005"
+	cclfFileOld := &models.CCLFFile{CCLFNum: 8, ACOCMSID: acoID, Timestamp: time.Now().Add(-48 * time.Hour), PerformanceYear: 23, Name: "T.BCD.A0005.ZC8Y23.D231119.T1000009", ImportStatus: constants.ImportComplete}
+	cclfFileNew := &models.CCLFFile{CCLFNum: 8, ACOCMSID: acoID, Timestamp: time.Now().Add(-24 * time.Hour), PerformanceYear: 23, Name: "T.BCD.A0005.ZC8Y23.D231120.T1000009", ImportStatus: constants.ImportComplete}
+	postgrestest.CreateCCLFFile(s.T(), db, cclfFileOld)
+	postgrestest.CreateCCLFFile(s.T(), db, cclfFileNew)
+
+	bene1OldRecord := &models.CCLFBeneficiary{FileID: cclfFileOld.ID, MBI: testUtils.RandomMBI(s.T()), BlueButtonID: testUtils.RandomHexID()}
+	bene1NewRecord := &models.CCLFBeneficiary{FileID: cclfFileNew.ID, MBI: bene1OldRecord.MBI, BlueButtonID: testUtils.RandomHexID()}
+	bene2NewRecord := &models.CCLFBeneficiary{FileID: cclfFileNew.ID, MBI: testUtils.RandomMBI(s.T()), BlueButtonID: testUtils.RandomHexID()}
+
+	postgrestest.CreateCCLFBeneficiary(s.T(), db, bene1OldRecord)
+	postgrestest.CreateCCLFBeneficiary(s.T(), db, bene1NewRecord)
+	postgrestest.CreateCCLFBeneficiary(s.T(), db, bene2NewRecord)
+
+	// Call
+	cfg := &Config{
+		cutoffDuration:          -50 * time.Hour,
+		SuppressionLookbackDays: int(30),
+		RunoutConfig: RunoutConfig{
+			cutoffDuration: defaultRunoutCutoff,
+			claimThru:      defaultRunoutClaimThru,
+		},
+	}
+
+	since := time.Now()
+
+	repository := postgres.NewRepository(db)
+	serviceInstance := NewService(repository, cfg, "").(*service)
+	newBenes, oldBenes, err := serviceInstance.getNewAndExistingBeneficiaries(context.Background(),
+		RequestConditions{CMSID: acoID, Since: since, fileType: models.FileTypeDefault})
+
+	// Assert
+	assert.NoError(err)
+	assert.Len(oldBenes, 1)
+	assert.Len(newBenes, 1)
+
+	assert.Equal(bene1OldRecord.MBI, oldBenes[0].MBI, "MBI %s should be found in old MBI map %v", bene1OldRecord.MBI, oldBenes)
+	assert.Equal(bene2NewRecord.MBI, newBenes[0].MBI, "MBI %s should be found in new MBI map %v", bene1OldRecord.MBI, newBenes)
 }
 
 func (s *ServiceTestSuite) TestGetBeneficiaries() {
@@ -1019,7 +1078,8 @@ func (s *ServiceTestSuite) TestGetACOConfigForID() {
 
 func getCCLFFile(id uint) *models.CCLFFile {
 	return &models.CCLFFile{
-		ID: id,
+		ID:        id,
+		Timestamp: time.Now(),
 	}
 }
 

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -323,7 +323,10 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 				}),
 				time.Time{},
 				models.FileTypeDefault).Return(tt.cclfFileNew, nil)
-			repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, cmsID, fileNum, constants.ImportComplete, time.Time{}, since, models.FileTypeDefault).Return(tt.cclfFileOld, nil)
+
+			if tt.cclfFileNew != nil {
+				repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, cmsID, fileNum, constants.ImportComplete, time.Time{}, tt.cclfFileNew.Timestamp.Add(-1*time.Second), models.FileTypeDefault).Return(tt.cclfFileOld, nil)
+			}
 
 			if tt.cclfFileOld != nil {
 				repository.On("GetCCLFBeneficiaryMBIs", testUtils.CtxMatcher, tt.cclfFileOld.ID).Return(tt.oldMBIs, nil)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7455

## 🛠 Changes

- Fix the logic for calculating new beneficiaries when the Group endpoint is called using the _since parameter

## ℹ️ Context for reviewers

As described [in our documentation](https://bcda.cms.gov/guide.html#group-endpoint)...

>  If you use _since within the /Group endpoint, you will receive data filtered since the selected date for your existing beneficiaries AND you will receive historical data as far back as 2014 unfiltered by date for new beneficiaries. 

The logic for calculating new beneficiaries works by diffing between two CCLF files:

- `cclfFileNew` — pulls the latest CCLF file
- `cclfFileOld` — pulls the latest CCLF file with a timestamp prior to the _since parameter provided in the Group request.

This logic can sometimes incorrectly calculate the diff between the same CCLF file. For example, in the following situation:

- Latest file: July 8, 2023
- Older file: June 8, 2023
- Job Request: Request for data "since July 12th, 2023"

Both `cclfFileNew` and `cclfFileOld` will be assigned the July 8th file. Instead, when the `_since` parameter is more recent than the latest CCLF file we have on hand, we should be looking even farther back to find the prior file.

## ✅ Acceptance Validation

Confirmed that the new test fails prior to changes, and is passing now.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.