### PR TITLE
BCDA-7480: Add alerting when CCLF-8 import job fails to open a file

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -369,7 +369,7 @@ func setUpApp() *cli.App {
 					return err
 				}
 				if failure > 0 || skipped > 0 {
-					log.API.Error("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details. ", err)
+					log.API.Error("files failed to import or were skipped.  See logs for more details. ", err)
 					cli.NewExitError("some files failed to import or were skipped, see logs for more details", 1)
 					return err
 				}

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -23,6 +23,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/alr/gen"
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	authclient "github.com/CMSgov/bcda-app/bcda/auth/client"
+
 	"github.com/CMSgov/bcda-app/bcda/cclf"
 	cclfUtils "github.com/CMSgov/bcda-app/bcda/cclf/utils"
 	"github.com/CMSgov/bcda-app/bcda/constants"
@@ -362,6 +363,17 @@ func setUpApp() *cli.App {
 			Action: func(c *cli.Context) error {
 				ignoreSignals()
 				success, failure, skipped, err := cclf.ImportCCLFDirectory(filePath)
+				if err != nil {
+					log.API.Error("error returned from ImportCCLFDirectory: ", err)
+					cli.NewExitError("an error occurred during the cclf-import process, see logs for more details", 1)
+					return err
+				}
+				if failure > 0 || skipped > 0 {
+					log.API.Error("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details. ", err)
+					cli.NewExitError("some files failed to import or were skipped, see logs for more details", 1)
+					return err
+				}
+				log.API.Infof("Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)
 				fmt.Fprintf(app.Writer, "Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)
 				return err
 			},

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -365,13 +365,13 @@ func setUpApp() *cli.App {
 				success, failure, skipped, err := cclf.ImportCCLFDirectory(filePath)
 				if err != nil {
 					log.API.Error("error returned from ImportCCLFDirectory: ", err)
-					cli.NewExitError("an error occurred during the cclf-import process, see logs for more details", 1)
-					return err
+					return cli.NewExitError("an error occurred during the cclf-import process, see logs for more details", 1)
+
 				}
 				if failure > 0 || skipped > 0 {
 					log.API.Errorf("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped, err)
-					cli.NewExitError("some files failed to import or were skipped, see logs for more details", 1)
-					return err
+					return cli.NewExitError("some files failed to import or were skipped, see logs for more details", 1)
+
 				}
 				log.API.Infof("Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)
 				fmt.Fprintf(app.Writer, "Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -365,12 +365,13 @@ func setUpApp() *cli.App {
 				success, failure, skipped, err := cclf.ImportCCLFDirectory(filePath)
 				if err != nil {
 					log.API.Error("error returned from ImportCCLFDirectory: ", err)
-					return cli.NewExitError("an error occurred during the cclf-import process, see logs for more details", 1)
+					return err
 
 				}
 				if failure > 0 || skipped > 0 {
 					log.API.Errorf("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped, err)
-					return cli.NewExitError("some files failed to import or were skipped, see logs for more details", 1)
+					err = errors.New("Files skipped or failed import. See logs for more details.")
+					return err
 
 				}
 				log.API.Infof("Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -369,7 +369,7 @@ func setUpApp() *cli.App {
 					return err
 				}
 				if failure > 0 || skipped > 0 {
-					log.API.Error("files failed to import or were skipped.  See logs for more details. ", err)
+					log.API.Errorf("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped, err)
 					cli.NewExitError("some files failed to import or were skipped, see logs for more details", 1)
 					return err
 				}

--- a/bcda/bcdacli/cli_test.go
+++ b/bcda/bcdacli/cli_test.go
@@ -711,7 +711,7 @@ func (s *CLITestSuite) TestImportCCLFDirectory() {
 
 	args := []string{"bcda", "import-cclf-directory", constants.DirectoryArg, path}
 	err := s.testApp.Run(args)
-	assert.Nil(err)
+	assert.NotNil(err)
 	var success, failed, skipped bool
 	for _, entry := range hook.AllEntries() {
 		if strings.Contains(entry.Message, "Successfully imported 2 files.") {
@@ -727,6 +727,7 @@ func (s *CLITestSuite) TestImportCCLFDirectory() {
 	assert.True(success)
 	assert.True(failed)
 	assert.True(skipped)
+
 }
 
 func (s *CLITestSuite) TestDeleteDirectoryContents() {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7480

## 🛠 Changes

Updated the cli command `import-cclf-directory` to return the error when one occurs. If no errors come from the `importcclfdirectory` function in cli.go but a file is skipped or fails import, then a new error is created and returned to be handled by the jenkins script.

## ℹ️ Context for reviewers

Jenkins pipeline currently always runs successfully even if cclf files are skipped or fail to import. 

## ✅ Acceptance Validation

Tests still passing. This jenkins pipeline does not have the option to run from a development branch, for both the pipeline and the app. This will need to be deployed and a mock test file will need to be created in order to test. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
