### PR TITLE
BCDA-7602: Add Transaction ID to log events

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -447,7 +447,7 @@ func (h *Handler) getAttributionFileStatus(ctx context.Context, CMSID string, fi
 func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType service.RequestType) {
 	// Create context to encapsulate the entire workflow. In the future, we can define child context's for timing.
 	ctx := r.Context()
-	logger := log.GetCtxLogger(r.Context())
+	logger := log.GetCtxLogger(ctx)
 
 	var (
 		ad  auth.AuthData

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database/databasetest"
+	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -905,8 +906,8 @@ func (s *RequestsTestSuite) TestJobFailedStatus() {
 			rctx.URLParams.Add("jobID", "1")
 
 			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-			req = req.WithContext(ctx)
-			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			ctx = context.WithValue(ctx, logging.CtxTransactionKey, uuid.New())
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{})
 			req = req.WithContext(context.WithValue(ctx, log.CtxLoggerKey, newLogEntry))
 
 			w := httptest.NewRecorder()

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -350,7 +350,6 @@ func (bbc *BlueButtonClient) getRawData(jobData models.JobEnqueueArgs, u *url.UR
 			return err
 		}
 		addDefaultRequestHeaders(req, uuid.NewRandom(), jobData)
-		// add transaction ID to req context
 		result, err = bbc.client.DoRaw(req)
 		if err != nil {
 			logger.Error(err)

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -36,8 +36,9 @@ import (
 var logger logrus.FieldLogger
 
 const (
-	clientIDHeader = "BULK-CLIENTID"
-	jobIDHeader    = "BULK-JOBID"
+	clientIDHeader      = "BULK-CLIENTID"
+	jobIDHeader         = "BULK-JOBID"
+	transactionIDHeader = "TRANSACTIONID"
 )
 
 // BlueButtonConfig holds the configuration settings needed to create a BlueButtonClient
@@ -310,7 +311,7 @@ func (bbc *BlueButtonClient) tryBundleRequest(u *url.URL, jobData models.JobEnqu
 		}
 
 		queryID := uuid.NewRandom()
-		addDefaultRequestHeaders(req, queryID, strconv.Itoa(jobData.ID), jobData.CMSID)
+		addDefaultRequestHeaders(req, queryID, jobData)
 
 		result, nextURL, err = bbc.client.DoBundleRequest(req)
 		if err != nil {
@@ -348,8 +349,8 @@ func (bbc *BlueButtonClient) getRawData(jobData models.JobEnqueueArgs, u *url.UR
 			logger.Error(err)
 			return err
 		}
-		addDefaultRequestHeaders(req, uuid.NewRandom(), strconv.Itoa(jobData.ID), jobData.CMSID)
-
+		addDefaultRequestHeaders(req, uuid.NewRandom(), jobData)
+		// add transaction ID to req context
 		result, err = bbc.client.DoRaw(req)
 		if err != nil {
 			logger.Error(err)
@@ -379,7 +380,7 @@ func (bbc *BlueButtonClient) getURL(path string, params url.Values) (*url.URL, e
 	return u, nil
 }
 
-func addDefaultRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID string) {
+func addDefaultRequestHeaders(req *http.Request, reqID uuid.UUID, jobData models.JobEnqueueArgs) {
 	// Info for BB backend: https://jira.cms.gov/browse/BLUEBUTTON-483
 	req.Header.Add("keep-alive", "")
 	req.Header.Add(constants.BBHeaderTS, time.Now().String())
@@ -388,8 +389,9 @@ func addDefaultRequestHeaders(req *http.Request, reqID uuid.UUID, jobID, cmsID s
 	req.Header.Add(constants.BBHeaderOriginURL, req.URL.String())
 	req.Header.Add(constants.BBHeaderOriginQ, req.URL.RawQuery)
 	req.Header.Add("IncludeIdentifiers", "mbi")
-	req.Header.Add(jobIDHeader, jobID)
-	req.Header.Add(clientIDHeader, cmsID)
+	req.Header.Add(jobIDHeader, strconv.Itoa(jobData.ID))
+	req.Header.Add(clientIDHeader, jobData.CMSID)
+	req.Header.Add(transactionIDHeader, jobData.TransactionID)
 
 	// We SHOULD NOT be specifying "Accept-Encoding: gzip" on the request header.
 	// If we specify this header at the client level, then we must be responsible for decompressing the response.
@@ -472,11 +474,12 @@ func (h *httpLogger) logRequest(req *http.Request) {
 
 func (h *httpLogger) logResponse(req *http.Request, resp *http.Response) {
 	h.l.WithFields(logrus.Fields{
-		"resp_code":   resp.StatusCode,
-		"bb_query_id": req.Header.Get(constants.BBHeaderOriginQID),
-		"bb_query_ts": req.Header.Get(constants.BBHeaderTS),
-		"bb_uri":      req.URL.String(),
-		"job_id":      req.Header.Get(jobIDHeader),
-		"cms_id":      req.Header.Get(clientIDHeader),
+		"resp_code":      resp.StatusCode,
+		"bb_query_id":    req.Header.Get(constants.BBHeaderOriginQID),
+		"bb_query_ts":    req.Header.Get(constants.BBHeaderTS),
+		"bb_uri":         req.URL.String(),
+		"job_id":         req.Header.Get(jobIDHeader),
+		"cms_id":         req.Header.Get(clientIDHeader),
+		"transaction_id": req.Header.Get(transactionIDHeader),
 	}).Infoln("response")
 }

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/auth"
@@ -20,7 +21,6 @@ import (
 )
 
 // https://github.com/go-chi/chi/blob/master/_examples/logging/main.go
-
 func NewStructuredLogger() func(next http.Handler) http.Handler {
 	return middleware.RequestLogger(&StructuredLogger{Logger: log.Request})
 }
@@ -59,6 +59,8 @@ func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 		logFields["token_id"] = ad.TokenID
 		logFields["cms_id"] = ad.CMSID
 	}
+
+	logFields["transaction_id"] = r.Context().Value(CtxTransactionKey).(string)
 
 	entry.Logger = entry.Logger.WithFields(logFields)
 
@@ -122,8 +124,23 @@ func NewCtxLogger(next http.Handler) http.Handler {
 		if ad, ok := r.Context().Value(auth.AuthDataContextKey).(auth.AuthData); ok {
 			logFields["cms_id"] = ad.CMSID
 		}
+		logFields["transaction_id"] = r.Context().Value(CtxTransactionKey).(string)
 		newLogEntry := &log.StructuredLoggerEntry{Logger: log.API.WithFields(logFields)}
 		r = r.WithContext(context.WithValue(r.Context(), log.CtxLoggerKey, newLogEntry))
+		next.ServeHTTP(w, r)
+	})
+}
+
+// type to create context.Context key
+type CtxTransactionKeyType string
+
+// context.Context key to get the transaction ID from the request context
+const CtxTransactionKey CtxTransactionKeyType = "ctxTransaction"
+
+// Adds a transaction ID to the request context
+func TransactionHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(context.WithValue(r.Context(), CtxTransactionKey, uuid.New().String()))
 		next.ServeHTTP(w, r)
 	})
 }

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -60,7 +60,9 @@ func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 		logFields["cms_id"] = ad.CMSID
 	}
 
-	logFields["transaction_id"] = r.Context().Value(CtxTransactionKey).(string)
+	if tid, ok := r.Context().Value(CtxTransactionKey).(string); ok {
+		logFields["transaction_id"] = tid
+	}
 
 	entry.Logger = entry.Logger.WithFields(logFields)
 
@@ -138,7 +140,7 @@ type CtxTransactionKeyType string
 const CtxTransactionKey CtxTransactionKeyType = "ctxTransaction"
 
 // Adds a transaction ID to the request context
-func TransactionHandler(next http.Handler) http.Handler {
+func NewTransactionID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r = r.WithContext(context.WithValue(r.Context(), CtxTransactionKey, uuid.New().String()))
 		next.ServeHTTP(w, r)

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -33,7 +33,7 @@ type LoggingMiddlewareTestSuite struct {
 
 func (s *LoggingMiddlewareTestSuite) CreateRouter() http.Handler {
 	r := chi.NewRouter()
-	r.Use(middleware.RequestID, logging.TransactionHandler, contextToken, logging.NewStructuredLogger(), middleware.Recoverer)
+	r.Use(middleware.RequestID, logging.NewTransactionID, contextToken, logging.NewStructuredLogger(), middleware.Recoverer)
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		// Base server route for logging tests to be checked, blank return for overrides
 	})
@@ -240,7 +240,7 @@ func TestMiddlewareLogCtx(t *testing.T) {
 		}
 	})
 
-	handlerToTest := contextToken(middleware.RequestID(logging.TransactionHandler(logging.NewCtxLogger(nextHandler))))
+	handlerToTest := contextToken(middleware.RequestID(logging.NewTransactionID(logging.NewCtxLogger(nextHandler))))
 	req := httptest.NewRequest("GET", "http://testing", nil)
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
 }
