### PR TITLE
BCDA-7411: pass transaction ID to SSAS

### DIFF
--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/client"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database/databasetest"
-	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -32,6 +31,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcdaworker/queueing"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
+	appMiddleware "github.com/CMSgov/bcda-app/middleware"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/pborman/uuid"
@@ -906,7 +906,7 @@ func (s *RequestsTestSuite) TestJobFailedStatus() {
 			rctx.URLParams.Add("jobID", "1")
 
 			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
-			ctx = context.WithValue(ctx, logging.CtxTransactionKey, uuid.New())
+			ctx = context.WithValue(ctx, appMiddleware.CtxTransactionKey, uuid.New())
 			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{})
 			req = req.WithContext(context.WithValue(ctx, log.CtxLoggerKey, newLogEntry))
 

--- a/bcda/auth/api.go
+++ b/bcda/auth/api.go
@@ -41,7 +41,7 @@ func GetAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenInfo, err := GetProvider().MakeAccessToken(Credentials{ClientID: clientId, ClientSecret: secret})
+	tokenInfo, err := GetProvider().MakeAccessToken(Credentials{ClientID: clientId, ClientSecret: secret}, r)
 	if err != nil {
 
 		switch err.(type) {

--- a/bcda/auth/mock_provider.go
+++ b/bcda/auth/mock_provider.go
@@ -3,6 +3,8 @@
 package auth
 
 import (
+	"net/http"
+
 	jwt "github.com/dgrijalva/jwt-go"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -34,7 +36,7 @@ func (_m *MockProvider) GetVersion() (string, error) {
 }
 
 // MakeAccessToken provides a mock function with given fields: credentials
-func (_m *MockProvider) MakeAccessToken(credentials Credentials) (string, error) {
+func (_m *MockProvider) MakeAccessToken(credentials Credentials, r *http.Request) (string, error) {
 	ret := _m.Called(credentials)
 
 	var r0 string

--- a/bcda/auth/provider.go
+++ b/bcda/auth/provider.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -79,7 +80,7 @@ type Provider interface {
 	RevokeSystemCredentials(clientID string) error
 
 	// MakeAccessToken mints an access token for the given credentials
-	MakeAccessToken(credentials Credentials) (string, error)
+	MakeAccessToken(credentials Credentials, r *http.Request) (string, error)
 
 	// RevokeAccessToken a specific access token identified in a base64 encoded token string
 	RevokeAccessToken(tokenString string) error

--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/dgrijalva/jwt-go"
@@ -95,8 +96,8 @@ func (s SSASPlugin) RevokeSystemCredentials(ssasID string) error {
 }
 
 // MakeAccessToken mints an access token for the given credentials.
-func (s SSASPlugin) MakeAccessToken(credentials Credentials) (string, error) {
-	tokenInfo, err := s.client.GetToken(client.Credentials{ClientID: credentials.ClientID, ClientSecret: credentials.ClientSecret})
+func (s SSASPlugin) MakeAccessToken(credentials Credentials, r *http.Request) (string, error) {
+	tokenInfo, err := s.client.GetToken(client.Credentials{ClientID: credentials.ClientID, ClientSecret: credentials.ClientSecret}, *r)
 	if err != nil {
 		log.SSAS.Errorf("Failed to get token; %s", err.Error())
 		return "", err

--- a/bcda/auth/ssas_test.go
+++ b/bcda/auth/ssas_test.go
@@ -212,33 +212,35 @@ func (s *SSASPluginTestSuite) TestMakeAccessToken() {
 	}
 	s.p = SSASPlugin{client: c, repository: s.r}
 
-	tokenInfo, err := s.p.MakeAccessToken(Credentials{ClientID: "mock-client", ClientSecret: "mock-secret"})
+	r := testUtils.ContextTransactionID()
+
+	tokenInfo, err := s.p.MakeAccessToken(Credentials{ClientID: "mock-client", ClientSecret: "mock-secret"}, r)
 	assert.Nil(s.T(), err)
 	assert.NotEmpty(s.T(), string(tokenInfo))
 	assert.Contains(s.T(), string(tokenInfo), constants.ExpiresInDefault)
 	assert.Regexp(s.T(), regexp.MustCompile(`[^.\s]+\.[^.\s]+\.[^.\s]+`), string(tokenInfo))
 
-	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientID: "sad", ClientSecret: "customer"})
+	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientID: "sad", ClientSecret: "customer"}, r)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), string(tokenInfo))
 	assert.Contains(s.T(), err.Error(), "401")
 
-	tokenInfo, err = s.p.MakeAccessToken(Credentials{})
+	tokenInfo, err = s.p.MakeAccessToken(Credentials{}, r)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), string(tokenInfo))
 	assert.Contains(s.T(), err.Error(), "401")
 
-	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientID: uuid.NewRandom().String()})
+	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientID: uuid.NewRandom().String()}, r)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), string(tokenInfo))
 	assert.Contains(s.T(), err.Error(), "401")
 
