### PR TITLE
BCDA-7799: Enforce Performance Year Requirement

### DIFF
--- a/bcda/models/postgres/repository.go
+++ b/bcda/models/postgres/repository.go
@@ -145,7 +145,7 @@ func (r *Repository) GetLatestCCLFFile(ctx context.Context, cmsID string, cclfNu
 			sb.LessEqualThan("timestamp", upperBound),
 		)
 	}
-	sb.OrderBy("timestamp").Desc().Limit(1)
+	sb.OrderBy("performance_year DESC, timestamp DESC").Limit(1)
 
 	query, args := sb.Build()
 	row := r.QueryRowContext(ctx, query, args...)

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -61,7 +61,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Time{},
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -69,7 +69,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Time{},
 			models.FileTypeRunout,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeRunout),
 		},
 		{
@@ -77,7 +77,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Now(),
 			time.Time{},
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 ORDER BY timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -85,7 +85,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Now(),
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp <= $5 ORDER BY timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp <= $5 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -93,7 +93,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Now(),
 			time.Now(),
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 AND timestamp <= $6 ORDER BY timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 AND timestamp <= $6 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -101,7 +101,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Time{},
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			nil,
 		},
 	}

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -350,7 +350,12 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get new CCLF file for cmsID %s %s", conditions.CMSID, err.Error())
 	}
