### PR TITLE
BCDA-7494: Add 2024 undo-runout script

### DIFF
--- a/db/migrations/manual/20240131-runout-undo.sql
+++ b/db/migrations/manual/20240131-runout-undo.sql
@@ -1,0 +1,18 @@
+-- This is a manual DB wrangle to convert Dec CCLF attribution into runouts
+-- We will undo this and convert back to Dec CCLF once the runout for 2024 is received
+
+BEGIN;
+DO $$
+
+DECLARE cclfids integer ARRAY;
+BEGIN
+cclfids := ARRAY(SELECT id FROM cclf_files WHERE timestamp > '2023-11-30' AND type = 1 AND timestamp < '2024-01-01' AND aco_cms_id NOT LIKE ALL(ARRAY['A999%', 'V99%', 'E999%']);
+
+-- Compare this output with what you may have stored in keybase
+raise notice 'Following IDs affected: %', cclfids;
+UPDATE cclf_files SET type = 0 where id = ANY(cclfids);
+END;
+
+$$;
+
+COMMIT;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7494

## 🛠 Changes

Updated Undo-runout script to refer to 2024 instead of 2023.

## ℹ️ Context for reviewers

Will not be run until mid-late January, hence naming.

## ✅ Acceptance Validation

Manual verification

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