-	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientSecret: testUtils.RandomBase64(20)})
+	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientSecret: testUtils.RandomBase64(20)}, r)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), string(tokenInfo))
 	assert.Contains(s.T(), err.Error(), "401")
 
-	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientID: uuid.NewRandom().String(), ClientSecret: testUtils.RandomBase64(20)})
+	tokenInfo, err = s.p.MakeAccessToken(Credentials{ClientID: uuid.NewRandom().String(), ClientSecret: testUtils.RandomBase64(20)}, r)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), string(tokenInfo))
 	assert.Contains(s.T(), err.Error(), "401")

--- a/bcda/logging/middleware_test.go
+++ b/bcda/logging/middleware_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
+	appMiddleware "github.com/CMSgov/bcda-app/middleware"
 )
 
 type LoggingMiddlewareTestSuite struct {
@@ -33,7 +34,7 @@ type LoggingMiddlewareTestSuite struct {
 
 func (s *LoggingMiddlewareTestSuite) CreateRouter() http.Handler {
 	r := chi.NewRouter()
-	r.Use(middleware.RequestID, logging.NewTransactionID, contextToken, logging.NewStructuredLogger(), middleware.Recoverer)
+	r.Use(middleware.RequestID, appMiddleware.NewTransactionID, contextToken, logging.NewStructuredLogger(), middleware.Recoverer)
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		// Base server route for logging tests to be checked, blank return for overrides
 	})
@@ -240,20 +241,20 @@ func TestMiddlewareLogCtx(t *testing.T) {
 		}
 	})
 
-	handlerToTest := contextToken(middleware.RequestID(logging.NewTransactionID(logging.NewCtxLogger(nextHandler))))
+	handlerToTest := contextToken(middleware.RequestID(appMiddleware.NewTransactionID(logging.NewCtxLogger(nextHandler))))
 	req := httptest.NewRequest("GET", "http://testing", nil)
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
 }
 
 func TestMiddlewareTransactionCtx(t *testing.T) {
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		trans := r.Context().Value(logging.CtxTransactionKey).(string)
+		trans := r.Context().Value(appMiddleware.CtxTransactionKey).(string)
 		if trans == "" {
 			t.Error("no transaction id in context")
 		}
 	})
 
