### PR TITLE
BCDA-7655: Update BCDA database settings

### DIFF
--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -56,8 +56,8 @@ func NewSSASClient() (*SSASClient, error) {
 
 	var timeout int
 	if timeout, err = strconv.Atoi(conf.GetEnv("SSAS_TIMEOUT_MS")); err != nil {
-		log.SSAS.Warn(errors.Wrap(err, "Could not get SSAS timeout from environment variable; using default value of 500."))
-		timeout = 500
+		log.SSAS.Warn(errors.Wrap(err, "Could not get SSAS timeout from environment variable; using default value of 5000."))
+		timeout = 5000
 	}
 
 	ssasURL := conf.GetEnv("SSAS_URL")

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -124,8 +124,8 @@ func NewBlueButtonClient(config BlueButtonConfig) (*BlueButtonClient, error) {
 	}
 	var timeout int
 	if timeout, err = strconv.Atoi(conf.GetEnv("BB_TIMEOUT_MS")); err != nil {
-		logger.Warn(errors.Wrap(err, "Could not get Blue Button timeout from environment variable; using default value of 500."))
-		timeout = 500
+		logger.Warn(errors.Wrap(err, "Could not get Blue Button timeout from environment variable; using default value of 45000."))
+		timeout = 45000
 	}
 
 	hl := &httpLogger{transport, logger}

--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -124,8 +124,8 @@ func NewBlueButtonClient(config BlueButtonConfig) (*BlueButtonClient, error) {
 	}
 	var timeout int
 	if timeout, err = strconv.Atoi(conf.GetEnv("BB_TIMEOUT_MS")); err != nil {
-		logger.Warn(errors.Wrap(err, "Could not get Blue Button timeout from environment variable; using default value of 45000."))
-		timeout = 45000
+		logger.Warn(errors.Wrap(err, "Could not get Blue Button timeout from environment variable; using default value of 10000."))
+		timeout = 10000
 	}
 
 	hl := &httpLogger{transport, logger}

--- a/bcda/database/config.go
+++ b/bcda/database/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Config struct {
-	MaxOpenConns       int `conf:"BCDA_DB_MAX_OPEN_CONNS" conf_default:"40"`
+	MaxOpenConns       int `conf:"BCDA_DB_MAX_OPEN_CONNS" conf_default:"60"`
 	MaxIdleConns       int `conf:"BCDA_DB_MAX_IDLE_CONNS" conf_default:"40"`
 	ConnMaxLifetimeMin int `conf:"BCDA_DB_CONN_MAX_LIFETIME_MIN" conf_default:"5"`
+	ConnMaxIdleTime    int `conf:"BCDA_DB_CONN_MAX_IDLE_TIME" conf_default:"30"`
 
 	DatabaseURL      string `conf:"DATABASE_URL"`
 	QueueDatabaseURL string `conf:"QUEUE_DATABASE_URL"`

--- a/bcda/database/connection.go
+++ b/bcda/database/connection.go
@@ -60,6 +60,7 @@ func createDB(cfg *Config) (*sql.DB, error) {
 	db.SetMaxOpenConns(cfg.MaxOpenConns)
 	db.SetMaxIdleConns(cfg.MaxIdleConns)
 	db.SetConnMaxLifetime(time.Duration(cfg.ConnMaxLifetimeMin) * time.Minute)
+	db.SetConnMaxIdleTime(time.Duration(cfg.ConnMaxIdleTime) * time.Second)
 
 	if err := db.Ping(); err != nil {
 		return nil, err


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7655

## 🛠 Changes

Updated maximum number of DB connections from 40 -> 60
Added idle connection timeout

## ℹ️ Context for reviewers

There are inefficiencies in connection handling for the go postgres / sql libraries that we use, and these settings should help mitigate those inefficiencies by pruning idle connections. Specifically, the pgx library doesn't check if a connection is active before trying to use it, and an aggressive idle timeout should reduce the number of instances where a stale connection is thought to be available. 
I also updated some default configs for timeouts for worker-> BB + app-> SSAS to reflect the configs that are actually deployed. In the case of app -> SSAS, the timeout was 1/10 what we actually deploy as an env var, and BB was 1/20. 

## ✅ Acceptance Validation

Manual verification of information in the commit

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
