### PR TITLE
BCDA-7610: Add logging to WriteBBToFile

### DIFF
--- a/bcdaworker/queueing/manager/que.go
+++ b/bcdaworker/queueing/manager/que.go
@@ -115,7 +115,8 @@ func (q *queue) processJob(job *que.Job) error {
 	}
 
 	ctx = log.NewStructuredLoggerEntry(log.Worker, ctx)
-	ctx, logger := log.SetCtxLogger(ctx, "job_id", jobArgs.ID)
+	ctx, _ = log.SetCtxLogger(ctx, "job_id", jobArgs.ID)
+	ctx, logger := log.SetCtxLogger(ctx, "transaction_id", jobArgs.TransactionID)
 
 	exportJob, err := q.worker.ValidateJob(ctx, jobArgs)
 	if goerrors.Is(err, worker.ErrParentJobCancelled) {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7610

## 🛠 Changes

- Added logging statement back to `WriteBBToFile`; it was removed in a [previous PR](https://github.com/CMSgov/bcda-app/commit/7398aef93051d8417d5a7a586d19c218b9df0fc2#diff-d42a7d3de9fe41fcee5e61a5d01e675b0b6e4bf0b1e0b3b1745e328cdb16386cL265) to reduce duplicate logs.
- removed unneeded `else` statement to reduce nesting in `ProcessJob`
- removed duplicate log statement in `ProcessJob`
- add the transaction ID to the log entry in `que.processJob` to ensure we still get the ID in log statements called from that function

## ℹ️ Context for reviewers

We have been getting error alerts for HTTP 500s from the job/ endpoint. After further investigation, it appears that the job is failing when attempting to write data to the file in WriteBBToFile and the job eventually fails after a threshold of errors has been met. When the job has failed and a consumer attempts to check the status or retrieve the bulk file, it returns an HTTP 500, hence the error.

These changes will give us visibility into why the failures while writing to the file occurred and we can continue troubleshooting from there.

## ✅ Acceptance Validation

Tests pass, verified logs locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