-	if cclfFileNew == nil {
+	performanceYear := time.Now().Year() % 100
+	if conditions.fileType == models.FileTypeRunout {
+		performanceYear -= 1
+	}
+	//Note, we only compare performanceYear for the new CCLF file since the old file will only be used for identifying new ones.
+	if cclfFileNew == nil || performanceYear != cclfFileNew.PerformanceYear {
 		return nil, nil, CCLFNotFoundError{8, conditions.CMSID, conditions.fileType, cutoffTime}
 	}
 
@@ -441,7 +446,12 @@ func (s *service) getBeneficiaries(ctx context.Context, conditions RequestCondit
 		return nil, fmt.Errorf("failed to get CCLF file for cmsID %s fileType %d %s",
 			conditions.CMSID, conditions.fileType, err.Error())
 	}
-	if cclfFile == nil {
+	performanceYear := time.Now().Year() % 100
+	if conditions.fileType == models.FileTypeRunout {
+		performanceYear -= 1
+	}
+
+	if cclfFile == nil || performanceYear != cclfFile.PerformanceYear {
 		return nil, CCLFNotFoundError{8, conditions.CMSID, conditions.fileType, cutoffTime}
 	}
 

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -184,8 +184,8 @@ func (s *ServiceTestSuite) TestIncludeSuppressedBeneficiaries() {
 	}{
 		{
 			"GetNewAndExistingBeneficiaries",
-			getCCLFFile(1),
-			getCCLFFile(2),
+			getCCLFFile(1, false, false),
+			getCCLFFile(2, false, false),
 			func(serv *service) error {
 				_, _, err := serv.getNewAndExistingBeneficiaries(context.Background(), conditions)
 				return err
@@ -193,7 +193,7 @@ func (s *ServiceTestSuite) TestIncludeSuppressedBeneficiaries() {
 		},
 		{
 			"GetBeneficiaries",
-			getCCLFFile(3),
+			getCCLFFile(3, false, false),
 			nil,
 			func(serv *service) error {
 				_, err := serv.getBeneficiaries(context.Background(), conditions)
@@ -238,14 +238,14 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 	}{
 		{
 			"NewAndExistingBenes",
-			getCCLFFile(1),
-			getCCLFFile(2),
+			getCCLFFile(1, false, false),
+			getCCLFFile(2, false, false),
 			[]string{"123", "456"},
 			nil,
 		},
 		{
 			"NewBenesOnly",
-			getCCLFFile(3),
+			getCCLFFile(3, false, false),
 			nil,
 			nil,
 			nil,
@@ -259,24 +259,31 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 		},
 		{
 			"NoBenesFoundNew",
-			getCCLFFile(4),
+			getCCLFFile(4, false, false),
 			nil,
 			nil,
 			fmt.Errorf("Found 0 new beneficiaries from CCLF8 file for cmsID"),
 		},
 		{
 			"NoBenesFoundNewAndOld",
-			getCCLFFile(5),
-			getCCLFFile(6),
+			getCCLFFile(5, false, false),
+			getCCLFFile(6, false, false),
 			nil,
 			fmt.Errorf("Found 0 new or existing beneficiaries from CCLF8 file for cmsID"),
 		},
 		{
 			"NoMBIsForOldCCLF",
-			getCCLFFile(7),
-			getCCLFFile(8),
+			getCCLFFile(7, false, false),
+			getCCLFFile(8, false, false),
 			nil,
 			nil,
+		},
+		{
+			"NoMBIsForOldCCLF",
+			getCCLFFile(7, false, true),
+			getCCLFFile(8, false, false),
+			nil,
+			fmt.Errorf("no CCLF8 file found for cmsID"),
 		},
 	}
 
@@ -386,8 +393,9 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries_RecentSinceParamet
 	defer postgrestest.DeleteCCLFFilesByCMSID(s.T(), db, "A0005")
 
 	acoID := "A0005"
-	cclfFileOld := &models.CCLFFile{CCLFNum: 8, ACOCMSID: acoID, Timestamp: time.Now().Add(-48 * time.Hour), PerformanceYear: 23, Name: "T.BCD.A0005.ZC8Y23.D231119.T1000009", ImportStatus: constants.ImportComplete}
-	cclfFileNew := &models.CCLFFile{CCLFNum: 8, ACOCMSID: acoID, Timestamp: time.Now().Add(-24 * time.Hour), PerformanceYear: 23, Name: "T.BCD.A0005.ZC8Y23.D231120.T1000009", ImportStatus: constants.ImportComplete}
+	performanceYear := time.Now().Year() % 100
+	cclfFileOld := &models.CCLFFile{CCLFNum: 8, ACOCMSID: acoID, Timestamp: time.Now().Add(-48 * time.Hour), PerformanceYear: performanceYear, Name: "T.BCD.A0005.ZC8Y23.D231119.T1000009", ImportStatus: constants.ImportComplete}
+	cclfFileNew := &models.CCLFFile{CCLFNum: 8, ACOCMSID: acoID, Timestamp: time.Now().Add(-24 * time.Hour), PerformanceYear: performanceYear, Name: "T.BCD.A0005.ZC8Y23.D231120.T1000009", ImportStatus: constants.ImportComplete}
 	postgrestest.CreateCCLFFile(s.T(), db, cclfFileOld)
 	postgrestest.CreateCCLFFile(s.T(), db, cclfFileNew)
 
@@ -435,7 +443,7 @@ func (s *ServiceTestSuite) TestGetBeneficiaries() {
 		{
 			"BenesReturned",
 			models.FileTypeDefault,
-			getCCLFFile(1),
+			getCCLFFile(1, false, false),
 			nil,
 		},
 		{
@@ -447,14 +455,26 @@ func (s *ServiceTestSuite) TestGetBeneficiaries() {
 		{
 			"NoBenesFound",
 			models.FileTypeDefault,
-			getCCLFFile(2),
+			getCCLFFile(2, false, false),
 			fmt.Errorf("Found 0 beneficiaries from CCLF8 file for cmsID"),
 		},
 		{
 			"BenesReturnedRunout",
 			models.FileTypeRunout,
-			getCCLFFile(3),
+			getCCLFFile(3, true, false),
 			nil,
+		},
+		{
+			"NoBenesReturnedOld",
+			models.FileTypeRunout,
+			getCCLFFile(4, false, true),
+			fmt.Errorf("no CCLF8 file found for cmsID"),
+		},
+		{
+			"NoBenesReturnedOldRunout",
+			models.FileTypeRunout,
+			getCCLFFile(4, true, true),
+			fmt.Errorf("no CCLF8 file found for cmsID"),
 		},
 	}
 
@@ -654,7 +674,11 @@ func (s *ServiceTestSuite) TestGetQueJobs() {
 			repository := &models.MockRepository{}
 			repository.On("GetACOByCMSID", testUtils.CtxMatcher, conditions.CMSID).
 				Return(&models.ACO{UUID: conditions.ACOID, TerminationDetails: tt.terminationDetails}, nil)
-			repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1), nil)
+			if tt.reqType == Runout {
+				repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1, true, false), nil)
+			} else {
+				repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1, false, false), nil)
+			}
 			repository.On("GetSuppressedMBIs", testUtils.CtxMatcher, mock.Anything, mock.Anything).Return(nil, nil)
 			repository.On("GetCCLFBeneficiaries", testUtils.CtxMatcher, mock.Anything, mock.Anything).Return(tt.expBenes, nil)
 			// use benes1 as the "old" benes. Allows us to verify the since parameter is populated as expected
@@ -793,7 +817,7 @@ func (s *ServiceTestSuite) TestGetQueJobsByDataType() {
 			repository := &models.MockRepository{}
 			repository.On("GetACOByCMSID", testUtils.CtxMatcher, conditions.CMSID).
 				Return(&models.ACO{UUID: conditions.ACOID, TerminationDetails: tt.terminationDetails}, nil)
-			repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1), nil)
+			repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1, false, false), nil)
 			repository.On("GetSuppressedMBIs", testUtils.CtxMatcher, mock.Anything, mock.Anything).Return(nil, nil)
 			repository.On("GetCCLFBeneficiaries", testUtils.CtxMatcher, mock.Anything, mock.Anything).Return(tt.expBenes, nil)
 			// use benes1 as the "old" benes. Allows us to verify the since parameter is populated as expected
