### PR TITLE
BCDA-7581: Utilize context logger for FHIR response writers in bcda-app

### DIFF
--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -36,6 +36,7 @@ RUN openssl rsa -in /var/local/private.pem -outform PEM -pubout -out /var/local/
 
 # Make sure we are in the directory to ensure the config files are resolved as expected
 COPY --from=base /go/bcda-ssas-app/ /go/bcda-ssas-app/
+COPY --from=base /go/bcda-ssas-app/ssas/cfg/configs  /go/src/github.com/CMSgov/bcda-ssas-app/ssas/cfg/configs
 COPY --from=base /go/bin/ /go/bin/
 WORKDIR /go/bcda-ssas-app/ssas/
 

--- a/bcda/api/alr.go
+++ b/bcda/api/alr.go
@@ -63,7 +63,7 @@ func (h *Handler) alrRequest(w http.ResponseWriter, r *http.Request) {
 		log.API.Error(err.Error())
 		oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION,
 			responseutils.InternalErr, err.Error())
-		responseutils.WriteError(oo, w, http.StatusInternalServerError)
+		responseutils.WriteError(ctx, oo, w, http.StatusInternalServerError)
 		return
 	}
 
@@ -74,14 +74,14 @@ func (h *Handler) alrRequest(w http.ResponseWriter, r *http.Request) {
 			}
 			log.API.Errorf("Could not handle ALR request %s", err.Error())
 			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			responseutils.WriteError(ctx, oo, w, http.StatusInternalServerError)
 			return
 		}
 
 		if err = tx.Commit(); err != nil {
 			log.API.Errorf("Failed to commit transaction %s", err.Error())
 			oo := responseutils.CreateOpOutcome(fhircodes.IssueSeverityCode_ERROR, fhircodes.IssueTypeCode_EXCEPTION, responseutils.DbErr, "")
-			responseutils.WriteError(oo, w, http.StatusInternalServerError)
+			responseutils.WriteError(ctx, oo, w, http.StatusInternalServerError)
 			return
 		}
 

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -39,142 +39,150 @@ func init() {
 }
 
 /*
-	swagger:route GET /api/v1/alr/$export alrData alrRequest
+swagger:route GET /api/v1/alr/$export alrData alrRequest
 
-	Start FHIR STU3 data export for all supported resource types
+# Start FHIR STU3 data export for all supported resource types
 
-	Initiates a job to collect Assignment List Report data for your ACO. Supported resource types are Patient, Coverage, Group, Risk Assessment, Observation, and Covid Episode.
+Initiates a job to collect Assignment List Report data for your ACO. Supported resource types are Patient, Coverage, Group, Risk Assessment, Observation, and Covid Episode.
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		202: BulkRequestResponse
-		400: badRequestResponse
-		401: invalidCredentials
-		429: tooManyRequestsResponse
-		500: errorResponse
+	bearer_token:
+
+Responses:
+
+	202: BulkRequestResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	429: tooManyRequestsResponse
+	500: errorResponse
 */
 func ALRRequest(w http.ResponseWriter, r *http.Request) {
 	h.ALRRequest(w, r)
 }
 
 /*
-	swagger:route GET /api/v1/Patient/$export bulkData bulkPatientRequest
+swagger:route GET /api/v1/Patient/$export bulkData bulkPatientRequest
 
-	Start FHIR STU3 data export for all supported resource types
+# Start FHIR STU3 data export for all supported resource types
 
-	Initiates a job to collect data from the Blue Button API for your ACO. Supported resource types are Patient, Coverage, and ExplanationOfBenefit.
+Initiates a job to collect data from the Blue Button API for your ACO. Supported resource types are Patient, Coverage, and ExplanationOfBenefit.
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		202: BulkRequestResponse
-		400: badRequestResponse
-		401: invalidCredentials
-		429: tooManyRequestsResponse
-		500: errorResponse
+	bearer_token:
+
+Responses:
+
+	202: BulkRequestResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	429: tooManyRequestsResponse
+	500: errorResponse
 */
 func BulkPatientRequest(w http.ResponseWriter, r *http.Request) {
 	h.BulkPatientRequest(w, r)
 }
 
 /*
-	swagger:route GET /api/v1/Group/{groupId}/$export bulkData bulkGroupRequest
+		swagger:route GET /api/v1/Group/{groupId}/$export bulkData bulkGroupRequest
 
-    Start FHIR STU3 data export (for the specified group identifier) for all supported resource types
+	    Start FHIR STU3 data export (for the specified group identifier) for all supported resource types
 
-	Initiates a job to collect data from the Blue Button API for your ACO. The supported Group identifiers are `all` and `runout`.
+		Initiates a job to collect data from the Blue Button API for your ACO. The supported Group identifiers are `all` and `runout`.
 
-	The `all` identifier returns data for the group of all patients attributed to the requesting ACO.  If used when specifying `_since`: all claims data which has been updated since the specified date will be returned for beneficiaries which have been attributed to the ACO since before the specified date; and all historical claims data will be returned for beneficiaries which have been newly attributed to the ACO since the specified date.
+		The `all` identifier returns data for the group of all patients attributed to the requesting ACO.  If used when specifying `_since`: all claims data which has been updated since the specified date will be returned for beneficiaries which have been attributed to the ACO since before the specified date; and all historical claims data will be returned for beneficiaries which have been newly attributed to the ACO since the specified date.
 
-	The `runout` identifier returns claims runouts data.
+		The `runout` identifier returns claims runouts data.
 
-	Produces:
-	- application/fhir+json
+		Produces:
+		- application/fhir+json
 
-	Security:
-		bearer_token:
+		Security:
+			bearer_token:
 
-	Responses:
-		202: BulkRequestResponse
-		400: badRequestResponse
-		401: invalidCredentials
-		429: tooManyRequestsResponse
-		500: errorResponse
+		Responses:
+			202: BulkRequestResponse
+			400: badRequestResponse
+			401: invalidCredentials
+			429: tooManyRequestsResponse
+			500: errorResponse
 */
 func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
 	h.BulkGroupRequest(w, r)
 }
 
 /*
-	swagger:route GET /api/v1/jobs/{jobId} job jobStatus
+swagger:route GET /api/v1/jobs/{jobId} job jobStatus
 
-	Get job status
+# Get job status
 
-	Returns the current status of an export job.
+Returns the current status of an export job.
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		202: jobStatusResponse
-		200: completedJobResponse
-		400: badRequestResponse
-		401: invalidCredentials
-		404: notFoundResponse
-		410: goneResponse
-		500: errorResponse
+	bearer_token:
+
+Responses:
+
+	202: jobStatusResponse
+	200: completedJobResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	410: goneResponse
+	500: errorResponse
 */
 func JobStatus(w http.ResponseWriter, r *http.Request) {
 	h.JobStatus(w, r)
 }
 
 /*
-	swagger:route GET /api/v1/jobs job jobsStatus
+swagger:route GET /api/v1/jobs job jobsStatus
 
-	Get jobs statuses
+# Get jobs statuses
 
-	Returns the current statuses of export jobs. Supported status types are Completed, Archived, Expired, Failed, FailedExpired,
-	Pending, In Progress, Cancelled, and CancelledExpired. If no status(s) is provided, all jobs will be returned.
+Returns the current statuses of export jobs. Supported status types are Completed, Archived, Expired, Failed, FailedExpired,
+Pending, In Progress, Cancelled, and CancelledExpired. If no status(s) is provided, all jobs will be returned.
 
-	Note on job status to fhir task resource status mapping:
-	Due to the fhir task status field having a smaller set of values, the following statuses will be set to different fhir values in the response
+Note on job status to fhir task resource status mapping:
+Due to the fhir task status field having a smaller set of values, the following statuses will be set to different fhir values in the response
 
-	Archived, Expired -> Completed
-	FailedExpired -> Failed
-	Pending -> In Progress
-	CancelledExpired -> Cancelled
+Archived, Expired -> Completed
+FailedExpired -> Failed
+Pending -> In Progress
+CancelledExpired -> Cancelled
 
-	Though the status name has been remapped the response will still only contain jobs pertaining to the provided job status in the request.
+Though the status name has been remapped the response will still only contain jobs pertaining to the provided job status in the request.
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		200: jobsStatusResponse
-		400: badRequestResponse
-		401: invalidCredentials
-		404: notFoundResponse
-		410: goneResponse
-		500: errorResponse
+	bearer_token:
+
+Responses:
+
+	200: jobsStatusResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	410: goneResponse
+	500: errorResponse
 */
 func JobsStatus(w http.ResponseWriter, r *http.Request) {
 	h.JobsStatus(w, r)
@@ -194,76 +202,82 @@ func (w gzipResponseWriter) Write(b []byte) (int, error) {
 }
 
 /*
-	swagger:route DELETE /api/v1/jobs/{jobId} job deleteJob
+swagger:route DELETE /api/v1/jobs/{jobId} job deleteJob
 
-	Cancel a job
+# Cancel a job
 
-	Cancels a currently running job.
+Cancels a currently running job.
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		202: deleteJobResponse
-		400: badRequestResponse
-		401: invalidCredentials
-		404: notFoundResponse
-		410: goneResponse
-		500: errorResponse
+	bearer_token:
+
+Responses:
+
+	202: deleteJobResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	410: goneResponse
+	500: errorResponse
 */
 func DeleteJob(w http.ResponseWriter, r *http.Request) {
 	h.DeleteJob(w, r)
 }
 
 /*
-	swagger:route GET /api/v1/attribution_status attributionStatus attributionStatus
+swagger:route GET /api/v1/attribution_status attributionStatus attributionStatus
 
-	Get attribution status
+# Get attribution status
 
-	Returns the status of the latest ingestion for attribution and claims runout files. The response will contain the Type to identify which ingestion and a Timestamp for the last time it was updated.
+Returns the status of the latest ingestion for attribution and claims runout files. The response will contain the Type to identify which ingestion and a Timestamp for the last time it was updated.
 
-	Produces:
-	- application/json
+Produces:
+- application/json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		200: AttributionFileStatusResponse
-		404: notFoundResponse
+	bearer_token:
+
+Responses:
+
+	200: AttributionFileStatusResponse
+	404: notFoundResponse
 */
 func AttributionStatus(w http.ResponseWriter, r *http.Request) {
 	h.AttributionStatus(w, r)
 }
 
 /*
-	swagger:route GET /data/{jobId}/{filename} job serveData
+swagger:route GET /data/{jobId}/{filename} job serveData
 
-	Get data file
+# Get data file
 
-	Returns the NDJSON file of data generated by an export job.  Will be in the format <UUID>.ndjson.  Get the full value from the job status response
+Returns the NDJSON file of data generated by an export job.  Will be in the format <UUID>.ndjson.  Get the full value from the job status response
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Security:
-		bearer_token:
+Security:
 
-	Responses:
-		200: FileNDJSON
-		400: badRequestResponse
-		401: invalidCredentials
-		404: notFoundResponse
-		500: errorResponse
+	bearer_token:
+
+Responses:
+
+	200: FileNDJSON
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	500: errorResponse
 */
 func ServeData(w http.ResponseWriter, r *http.Request) {
 	dataDir := conf.GetEnv("FHIR_PAYLOAD_DIR")
@@ -293,19 +307,20 @@ func ServeData(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	swagger:route GET /api/v1/metadata metadata metadata
+swagger:route GET /api/v1/metadata metadata metadata
 
-	Get metadata
+# Get metadata
 
-	Returns metadata about the API.
+Returns metadata about the API.
 
-	Produces:
-	- application/fhir+json
+Produces:
+- application/fhir+json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Responses:
-		200: MetadataResponse
+Responses:
+
+	200: MetadataResponse
 */
 func Metadata(w http.ResponseWriter, r *http.Request) {
 	dt := time.Now()
@@ -316,23 +331,24 @@ func Metadata(w http.ResponseWriter, r *http.Request) {
 	}
 	host := fmt.Sprintf("%s://%s", scheme, r.Host)
 	statement := responseutils.CreateCapabilityStatement(dt, constants.Version, host)
-	responseutils.WriteCapabilityStatement(statement, w)
+	responseutils.WriteCapabilityStatement(r.Context(), statement, w)
 }
 
 /*
-	swagger:route GET /_version metadata getVersion
+swagger:route GET /_version metadata getVersion
 
-	Get API version
+# Get API version
 
-	Returns the version of the API that is currently running. Note that this endpoint is **not** prefixed with the base path (e.g. /api/v1).
+Returns the version of the API that is currently running. Note that this endpoint is **not** prefixed with the base path (e.g. /api/v1).
 
-	Produces:
-	- application/json
+Produces:
+- application/json
 
-	Schemes: http, https
+Schemes: http, https
 
-	Responses:
-		200: VersionResponse
+Responses:
+
+	200: VersionResponse
 */
 func GetVersion(w http.ResponseWriter, r *http.Request) {
 	respMap := make(map[string]string)
@@ -383,19 +399,20 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-   swagger:route GET /_auth metadata getAuthInfo
+swagger:route GET /_auth metadata getAuthInfo
 
-   Get details about auth
+# Get details about auth
 
-   Returns the auth provider that is currently being used. Note that this endpoint is **not** prefixed with the base path (e.g. /api/v1).
+Returns the auth provider that is currently being used. Note that this endpoint is **not** prefixed with the base path (e.g. /api/v1).
 
-   Produces:
-   - application/json
+Produces:
+- application/json
 
-   Schemes: http, https
+Schemes: http, https
 
-   Responses:
-           200: AuthResponse
+Responses:
+
+	200: AuthResponse
 */
 func GetAuthInfo(w http.ResponseWriter, r *http.Request) {
 	respMap := make(map[string]string)

--- a/bcda/web/middleware/middleware.go
+++ b/bcda/web/middleware/middleware.go
@@ -50,7 +50,7 @@ func ACOEnabled(cfg *service.Config) func(next http.Handler) http.Handler {
 			if cfg.IsACODisabled(ad.CMSID) {
 				logger := log.GetCtxLogger(r.Context())
 				logger.Error(fmt.Sprintf("failed to complete request, CMSID %s is not enabled", ad.CMSID))
-				rw.Exception(w, http.StatusUnauthorized, responseutils.InternalErr, "")
+				rw.Exception(r.Context(), w, http.StatusUnauthorized, responseutils.InternalErr, "")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/bcda/web/middleware/ratelimit.go
+++ b/bcda/web/middleware/ratelimit.go
@@ -53,7 +53,7 @@ func CheckConcurrentJobs(next http.Handler) http.Handler {
 		if err != nil {
 			logger := log.GetCtxLogger(r.Context())
 			logger.Error(fmt.Errorf("failed to lookup pending and in-progress jobs: %w", err))
-			rw.Exception(w, http.StatusInternalServerError, responseutils.InternalErr, "")
+			rw.Exception(r.Context(), w, http.StatusInternalServerError, responseutils.InternalErr, "")
 			return
 		}
 		if len(pendingAndInProgressJobs) > 0 {

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -58,7 +58,7 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 			if _, found := supportedOutputFormats[params[0]]; !found {
 				errMsg := fmt.Sprintf("_outputFormat parameter must be one of %v", getKeys(supportedOutputFormats))
 				log.API.Error(errMsg)
-				rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
+				rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
 				return
 			}
 		}
@@ -68,7 +68,7 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 		if ok {
 			errMsg := "Invalid parameter: this server does not support the _elements parameter."
 			log.API.Warn(errMsg)
-			rw.Exception(w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
+			rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
 			return
 		}
 
@@ -78,7 +78,7 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 			if strings.HasPrefix(key, "?") {
 				errMsg := "Invalid parameter: query parameters cannot start with ?"
 				log.API.Warn(errMsg)
-				rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
+				rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
 				return
 			}
 		}
@@ -90,12 +90,12 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 			if err != nil {
 				errMsg := "Invalid date format supplied in _since parameter.  Date must be in FHIR Instant format."
 				log.API.Warn(errMsg)
-				rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
+				rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
 				return
 			} else if sinceDate.After(time.Now()) {
 				errMsg := "Invalid date format supplied in _since parameter. Date must be a date that has already passed"
 				log.API.Warn(errMsg)
-				rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
+				rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, errMsg)
 				return
 			}
 			rp.Since = sinceDate
@@ -112,7 +112,7 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 				} else {
 					errMsg := fmt.Sprintf("Repeated resource type %s", resource)
 					log.API.Error(errMsg)
-					rw.Exception(w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
+					rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
 					return
 				}
 			}
@@ -141,21 +141,21 @@ func ValidateRequestHeaders(next http.Handler) http.Handler {
 
 		if acceptHeader == "" {
 			logger.Warn("Accept header is required")
-			rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, "Accept header is required")
+			rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, "Accept header is required")
 			return
 		} else if acceptHeader != "application/fhir+json" {
 			logger.Warn("application/fhir+json is the only supported response format")
-			rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, "application/fhir+json is the only supported response format")
+			rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, "application/fhir+json is the only supported response format")
 			return
 		}
 
 		if preferHeader == "" {
 			logger.Warn("Prefer header is required")
-			rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, "Prefer header is required")
+			rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, "Prefer header is required")
 			return
 		} else if preferHeader != "respond-async" {
 			logger.Warn("Only asynchronous responses are supported")
-			rw.Exception(w, http.StatusBadRequest, responseutils.FormatErr, "Only asynchronous responses are supported")
+			rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.FormatErr, "Only asynchronous responses are supported")
 			return
 		}
 
