### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.golanglint-ci.yml
+++ b/.golanglint-ci.yml
@@ -12,3 +12,4 @@ linters:
     - unused
     - godox
     - gosec
+    - gosimple

--- a/.golanglint-ci.yml
+++ b/.golanglint-ci.yml
@@ -1,0 +1,14 @@
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - gofmt
+    - goimports
+    - govet
+    - ineffassign
+    - unused
+    - godox
+    - gosec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: master
+    rev: v1.0.0-rc.1
     hooks:
-      - id: go-imports
-        args: ['-w']
+      - id: golangci-lint


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

- The pre-commit config file has been updated to use golanglint-ci.
- golanlint-ci config file has been added with additional linters
- pinned pre-commit version to stop moving rev warnings

## ℹ️ Context for reviewers

The pre-commit config file has been updated to use golanglint-ci so we can do linting before we commit changes and don't have to wait for CI to run. 

Linters and their descriptions: https://golangci-lint.run/usage/linters/


## ✅ Acceptance Validation

Ran locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