-	handlerToTest := logging.NewTransactionID(nextHandler)
+	handlerToTest := appMiddleware.NewTransactionID(nextHandler)
 	req := httptest.NewRequest("GET", "http://testing", nil)
 	handlerToTest.ServeHTTP(httptest.NewRecorder(), req)
 

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -13,11 +13,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/CMSgov/bcda-app/bcda/constants"
-	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
+	"github.com/CMSgov/bcda-app/middleware"
 )
 
 type RequestConditions struct {
@@ -300,7 +300,7 @@ func (s *service) createQueueJobs(ctx context.Context, conditions RequestConditi
 									BeneficiaryIDs:  jobIDs,
 									ResourceType:    rt,
 									Since:           sinceArg,
-									TransactionID:   ctx.Value(logging.CtxTransactionKey).(string),
+									TransactionID:   ctx.Value(middleware.CtxTransactionKey).(string),
 									TransactionTime: transactionTime,
 									BBBasePath:      s.bbBasePath,
 									DataType:        dataType,

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/bcda/logging"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/middleware"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -671,7 +671,7 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			serviceInstance := NewService(repository, cfg, basePath)
 			serviceInstance.(*service).acoConfigs = acoCfgs
 			ctx := context.Background()
-			queJobs, err := serviceInstance.GetQueJobs(context.WithValue(ctx, logging.CtxTransactionKey, uuid.New()), conditions)
+			queJobs, err := serviceInstance.GetQueJobs(context.WithValue(ctx, middleware.CtxTransactionKey, uuid.New()), conditions)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID
 			benesInJob := make(map[string]map[string]struct{})
@@ -810,7 +810,7 @@ func (s *ServiceTestSuite) TestGetQueJobsByDataType() {
 			serviceInstance := NewService(repository, cfg, basePath)
 			serviceInstance.(*service).acoConfigs = acoCfgs
 			ctx := context.Background()
-			queJobs, err := serviceInstance.GetQueJobs(context.WithValue(ctx, logging.CtxTransactionKey, uuid.New()), conditions)
+			queJobs, err := serviceInstance.GetQueJobs(context.WithValue(ctx, middleware.CtxTransactionKey, uuid.New()), conditions)
 			assert.NoError(t, err)
 			// map tuple of resourceType:beneID
 			benesInJob := make(map[string]map[string]struct{})

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -459,7 +459,8 @@ func MakeTestServerWithInternalServerErrAuthTokenRequest() *httptest.Server {
 }
 
 func ContextTransactionID() *http.Request {
-	r := httptest.NewRequest("GET", "http://bcda.cms.gov/api/v1/Group/$export", nil)
+	// this request url is a placeholder/arbitrary
+	r := httptest.NewRequest("GET", "http://bcda.cms.gov/api/v1/token", nil)
 	ctx := context.Background()
 	r = r.WithContext(context.WithValue(ctx, middleware.CtxTransactionKey, uuid.New()))
 	return r

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -17,7 +17,7 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/bcda/web/middleware"
 	"github.com/CMSgov/bcda-app/conf"
-
+	appMiddleware "github.com/CMSgov/bcda-app/middleware"
 	"github.com/go-chi/chi/v5"
 	gcmw "github.com/go-chi/chi/v5/middleware"
 )
@@ -30,7 +30,7 @@ var commonAuth = []func(http.Handler) http.Handler{
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(auth.ParseToken, gcmw.RequestID, appMiddleware.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui/v1"))
@@ -88,7 +88,7 @@ func NewAPIRouter() http.Handler {
 }
 
 func NewAuthRouter() http.Handler {
-	return auth.NewAuthRouter(gcmw.RequestID, logging.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	return auth.NewAuthRouter(gcmw.RequestID, appMiddleware.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 }
 
 func NewDataRouter() http.Handler {
@@ -97,7 +97,7 @@ func NewDataRouter() http.Handler {
 	resourceTypeLogger := &logging.ResourceTypeLogger{
 		Repository: postgres.NewRepository(database.Connection),
 	}
-	r.Use(auth.ParseToken, gcmw.RequestID, logging.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(auth.ParseToken, gcmw.RequestID, appMiddleware.NewTransactionID, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 	r.With(append(
 		commonAuth,
 		auth.RequireTokenJobMatch,
@@ -109,7 +109,7 @@ func NewDataRouter() http.Handler {
 func NewHTTPRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(gcmw.RequestID, middleware.ConnectionClose, logging.NewTransactionID, logging.NewCtxLogger)
+	r.Use(gcmw.RequestID, middleware.ConnectionClose, appMiddleware.NewTransactionID, logging.NewCtxLogger)
 	r.With(logging.NewStructuredLogger()).Get(m.WrapHandler("/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		url := "https://" + req.Host + req.URL.String()
 		http.Redirect(w, req, url, http.StatusMovedPermanently)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pborman/uuid"
+)
+
+// type to create context.Context key
+type CtxTransactionKeyType string
+
+// context.Context key to get the transaction ID from the request context
+const CtxTransactionKey CtxTransactionKeyType = "ctxTransaction"
+
+// Adds a transaction ID to the request context
+func NewTransactionID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(context.WithValue(r.Context(), CtxTransactionKey, uuid.New()))
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7411

## 🛠 Changes

- Requests to SSAS to get a token now include a transaction ID header called `transaction-id` which contains a stringified UUID
- Fixed circular dependency by moving the transaction context key handler that adds transaction ids to incoming request's context to a separate package under `bcda/middleware`. We should eventually move more middleware functionality there, as it is split across multiple packages at the moment.

## ℹ️ Context for reviewers

As part of an ongoing effort to improve logging capabilities, this addition will allow us to correlate logs generated in SSAS as part of a consumer request by including the transaction ID in log events.

## ✅ Acceptance Validation

Added test, verified existing tests pass.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