@@ -182,8 +182,8 @@ func getVersion(path string) (string, error) {
 }
 
 type fhirResponseWriter interface {
-	Exception(http.ResponseWriter, int, string, string)
-	NotFound(http.ResponseWriter, int, string, string)
+	Exception(context.Context, http.ResponseWriter, int, string, string)
+	NotFound(context.Context, http.ResponseWriter, int, string, string)
 }
 
 func getRespWriter(version string) (fhirResponseWriter, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       dockerfile: Dockerfiles/Dockerfile.ssas
     environment:
       - DATABASE_URL=postgresql://postgres:toor@db:5432/bcda?sslmode=disable
+      - DEPLOYMENT_TARGET=local
       - JWT_PUBLIC_KEY_FILE=/var/local/public.pem
       - JWT_PRIVATE_KEY_FILE=/var/local/private.pem
       - DEBUG=true


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7581

## 🛠 Changes

- Passing logger context to response writers to be consistent with use of ctx logger elsewhere. 
- Metadata endpoint still using `log.API` since there is no relevant ctx to use
- auth middleware is using `log.AUTH` to create a ctx logger because auth middleware is processed before ctx logger middleware in the chi routers.
- MakeTestStructuredLoggerEntry duplication is because of circular dependencies in testUtils. Would like to work on package reorganization later to start eliminating circular dependencies here and elsewhere.

## ℹ️ Context for reviewers

We updated error logging but did not switch to using the context logger (which has standardized attributes) for the FHIR response v1 and v2 writer files (writer.go).

## ✅ Acceptance Validation

tests updated and passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
