### PR TITLE
BCDA-6594: Improve logging when receiving BFD 400/500 status codes

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -538,8 +538,16 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType se
 		logger.Info("job id created")
 	}
 
+	jobData := models.JobEnqueueArgs{
+		ID:              int(newJob.ID),
+		ACOID:           acoID.String(),
+		Since:           "",
+		TransactionTime: time.Now(),
+		CMSID:           ad.CMSID,
+	}
+
 	// request a fake patient in order to acquire the bundle's lastUpdated metadata
-	b, err := bb.GetPatient("0", strconv.FormatUint(uint64(newJob.ID), 10), acoID.String(), "", time.Now())
+	b, err := bb.GetPatient(jobData, "0")
 	if err != nil {
 		logger.Error(err)
 		h.RespWriter.Exception(w, http.StatusInternalServerError, responseutils.FormatErr, "Failure to retrieve transactionTime metadata from FHIR Data Server.")

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -4,23 +4,23 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
-	models "github.com/CMSgov/bcda-app/bcda/models/fhir"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	fhirModels "github.com/CMSgov/bcda-app/bcda/models/fhir"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/twinj/uuid"
 
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -49,6 +49,7 @@ var (
 	since        = "gt2020-02-14"
 	claimsDate   = client.ClaimsWindow{LowerBound: time.Date(2017, 12, 31, 0, 0, 0, 0, time.UTC),
 		UpperBound: time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)}
+	jobData = models.JobEnqueueArgs{ID: 1, CMSID: "A0000", Since: since, TransactionTime: now}
 )
 
 func (s *BBTestSuite) SetupSuite() {
@@ -224,64 +225,64 @@ func (s *BBTestSuite) TestGetDefaultParams() {
 
 /* Tests that make requests, using clients configured with the 200 response and 500 response httptest.Servers initialized in SetupSuite() */
 func (s *BBRequestTestSuite) TestGetPatient() {
-	p, err := s.bbClient.GetPatient("012345", "543210", "A0000", "", now)
+	p, err := s.bbClient.GetPatient(jobData, "012345")
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 1, len(p.Entries))
 	assert.Equal(s.T(), "20000000000001", p.Entries[0]["resource"].(map[string]interface{})["id"])
 }
 
 func (s *BBRequestTestSuite) TestGetPatient_500() {
-	p, err := s.bbClient.GetPatient("012345", "543210", "A0000", "", now)
+	p, err := s.bbClient.GetPatient(jobData, "012345")
 	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), p)
 }
 
 func (s *BBRequestTestSuite) TestGetCoverage() {
-	c, err := s.bbClient.GetCoverage("012345", "543210", "A0000", since, now)
+	c, err := s.bbClient.GetCoverage(jobData, "012345")
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 3, len(c.Entries))
 	assert.Equal(s.T(), "part-b-20000000000001", c.Entries[1]["resource"].(map[string]interface{})["id"])
 }
 
 func (s *BBRequestTestSuite) TestGetCoverage_500() {
-	c, err := s.bbClient.GetCoverage("012345", "543210", "A0000", since, now)
+	c, err := s.bbClient.GetCoverage(jobData, "012345")
 	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), c)
 }
 
 func (s *BBRequestTestSuite) TestGetExplanationOfBenefit() {
-	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now, client.ClaimsWindow{})
+	e, err := s.bbClient.GetExplanationOfBenefit(jobData, "012345", client.ClaimsWindow{})
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 33, len(e.Entries))
 	assert.Equal(s.T(), "carrier-10525061996", e.Entries[3]["resource"].(map[string]interface{})["id"])
 }
 
 func (s *BBRequestTestSuite) TestGetExplanationOfBenefit_500() {
-	e, err := s.bbClient.GetExplanationOfBenefit("012345", "543210", "A0000", "", now, client.ClaimsWindow{})
+	e, err := s.bbClient.GetExplanationOfBenefit(jobData, "012345", client.ClaimsWindow{})
 	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), e)
 }
 
 func (s *BBRequestTestSuite) TestGetClaim() {
-	e, err := s.bbClient.GetClaim("1234567890hashed", "543210", "A0000", "", now, client.ClaimsWindow{})
+	e, err := s.bbClient.GetClaim(jobData, "1234567890hashed", client.ClaimsWindow{})
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 1, len(e.Entries))
 }
 
 func (s *BBRequestTestSuite) TestGetClaim_500() {
-	e, err := s.bbClient.GetClaim("1234567890hashed", "543210", "A0000", "", now, client.ClaimsWindow{})
+	e, err := s.bbClient.GetClaim(jobData, "1234567890hashed", client.ClaimsWindow{})
 	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), e)
 }
 
 func (s *BBRequestTestSuite) TestGetClaimResponse() {
-	e, err := s.bbClient.GetClaimResponse("1234567890hashed", "543210", "A0000", "", now, client.ClaimsWindow{})
+	e, err := s.bbClient.GetClaimResponse(jobData, "1234567890hashed", client.ClaimsWindow{})
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 1, len(e.Entries))
 }
 
 func (s *BBRequestTestSuite) TestGetClaimResponse_500() {
-	e, err := s.bbClient.GetClaimResponse("1234567890hashed", "543210", "A0000", "", now, client.ClaimsWindow{})
+	e, err := s.bbClient.GetClaimResponse(jobData, "1234567890hashed", client.ClaimsWindow{})
 	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get bundle response`, err.Error())
 	assert.Nil(s.T(), e)
 }
@@ -300,9 +301,33 @@ func (s *BBRequestTestSuite) TestGetMetadata_500() {
 }
 
 func (s *BBRequestTestSuite) TestGetPatientByIdentifierHash() {
-	p, err := s.bbClient.GetPatientByIdentifierHash("hashedIdentifier")
+	p, err := s.bbClient.GetPatientByIdentifierHash(models.JobEnqueueArgs{}, "hashedIdentifier")
 	assert.Nil(s.T(), err)
 	assert.Contains(s.T(), p, `"id": "20000000000001"`)
+}
+
+func (s *BBRequestTestSuite) TestGetPatientByIdentifierHash_500() {
+	var cms_id, job_id bool
+	hook := test.NewLocal(logrus.StandardLogger())
+	jobData := models.JobEnqueueArgs{
+		ID:    1,
+		CMSID: "A0000",
+	}
+	p, err := s.bbClient.GetPatientByIdentifierHash(jobData, "hashedIdentifier")
+	entry := hook.AllEntries()
+	for _, t := range entry {
+		s.T().Log(t.Data)
+		if _, ok := t.Data["cms_id"]; ok {
+			cms_id = true
+		}
+		if _, ok := t.Data["job_id"]; ok {
+			job_id = true
+		}
+	}
+	assert.True(s.T(), cms_id, "Log entry should have a value for field `cms_id`.")
+	assert.True(s.T(), job_id, "Log entry should have a value for field `job_id`.")
+	assert.Regexp(s.T(), `blue button request failed \d+ time\(s\) failed to get response`, err.Error())
+	assert.Equal(s.T(), "", p)
 }
 
 // Sample values from https://confluence.cms.gov/pages/viewpage.action?spaceKey=BB&title=Getting+Started+with+Blue+Button+2.0%27s+Backend#space-menu-link-content
@@ -334,23 +359,24 @@ func (s *BBRequestTestSuite) TearDownAllSuite() {
 
 func (s *BBRequestTestSuite) TestValidateRequest() {
 	old := conf.GetEnv("BB_CLIENT_PAGE_SIZE")
+	jobDataNoSince := models.JobEnqueueArgs{ID: 1, CMSID: "A0000", Since: "", TransactionTime: now}
 	defer conf.SetEnv(s.T(), "BB_CLIENT_PAGE_SIZE", old)
 	conf.SetEnv(s.T(), "BB_CLIENT_PAGE_SIZE", "0") // Need to ensure that requests do not have the _count parameter
 
 	tests := []struct {
 		name          string
-		funcUnderTest func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error)
+		funcUnderTest func(bbClient *client.BlueButtonClient) (interface{}, error)
 		// Lighter validation checks since we've already thoroughly tested the methods in other tests
 		payloadChecker func(t *testing.T, payload interface{})
 		pathCheckers   []func(t *testing.T, req *http.Request)
 	}{
 		{
 			"GetExplanationOfBenefit",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, since, now, client.ClaimsWindow{})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetExplanationOfBenefit(jobData, "patient1", client.ClaimsWindow{})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -367,11 +393,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetExplanationOfBenefitNoSince",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, "", now, client.ClaimsWindow{})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetExplanationOfBenefit(jobDataNoSince, "patient1", client.ClaimsWindow{})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -388,11 +414,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetExplanationOfBenefitWithUpperBoundServiceDate",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, since, now, client.ClaimsWindow{UpperBound: claimsDate.UpperBound})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetExplanationOfBenefit(jobData, "patient1", client.ClaimsWindow{UpperBound: claimsDate.UpperBound})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -410,11 +436,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetExplanationOfBenefitWithLowerBoundServiceDate",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, since, now, client.ClaimsWindow{LowerBound: claimsDate.LowerBound})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetExplanationOfBenefit(jobData, "patient1", client.ClaimsWindow{LowerBound: claimsDate.LowerBound})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -432,11 +458,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetExplanationOfBenefitWithLowerAndUpperBoundServiceDate",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetExplanationOfBenefit("patient1", jobID, cmsID, since, now, claimsDate)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetExplanationOfBenefit(jobData, "patient1", claimsDate)
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -454,11 +480,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetPatient",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetPatient("patient2", jobID, cmsID, since, now)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetPatient(jobData, "patient2")
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -474,11 +500,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetPatientNoSince",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetPatient("patient2", jobID, cmsID, "", now)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetPatient(jobDataNoSince, "patient2")
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -494,11 +520,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetCoverage",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetCoverage("beneID1", jobID, cmsID, since, now)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetCoverage(jobData, "beneID1")
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -514,11 +540,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetCoverageNoSince",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetCoverage("beneID1", jobID, cmsID, "", now)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetCoverage(jobDataNoSince, "beneID1")
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -534,8 +560,8 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetPatientByIdentifierHash",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetPatientByIdentifierHash("hashedIdentifier")
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetPatientByIdentifierHash(models.JobEnqueueArgs{}, "hashedIdentifier")
 			},
 			func(t *testing.T, payload interface{}) {
 				result, ok := payload.(string)
@@ -552,11 +578,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaim",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaim("beneID1", jobID, cmsID, since, now, client.ClaimsWindow{})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaim(jobData, "beneID1", client.ClaimsWindow{})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -573,11 +599,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimNoSinceChecker",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaim("beneID1", jobID, cmsID, "", now, client.ClaimsWindow{})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaim(jobDataNoSince, "beneID1", client.ClaimsWindow{})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -594,11 +620,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimNoServiceDateUpperBound",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaim("beneID1", jobID, cmsID, since, now, client.ClaimsWindow{LowerBound: claimsDate.LowerBound})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaim(jobData, "beneID1", client.ClaimsWindow{LowerBound: claimsDate.LowerBound})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -616,11 +642,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimNoServiceDateLowerBound",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaim("beneID1", jobID, cmsID, since, now, client.ClaimsWindow{UpperBound: claimsDate.UpperBound})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaim(jobData, "beneID1", client.ClaimsWindow{UpperBound: claimsDate.UpperBound})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -638,11 +664,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimWithUpperAndLowerBoundServiceDate",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaim("beneID1", jobID, cmsID, since, now, claimsDate)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaim(jobData, "beneID1", claimsDate)
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -660,11 +686,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimResponse",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaimResponse("beneID1", jobID, cmsID, since, now, client.ClaimsWindow{})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaimResponse(jobData, "beneID1", client.ClaimsWindow{})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -681,11 +707,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimResponseNoSinceChecker",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaimResponse("beneID1", jobID, cmsID, "", now, client.ClaimsWindow{})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaimResponse(jobDataNoSince, "beneID1", client.ClaimsWindow{})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -702,11 +728,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimResponseNoServiceDateUpperBound",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaimResponse("beneID1", jobID, cmsID, since, now, client.ClaimsWindow{LowerBound: claimsDate.LowerBound})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaimResponse(jobData, "beneID1", client.ClaimsWindow{LowerBound: claimsDate.LowerBound})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -724,11 +750,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimResponseNoServiceDateLowerBound",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaimResponse("beneID1", jobID, cmsID, since, now, client.ClaimsWindow{UpperBound: claimsDate.UpperBound})
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaimResponse(jobData, "beneID1", client.ClaimsWindow{UpperBound: claimsDate.UpperBound})
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -746,11 +772,11 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 		},
 		{
 			"GetClaimResponseWithUpperAndLowerBoundServiceDate",
-			func(bbClient *client.BlueButtonClient, jobID, cmsID string) (interface{}, error) {
-				return bbClient.GetClaimResponse("beneID1", jobID, cmsID, since, now, claimsDate)
+			func(bbClient *client.BlueButtonClient) (interface{}, error) {
+				return bbClient.GetClaimResponse(jobData, "beneID1", claimsDate)
 			},
 			func(t *testing.T, payload interface{}) {
-				result, ok := payload.(*models.Bundle)
+				result, ok := payload.(*fhirModels.Bundle)
 				assert.True(t, ok)
 				assert.NotEmpty(t, result.Entries)
 			},
@@ -770,18 +796,13 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			var jobID, cmsID string
-
-			// GetPatientByIdentifierHash does not send in jobID and cmsID as arguments
-			// so we DO NOT expected the associated headers to be set.
-			// Only set the fields if we pass those parameters in.
-			if tt.name != "GetPatientByIdentifierHash" {
-				jobID = strconv.FormatUint(rand.Uint64(), 10)
-				cmsID = strconv.FormatUint(rand.Uint64(), 10)
-			}
 
 			tsValidation := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				assert.NotNil(t, uuid.Parse(req.Header.Get("BlueButton-OriginalQueryId")))
+				uid, err := uuid.Parse(req.Header.Get("BlueButton-OriginalQueryId"))
+				if err != nil {
+					assert.FailNow(t, err.Error())
+				}
+				assert.NotNil(t, uid)
 				assert.Equal(t, "1", req.Header.Get("BlueButton-OriginalQueryCounter"))
 
 				assert.Empty(t, req.Header.Get("keep-alive"))
@@ -818,7 +839,7 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.FailNow(t, err.Error())
 			}
 
-			data, err := tt.funcUnderTest(bbClient, jobID, cmsID)
+			data, err := tt.funcUnderTest(bbClient)
 			if err != nil {
 				assert.FailNow(t, err.Error())
 			}

--- a/bcda/client/mock_bluebutton.go
+++ b/bcda/client/mock_bluebutton.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
-	"time"
 
-	models "github.com/CMSgov/bcda-app/bcda/models/fhir"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	fhirModels "github.com/CMSgov/bcda-app/bcda/models/fhir"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -18,37 +18,37 @@ type MockBlueButtonClient struct {
 	MBI  *string
 }
 
-func (bbc *MockBlueButtonClient) GetExplanationOfBenefit(patientID, jobID, cmsID, since string, transactionTime time.Time, serviceDate ClaimsWindow) (*models.Bundle, error) {
-	args := bbc.Called(patientID, jobID, cmsID, since, transactionTime, serviceDate)
+func (bbc *MockBlueButtonClient) GetExplanationOfBenefit(jobData models.JobEnqueueArgs, patientID string, serviceDate ClaimsWindow) (*fhirModels.Bundle, error) {
+	args := bbc.Called(jobData, patientID, serviceDate)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*models.Bundle), args.Error(1)
+	return args.Get(0).(*fhirModels.Bundle), args.Error(1)
 }
 
-func (bbc *MockBlueButtonClient) GetPatientByIdentifierHash(hashedIdentifier string) (string, error) {
+func (bbc *MockBlueButtonClient) GetPatientByIdentifierHash(jobData models.JobEnqueueArgs, hashedIdentifier string) (string, error) {
 	args := bbc.Called(hashedIdentifier)
 	return args.String(0), args.Error(1)
 }
 
-func (bbc *MockBlueButtonClient) GetPatient(patientID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
-	args := bbc.Called(patientID, jobID, cmsID, since, transactionTime)
-	return args.Get(0).(*models.Bundle), args.Error(1)
+func (bbc *MockBlueButtonClient) GetPatient(jobData models.JobEnqueueArgs, patientID string) (*fhirModels.Bundle, error) {
+	args := bbc.Called(jobData, patientID)
+	return args.Get(0).(*fhirModels.Bundle), args.Error(1)
 }
 
-func (bbc *MockBlueButtonClient) GetCoverage(beneficiaryID, jobID, cmsID, since string, transactionTime time.Time) (*models.Bundle, error) {
-	args := bbc.Called(beneficiaryID, jobID, cmsID, since, transactionTime)
-	return args.Get(0).(*models.Bundle), args.Error(1)
+func (bbc *MockBlueButtonClient) GetCoverage(jobData models.JobEnqueueArgs, beneficiaryID string) (*fhirModels.Bundle, error) {
+	args := bbc.Called(jobData, beneficiaryID)
+	return args.Get(0).(*fhirModels.Bundle), args.Error(1)
 }
 
-func (bbc *MockBlueButtonClient) GetClaim(mbi, jobID, cmsID, since string, transactionTime time.Time, claimsWindow ClaimsWindow) (*models.Bundle, error) {
-	args := bbc.Called(mbi, jobID, cmsID, since, transactionTime, claimsWindow)
-	return args.Get(0).(*models.Bundle), args.Error(1)
+func (bbc *MockBlueButtonClient) GetClaim(jobData models.JobEnqueueArgs, mbi string, claimsWindow ClaimsWindow) (*fhirModels.Bundle, error) {
+	args := bbc.Called(jobData, mbi, claimsWindow)
+	return args.Get(0).(*fhirModels.Bundle), args.Error(1)
 }
 
-func (bbc *MockBlueButtonClient) GetClaimResponse(mbi, jobID, cmsID, since string, transactionTime time.Time, claimsWindow ClaimsWindow) (*models.Bundle, error) {
-	args := bbc.Called(mbi, jobID, cmsID, since, transactionTime, claimsWindow)
-	return args.Get(0).(*models.Bundle), args.Error(1)
+func (bbc *MockBlueButtonClient) GetClaimResponse(jobData models.JobEnqueueArgs, mbi string, claimsWindow ClaimsWindow) (*fhirModels.Bundle, error) {
+	args := bbc.Called(jobData, mbi, claimsWindow)
+	return args.Get(0).(*fhirModels.Bundle), args.Error(1)
 }
 
 // Returns copy of a static json file (From Blue Button Sandbox originally) after replacing the patient ID of 20000000000001 with the requested identifier
@@ -70,13 +70,13 @@ func (bbc *MockBlueButtonClient) GetData(endpoint, patientID string) (string, er
 	return cleanData, err
 }
 
-func (bbc *MockBlueButtonClient) GetBundleData(endpoint, patientID string) (*models.Bundle, error) {
+func (bbc *MockBlueButtonClient) GetBundleData(endpoint, patientID string) (*fhirModels.Bundle, error) {
 	payload, err := bbc.GetData(endpoint, patientID)
 	if err != nil {
 		return nil, err
 	}
 
-	var b models.Bundle
+	var b fhirModels.Bundle
 	err = json.Unmarshal([]byte(payload), &b)
 	if err != nil {
 		return nil, err

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -114,6 +114,7 @@ type CCLFBeneficiary struct {
 type JobEnqueueArgs struct {
 	ID              int
 	ACOID           string
+	CMSID           string
 	BeneficiaryIDs  []string
 	ResourceType    string
 	Since           string

--- a/bcdaworker/worker/bluebutton.go
+++ b/bcdaworker/worker/bluebutton.go
@@ -11,9 +11,9 @@ import (
 
 // This method will ensure that a valid BlueButton ID is returned.
 // If you use cclfBeneficiary.BlueButtonID you will not be guaranteed a valid value
-func getBlueButtonID(bb client.APIClient, mbi string) (blueButtonID string, err error) {
+func getBlueButtonID(bb client.APIClient, mbi string, jobData models.JobEnqueueArgs) (blueButtonID string, err error) {
 	hashedIdentifier := client.HashIdentifier(mbi)
-	jsonData, err := bb.GetPatientByIdentifierHash(hashedIdentifier)
+	jsonData, err := bb.GetPatientByIdentifierHash(jobData, hashedIdentifier)
 	if err != nil {
 		return "", err
 	}

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -201,15 +201,12 @@ func (s *WorkerTestSuite) TestWriteUnsupportedResourceToFile() {
 	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "UnsupportedResourceType")
 	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
 	assert.EqualValues(s.T(), 0, size)
-
-	files, err1 := ioutil.ReadDir(s.stagingDir)
-	assert.NoError(s.T(), err1)
-
 	assert.Error(s.T(), err)
 	assert.Empty(s.T(), uuid)
-	files, err = ioutil.ReadDir(s.stagingDir)
+	files, err := ioutil.ReadDir(s.stagingDir)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), files, 0)
+
 }
 
 func SetupWriteResourceToFile(s *WorkerTestSuite, resource string) (context.Context, models.JobEnqueueArgs, *client.MockBlueButtonClient) {

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -124,112 +125,163 @@ func TestWorkerTestSuite(t *testing.T) {
 	suite.Run(t, new(WorkerTestSuite))
 }
 
-func (s *WorkerTestSuite) TestWriteResourceToFile() {
+func (s *WorkerTestSuite) TestWriteEOBToFile() {
+
+	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "ExplanationOfBenefit")
+	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
+	assert.NotEqual(s.T(), int64(0), size)
+
+	files, err1 := ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), uuid)
+	assert.Len(s.T(), files, 1)
+
+	VerifyFileContent(s.T(), files, "ExplanationOfBenefit", 33, s.jobID)
+}
+
+func (s *WorkerTestSuite) TestWriteCoverageToFile() {
+	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "Coverage")
+	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
+	assert.NotEqual(s.T(), int64(0), size)
+
+	files, err1 := ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), uuid)
+	assert.Len(s.T(), files, 1)
+
+	VerifyFileContent(s.T(), files, "Coverage", 3, s.jobID)
+}
+
+func (s *WorkerTestSuite) TestWritePatientToFile() {
+	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "Patient")
+	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
+	assert.NotEqual(s.T(), int64(0), size)
+
+	files, err1 := ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), uuid)
+	assert.Len(s.T(), files, 1)
+
+	VerifyFileContent(s.T(), files, "Patient", 1, s.jobID)
+}
+
+func (s *WorkerTestSuite) TestWriteClaimToFile() {
+	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "Claim")
+	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
+	assert.NotEqual(s.T(), int64(0), size)
+
+	files, err1 := ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), uuid)
+	assert.Len(s.T(), files, 1)
+
+	VerifyFileContent(s.T(), files, "Claim", 1, s.jobID)
+}
+
+func (s *WorkerTestSuite) TestWriteClaimResponseToFile() {
+	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "ClaimResponse")
+	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
+	assert.NotEqual(s.T(), int64(0), size)
+
+	files, err1 := ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), uuid)
+	assert.Len(s.T(), files, 1)
+
+	VerifyFileContent(s.T(), files, "ClaimResponse", 1, s.jobID)
+
+}
+
+func (s *WorkerTestSuite) TestWriteUnsupportedResourceToFile() {
+	ctx, jobArgs, bbc := SetupWriteResourceToFile(s, "UnsupportedResourceType")
+	uuid, size, err := writeBBDataToFile(ctx, s.r, bbc, *s.testACO.CMSID, jobArgs)
+	assert.EqualValues(s.T(), 0, size)
+
+	files, err1 := ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err1)
+
+	assert.Error(s.T(), err)
+	assert.Empty(s.T(), uuid)
+	files, err = ioutil.ReadDir(s.stagingDir)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), files, 0)
+}
+
+func SetupWriteResourceToFile(s *WorkerTestSuite, resource string) (context.Context, models.JobEnqueueArgs, *client.MockBlueButtonClient) {
 	bbc := client.MockBlueButtonClient{}
 	since, transactionTime := time.Now().Add(-24*time.Hour).Format(time.RFC3339Nano), time.Now()
 	claimsWindow := client.ClaimsWindow{LowerBound: time.Now().Add(-365 * 24 * time.Hour), UpperBound: time.Now().Add(-180 * 24 * time.Hour)}
-
+	jobArgs := models.JobEnqueueArgs{ID: s.jobID, ResourceType: resource, Since: since, TransactionTime: transactionTime, ClaimsWindow: claimsWindow}
 	var cclfBeneficiaryIDs []string
-	// This will cause the expected counts to be doubled
-	for _, beneID := range []string{"a1000003701", "a1000050699"} {
-		bbc.MBI = &beneID
-		cclfBeneficiary := models.CCLFBeneficiary{FileID: s.cclfFile.ID, MBI: beneID, BlueButtonID: beneID}
-		postgrestest.CreateCCLFBeneficiary(s.T(), s.db, &cclfBeneficiary)
-		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
+	beneID := "a1000050699"
+	bbc.MBI = &beneID
+	cclfBeneficiary := models.CCLFBeneficiary{FileID: s.cclfFile.ID, MBI: beneID, BlueButtonID: beneID}
+	postgrestest.CreateCCLFBeneficiary(s.T(), s.db, &cclfBeneficiary)
+	cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
+	jobArgs.BeneficiaryIDs = cclfBeneficiaryIDs
+	ctx := context.Background()
+	ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
+
+	switch resource {
+	case "ExplanationOfBenefit":
 		bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(cclfBeneficiary.MBI)).Return(bbc.GetData("Patient", beneID))
-		bbc.On("GetExplanationOfBenefit", beneID, strconv.Itoa(s.jobID), *s.testACO.CMSID, since, transactionTime,
-			claimsWindowMatcher(claimsWindow.LowerBound, claimsWindow.UpperBound)).Return(bbc.GetBundleData("ExplanationOfBenefit", beneID))
-		bbc.On("GetCoverage", beneID, strconv.Itoa(s.jobID), *s.testACO.CMSID, since, transactionTime).Return(bbc.GetBundleData("Coverage", beneID))
-		bbc.On("GetPatient", beneID, strconv.Itoa(s.jobID), *s.testACO.CMSID, since, transactionTime).Return(bbc.GetBundleData("Patient", beneID))
-		bbc.On("GetClaim", beneID, strconv.Itoa(s.jobID), *s.testACO.CMSID, since, transactionTime,
-			claimsWindowMatcher(claimsWindow.LowerBound, claimsWindow.UpperBound)).Return(bbc.GetBundleData("Claim", beneID))
-		bbc.On("GetClaimResponse", beneID, strconv.Itoa(s.jobID), *s.testACO.CMSID, since, transactionTime,
-			claimsWindowMatcher(claimsWindow.LowerBound, claimsWindow.UpperBound)).Return(bbc.GetBundleData("ClaimResponse", beneID))
+		bbc.On("GetExplanationOfBenefit", jobArgs, beneID, claimsWindowMatcher(claimsWindow.LowerBound, claimsWindow.UpperBound)).Return(bbc.GetBundleData("ExplanationOfBenefit", beneID))
+	case "Coverage":
+		bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(cclfBeneficiary.MBI)).Return(bbc.GetData("Patient", beneID))
+		bbc.On("GetCoverage", jobArgs, beneID).Return(bbc.GetBundleData("Coverage", beneID))
+	case "Patient":
+		bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(cclfBeneficiary.MBI)).Return(bbc.GetData("Patient", beneID))
+		bbc.On("GetPatient", jobArgs, beneID).Return(bbc.GetBundleData("Patient", beneID))
+	case "Claim":
+		bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(cclfBeneficiary.MBI)).Return(bbc.GetData("Patient", beneID))
+		bbc.On("GetClaim", jobArgs, beneID, claimsWindowMatcher(claimsWindow.LowerBound, claimsWindow.UpperBound)).Return(bbc.GetBundleData("Claim", beneID))
+	case "ClaimResponse":
+		bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(cclfBeneficiary.MBI)).Return(bbc.GetData("Patient", beneID))
+		bbc.On("GetClaimResponse", jobArgs, beneID, claimsWindowMatcher(claimsWindow.LowerBound, claimsWindow.UpperBound)).Return(bbc.GetBundleData("ClaimResponse", beneID))
+
 	}
+	return ctx, jobArgs, &bbc
+}
 
-	tests := []struct {
-		resource       string
-		expectedCount  int
-		expectZeroSize bool
-	}{
-		// The expected count is double what a single request returns because we're checking 2 different benes
-		{"ExplanationOfBenefit", 66, false},
-		{"Coverage", 6, false},
-		{"Patient", 2, false},
-		{"Claim", 2, false},
-		{"ClaimResponse", 2, false},
-		{"SomeUnsupportedResource", 0, true},
+func VerifyFileContent(t *testing.T, files []fs.FileInfo, resource string, expectedCount int, jobID int) {
+	for _, f := range files {
+		filePath := fmt.Sprintf(constants.TestFilePathVariable, conf.GetEnv("FHIR_STAGING_DIR"), jobID, f.Name())
+		file, err := os.Open(filePath)
+		if err != nil {
+			t.FailNow()
+		}
+		defer func() {
+			assert.NoError(t, file.Close())
+			assert.NoError(t, os.Remove(filePath))
+		}()
+
+		scanner := bufio.NewScanner(file)
+
+		for i := 0; i < expectedCount; i++ {
+			assert.True(t, scanner.Scan())
+			var jsonOBJ map[string]interface{}
+			err := json.Unmarshal(scanner.Bytes(), &jsonOBJ)
+			assert.Nil(t, err)
+			assert.Equal(t, resource, jsonOBJ["resourceType"])
+			if resource == "ExplanationOfBenefit" || resource == "Coverage" {
+				assert.NotNil(t, jsonOBJ["status"], "JSON should contain a value for `status`.")
+				assert.NotNil(t, jsonOBJ["type"], "JSON should contain a value for `type`.")
+			}
+		}
+		scan := scanner.Scan()
+		assert.False(t, scan, "There should be only %d entries in the file.", expectedCount)
 	}
-
-	for _, tt := range tests {
-		s.T().Run(tt.resource, func(t *testing.T) {
-			jobArgs := models.JobEnqueueArgs{ID: s.jobID, ResourceType: tt.resource, BeneficiaryIDs: cclfBeneficiaryIDs,
-				Since: since, TransactionTime: transactionTime, ClaimsWindow: claimsWindow}
-			ctx := context.Background()
-			ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
-			uuid, size, err := writeBBDataToFile(ctx, s.r, &bbc, *s.testACO.CMSID, jobArgs)
-			if tt.expectZeroSize {
-				assert.EqualValues(t, 0, size)
-			} else {
-				assert.NotEqual(t, int64(0), size)
-			}
-
-			files, err1 := ioutil.ReadDir(s.stagingDir)
-			assert.NoError(t, err1)
-
-			// If we don't expect any files, we must've encountered some error
-			if tt.expectedCount == 0 {
-				assert.Error(t, err)
-				assert.Empty(t, uuid)
-				files, err := ioutil.ReadDir(s.stagingDir)
-				assert.NoError(t, err)
-				assert.Len(t, files, 0)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.NotEmpty(t, uuid)
-			assert.Len(t, files, 1)
-
-			for _, f := range files {
-				filePath := fmt.Sprintf(constants.TestFilePathVariable, conf.GetEnv("FHIR_STAGING_DIR"), s.jobID, f.Name())
-				file, err := os.Open(filePath)
-				if err != nil {
-					s.FailNow(err.Error())
-				}
-				defer func() {
-					assert.NoError(t, file.Close())
-					assert.NoError(t, os.Remove(filePath))
-				}()
-
-				scanner := bufio.NewScanner(file)
-
-				for i := 0; i < tt.expectedCount; i++ {
-					assert.True(t, scanner.Scan())
-					var jsonOBJ map[string]interface{}
-					err := json.Unmarshal(scanner.Bytes(), &jsonOBJ)
-					assert.Nil(t, err)
-					assert.Equal(t, tt.resource, jsonOBJ["resourceType"])
-					if tt.resource == "ExplanationOfBenefit" || tt.resource == "Coverage" {
-						assert.NotNil(t, jsonOBJ["status"], "JSON should contain a value for `status`.")
-						assert.NotNil(t, jsonOBJ["type"], "JSON should contain a value for `type`.")
-					}
-				}
-				assert.False(t, scanner.Scan(), "There should be only %d entries in the file.", tt.expectedCount)
-			}
-		})
-	}
-
-	// After running all of our subtests, we expect that our mocks were called as expected.
-	bbc.AssertExpectations(s.T())
 }
 
 func (s *WorkerTestSuite) TestWriteEmptyResourceToFile() {
 	transactionTime := time.Now()
 
 	bbc := client.MockBlueButtonClient{}
-	// Set up the mock function to return the expected values
-	bbc.On("GetExplanationOfBenefit", "abcdef12000", strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher()).Return(bbc.GetBundleData("ExplanationOfBenefitEmpty", "abcdef12000"))
 	beneficiaryID := "abcdef12000"
 	var cclfBeneficiaryIDs []string
 
@@ -240,6 +292,8 @@ func (s *WorkerTestSuite) TestWriteEmptyResourceToFile() {
 	bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(cclfBeneficiary.MBI)).Return(bbc.GetData("Patient", beneficiaryID))
 
 	jobArgs := models.JobEnqueueArgs{ID: s.jobID, ResourceType: "ExplanationOfBenefit", BeneficiaryIDs: cclfBeneficiaryIDs, TransactionTime: transactionTime, ACOID: s.testACO.UUID.String()}
+	// Set up the mock function to return the expected values
+	bbc.On("GetExplanationOfBenefit", jobArgs, "abcdef12000", client.ClaimsWindow{}).Return(bbc.GetBundleData("ExplanationOfBenefitEmpty", "abcdef12000"))
 	ctx := context.Background()
 	ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
 	_, size, err := writeBBDataToFile(ctx, s.r, &bbc, *s.testACO.CMSID, jobArgs)
@@ -252,12 +306,7 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(
 	defer conf.SetEnv(s.T(), "EXPORT_FAIL_PCT", origFailPct)
 	conf.SetEnv(s.T(), "EXPORT_FAIL_PCT", "70")
 	transactionTime := time.Now()
-
 	bbc := client.MockBlueButtonClient{}
-	// Set up the mock function to return the expected values
-	bbc.On("GetExplanationOfBenefit", "abcdef10000", strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher()).Return(nil, errors.New("error"))
-	bbc.On("GetExplanationOfBenefit", "abcdef11000", strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher()).Return(nil, errors.New("error"))
-	bbc.On("GetExplanationOfBenefit", "abcdef12000", strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher()).Return(bbc.GetBundleData("ExplanationOfBenefit", "abcdef12000"))
 	beneficiaryIDs := []string{"abcdef10000", "abcdef11000", "abcdef12000"}
 	var cclfBeneficiaryIDs []string
 
@@ -271,6 +320,10 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(
 	}
 
 	jobArgs := models.JobEnqueueArgs{ID: s.jobID, ResourceType: "ExplanationOfBenefit", BeneficiaryIDs: cclfBeneficiaryIDs, TransactionTime: transactionTime, ACOID: s.testACO.UUID.String()}
+	// Set up the mock function to return the expected values
+	bbc.On("GetExplanationOfBenefit", jobArgs, "abcdef10000", claimsWindowMatcher()).Return(nil, errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", jobArgs, "abcdef11000", claimsWindowMatcher()).Return(nil, errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", jobArgs, "abcdef12000", claimsWindowMatcher()).Return(bbc.GetBundleData("ExplanationOfBenefit", "abcdef12000"))
 	ctx := context.Background()
 	ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
 	fileUUID, size, err := writeBBDataToFile(ctx, s.r, &bbc, *s.testACO.CMSID, jobArgs)
@@ -278,7 +331,7 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(
 	assert.NoError(s.T(), err)
 
 	errorFilePath := fmt.Sprintf("%s/%d/%s-error.ndjson", conf.GetEnv("FHIR_STAGING_DIR"), s.jobID, fileUUID)
-	fData, err := ioutil.ReadFile(errorFilePath)
+	fData, err := os.ReadFile(errorFilePath)
 	assert.NoError(s.T(), err)
 
 	ooResp := fmt.Sprintf(`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"not-found","details":{"coding":[{"system":"http://hl7.org/fhir/ValueSet/operation-outcome","code":"Blue Button Error","display":"Error retrieving ExplanationOfBenefit for beneficiary MBI abcdef10000 in ACO %s"}],"text":"Error retrieving ExplanationOfBenefit for beneficiary MBI abcdef10000 in ACO %s"}}]}