@@ -998,7 +1022,7 @@ func (s *ServiceTestSuite) TestGetJobsNotFound() {
 
 func (s *ServiceTestSuite) TestGetLatestCCLFFile() {
 	repository := &models.MockRepository{}
-	repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1), nil)
+	repository.On("GetLatestCCLFFile", testUtils.CtxMatcher, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(getCCLFFile(1, false, false), nil)
 
 	serviceInstance := NewService(repository, &Config{}, "").(*service)
 
@@ -1080,9 +1104,17 @@ func (s *ServiceTestSuite) TestGetACOConfigForID() {
 	}
 }
 
-func getCCLFFile(id uint) *models.CCLFFile {
+func getCCLFFile(id uint, isRunout bool, forceIncorrect bool) *models.CCLFFile {
+	performanceYear := time.Now().Year() % 100
+	if isRunout {
+		performanceYear -= 1
+	}
+	if forceIncorrect {
+		performanceYear -= 10
+	}
 	return &models.CCLFFile{
-		ID: id,
+		ID:              id,
+		PerformanceYear: performanceYear,
 	}
 }
 

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -279,7 +279,7 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries() {
 			nil,
 		},
 		{
-			"NoMBIsForOldCCLF",
+			"NoCCLFPerfYearIncompatible",
 			getCCLFFile(7, false, true),
 			getCCLFFile(8, false, false),
 			nil,

--- a/db/postman_fixtures.sql
+++ b/db/postman_fixtures.sql
@@ -34,4 +34,5 @@ SET performance_year =
     CASE 
         WHEN type = 0 THEN CAST(RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::text, 2) AS integer)
         ELSE CAST(RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP - INTERVAL '1 year')::text, 2) AS integer)
-    END;
+    END
+WHERE aco_cms_id IN ('A9997', 'A9994', 'A9990', 'TEST001','A9996');

--- a/db/postman_fixtures.sql
+++ b/db/postman_fixtures.sql
@@ -28,3 +28,10 @@ where cms_id = 'A9990';
 update acos
 set system_id = 5, group_id = 'TEST001'
 where cms_id = 'TEST001';
+
+UPDATE cclf_files
+SET performance_year = 
+    CASE 
+        WHEN type = 0 THEN CAST(RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::text, 2) AS integer)
+        ELSE CAST(RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP - INTERVAL '1 year')::text, 2) AS integer)
+    END;

--- a/db/postman_fixtures.sql
+++ b/db/postman_fixtures.sql
@@ -35,4 +35,4 @@ SET performance_year =
         WHEN type = 0 THEN CAST(RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::text, 2) AS integer)
         ELSE CAST(RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP - INTERVAL '1 year')::text, 2) AS integer)
     END
-WHERE aco_cms_id IN ('A9997', 'A9994', 'A9990', 'TEST001','A9996');
+WHERE aco_cms_id LIKE 'A888%' OR aco_cms_id LIKE 'A999%' OR aco_cms_id LIKE 'TEST%' OR aco_cms_id LIKE 'D999%';


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7799

## 🛠 Changes

Overall, it enforces proper performance year requirements to prevent data leaking.
Specifically, this PR:
1. Sorts results from the cclf_files query in order of performance_year THEN timestamp. This avoids issues with PY23 files coming in after PY24 and causing security issues.
2. Enforces, in getBeneficiaries and getNewAndExistingBeneficiaries, the performance year explicitly. 
3. Updates unit tests to utilize PerformanceYear

## ℹ️ Context for reviewers

BCDA is dependent upon CCLF files to properly attribute beneficiaries to an ACO. Currently, BCDA would source the most recently timestamped CCLF file, regardless of if it is for the current or previous performance year. This is an error, and requires correction, or else claims data could be shared improperly. 

## ✅ Acceptance Validation

Added unit tests to cover specific scenarios and updated unit tests for existing scenarios. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
