### PR TITLE
BCDA-7565: Support multiple localstack S3 statuses in healthcheck

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -50,7 +50,7 @@ services:
       - "./.localstack_volume:/var/lib/localstack"
       - '/var/run/docker.sock:/var/run/docker.sock'
     healthcheck:
-      test: "curl --silent --fail localstack:4566/_localstack/health | grep -E '"s3": "(available|running)"'
+      test: "curl --silent --fail localstack:4566/_localstack/health | grep -E '\"s3\": \"(available|running)\"'"
       interval: 10s
       retries: 12
       start_period: 30s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -50,7 +50,7 @@ services:
       - "./.localstack_volume:/var/lib/localstack"
       - '/var/run/docker.sock:/var/run/docker.sock'
     healthcheck:
-      test: "curl --silent --fail localstack:4566/_localstack/health | grep '\"s3\": \"available\"'"
+      test: "curl --silent --fail localstack:4566/_localstack/health | grep -E '"s3": "(available|running)"'
       interval: 10s
       retries: 12
       start_period: 30s


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7565

## 🛠 Changes

- Fix intermittent failures in testing

## ℹ️ Context for reviewers

## ✅ Acceptance Validation

Still works locally:

```
655760bcea69   localstack/localstack:latest                                          "docker-entrypoint.sh"   29 seconds ago   Up 22 seconds (healthy)   4510-4559/tcp, 5678/tcp, 0.0.0.0:4566-4583->4566-4583/tcp   bcda-app-localstack-1
```

Should work on Jenkins (see PR checks?)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