@@ -298,17 +351,8 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(
 	conf.SetEnv(s.T(), "EXPORT_FAIL_PCT", "60")
 	transactionTime := time.Now()
 
-	bbc := client.MockBlueButtonClient{}
-	// Set up the mock function to return the expected values
-	beneficiaryIDs := []string{"a1000089833", "a1000065301", "a1000012463"}
-	bbc.On("GetExplanationOfBenefit", beneficiaryIDs[0], strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher()).Return(nil, errors.New("error"))
-	bbc.On("GetExplanationOfBenefit", beneficiaryIDs[1], strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher()).Return(nil, errors.New("error"))
-	bbc.MBI = &beneficiaryIDs[0]
-	bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(beneficiaryIDs[0])).Return(bbc.GetData("Patient", beneficiaryIDs[0]))
-	bbc.MBI = &beneficiaryIDs[1]
-	bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(beneficiaryIDs[1])).Return(bbc.GetData("Patient", beneficiaryIDs[1]))
 	var cclfBeneficiaryIDs []string
-
+	beneficiaryIDs := []string{"a1000089833", "a1000065301", "a1000012463"}
 	for i := 0; i < len(beneficiaryIDs); i++ {
 		beneficiaryID := beneficiaryIDs[i]
 		cclfBeneficiary := models.CCLFBeneficiary{FileID: s.cclfFile.ID, MBI: beneficiaryID, BlueButtonID: beneficiaryID}
@@ -317,6 +361,17 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(
 	}
 
 	jobArgs := models.JobEnqueueArgs{ID: s.jobID, ResourceType: "ExplanationOfBenefit", BeneficiaryIDs: cclfBeneficiaryIDs, TransactionTime: transactionTime, ACOID: s.testACO.UUID.String()}
+	bbc := client.MockBlueButtonClient{}
+	// Set up the mock function to return the expected values
+
+	bbc.On("GetExplanationOfBenefit", jobArgs, beneficiaryIDs[0], claimsWindowMatcher()).Return(nil, errors.New("error"))
+	bbc.On("GetExplanationOfBenefit", jobArgs, beneficiaryIDs[1], claimsWindowMatcher()).Return(nil, errors.New("error"))
+	bbc.MBI = &beneficiaryIDs[0]
+	bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(beneficiaryIDs[0])).Return(bbc.GetData("Patient", beneficiaryIDs[0]))
+	bbc.MBI = &beneficiaryIDs[1]
+	bbc.On("GetPatientByIdentifierHash", client.HashIdentifier(beneficiaryIDs[1])).Return(bbc.GetData("Patient", beneficiaryIDs[1]))
+
+	jobArgs.BeneficiaryIDs = cclfBeneficiaryIDs
 	ctx := context.Background()
 	ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
 	_, _, err := writeBBDataToFile(ctx, s.r, &bbc, *s.testACO.CMSID, jobArgs)