@@ -253,7 +253,7 @@ func TestMiddlewareTransactionCtx(t *testing.T) {
 		}
 	})
 
-	handlerToTest := logging.TransactionHandler(nextHandler)
+	handlerToTest := logging.NewTransactionID(nextHandler)
 	req := httptest.NewRequest("GET", "http://testing", nil)
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
 

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -118,6 +118,7 @@ type JobEnqueueArgs struct {
 	BeneficiaryIDs  []string
 	ResourceType    string
 	Since           string
+	TransactionID   string
 	TransactionTime time.Time
 	BBBasePath      string
 	ClaimsWindow    struct {

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
@@ -669,8 +670,8 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			}
 			serviceInstance := NewService(repository, cfg, basePath)
 			serviceInstance.(*service).acoConfigs = acoCfgs
-
-			queJobs, err := serviceInstance.GetQueJobs(context.Background(), conditions)
+			ctx := context.Background()
+			queJobs, err := serviceInstance.GetQueJobs(context.WithValue(ctx, logging.CtxTransactionKey, uuid.New()), conditions)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID
 			benesInJob := make(map[string]map[string]struct{})
@@ -808,8 +809,8 @@ func (s *ServiceTestSuite) TestGetQueJobsByDataType() {
 			}
 			serviceInstance := NewService(repository, cfg, basePath)
 			serviceInstance.(*service).acoConfigs = acoCfgs
-
-			queJobs, err := serviceInstance.GetQueJobs(context.Background(), conditions)
+			ctx := context.Background()
+			queJobs, err := serviceInstance.GetQueJobs(context.WithValue(ctx, logging.CtxTransactionKey, uuid.New()), conditions)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID
 			benesInJob := make(map[string]map[string]struct{})

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -30,7 +30,7 @@ var commonAuth = []func(http.Handler) http.Handler{
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.TransactionHandler, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui/v1"))
@@ -88,7 +88,7 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	return auth.NewAuthRouter(gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	return auth.NewAuthRouter(gcmw.RequestID, logging.TransactionHandler, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 }
 
 func NewDataRouter() http.Handler {
@@ -97,7 +97,7 @@ func NewDataRouter() http.Handler {
 	resourceTypeLogger := &logging.ResourceTypeLogger{
 		Repository: postgres.NewRepository(database.Connection),
 	}
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.TransactionHandler, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 	r.With(append(
 		commonAuth,
 		auth.RequireTokenJobMatch,
@@ -109,7 +109,7 @@ func NewDataRouter() http.Handler {
 func NewHTTPRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.TransactionHandler, logging.NewCtxLogger)
 	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		url := "https://" + req.Host + req.URL.String()
 		http.Redirect(w, req, url, http.StatusMovedPermanently)

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -30,7 +30,7 @@ var commonAuth = []func(http.Handler) http.Handler{
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.TransactionHandler, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui/v1"))
@@ -88,7 +88,7 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	return auth.NewAuthRouter(gcmw.RequestID, logging.TransactionHandler, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	return auth.NewAuthRouter(gcmw.RequestID, logging.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 }
 
 func NewDataRouter() http.Handler {
@@ -97,7 +97,7 @@ func NewDataRouter() http.Handler {
 	resourceTypeLogger := &logging.ResourceTypeLogger{
 		Repository: postgres.NewRepository(database.Connection),
 	}
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.TransactionHandler, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 	r.With(append(
 		commonAuth,
 		auth.RequireTokenJobMatch,
@@ -109,7 +109,7 @@ func NewDataRouter() http.Handler {
 func NewHTTPRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.TransactionHandler, logging.NewCtxLogger)
+	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.NewTransactionID, logging.NewCtxLogger)
 	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		url := "https://" + req.Host + req.URL.String()
 		http.Redirect(w, req, url, http.StatusMovedPermanently)

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -73,7 +73,8 @@ func (w *worker) ProcessJob(ctx context.Context, job models.Job, jobArgs models.
 		return err
 	}
 
-	ctx, logger := log.SetCtxLogger(ctx, "cms_id", aco.CMSID)
+	ctx, _ = log.SetCtxLogger(ctx, "cms_id", aco.CMSID)
+	ctx, logger := log.SetCtxLogger(ctx, "transaction_id", jobArgs.TransactionID)
 
 	err = w.r.UpdateJobStatusCheckStatus(ctx, job.ID, models.JobStatusPending, models.JobStatusInProgress)
 	if goerrors.Is(err, repository.ErrJobNotUpdated) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -78,7 +78,7 @@ func logger(logger *logrus.Logger, outputFile string,
 		"version":     constants.Version})
 }
 
-// type to create context.Contest key
+// type to create context.Context key
 type CtxLoggerKeyType string
 
 // context.Context key to set/get logrus.FieldLogger value within request context


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7602

## 🛠 Changes

Added:
- middleware that adds a transaction ID to the incoming requests context
- request headers in the BB client to include the transaction ID
- field of `TransactionID` to model JobEnqueueArgs to pass identifier to worker/job processing


Updated:
- tests to check for log messages
- updated deprecated `ioutil`

Removed:
- unused code

## ℹ️ Context for reviewers

Adding transaction ID to all log events between api, worker, ssas, and BFD so we can have better visibility into system health and alerts.

## ✅ Acceptance Validation

- added and modified tests; tests pass. 
- ran locally and verified transaction ID was added to log statements.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