@@ -342,7 +397,7 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsAboveFailureThreshold(
 
 	bbc.AssertExpectations(s.T())
 	// should not have requested third beneficiary EOB because failure threshold was reached after second
-	bbc.AssertNotCalled(s.T(), "GetExplanationOfBenefit", beneficiaryIDs[2], strconv.Itoa(s.jobID), *s.testACO.CMSID, "", transactionTime, claimsWindowMatcher())
+	bbc.AssertNotCalled(s.T(), "GetExplanationOfBenefit", jobArgs, beneficiaryIDs[2], claimsWindowMatcher())
 }
 
 func (s *WorkerTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-6594

## 🛠 Changes

Using struct `JobEnqueueArgs` in functions to replace individual arguments of `cmsID` and `jobID`, so that we can include those data points in our requests to BFD. The field of `cmsID` has been added to the model `JobEnqueueArgs`. I ended up the available struct with the additional field because many of the functions that required a changed needed some field data from JobEnqueueArgs. This reducing the number of parameters that functions expect and (hopefully) improves readability.

## ℹ️ Context for reviewers

Our BB client has two methods `GetMetaData` and `GetPatientHashIdentifier` that do not include the job ID or CMS ID in the request headers, which results in those values being empty when the request is logged. 

## ✅ Acceptance Validation

Wrote new test and modified existing; all are passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
