### PR TITLE
BCDA-7786: Create Job Keys for ndjson files

### DIFF
--- a/.golanglint-ci.yml
+++ b/.golanglint-ci.yml
@@ -1,3 +1,8 @@
+run:
+  go: '1.19'
+  # Show statistics per linter.
+  # Default: false
+  show-stats: true
 linters:
   # Disable all linters.
   # Default: false
@@ -13,3 +18,8 @@ linters:
     - godox
     - gosec
     - gosimple
+issues:
+  exclude-rules:
+  - path: /
+    linters:
+    - typecheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,4 +6,5 @@ repos:
   - repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-rc.1
     hooks:
-      - id: golangci-lint
+      - id: golangci-lint-pkg
+        args: ['--new']

--- a/bcda/models/postgres/postgrestest/postgrestest.go
+++ b/bcda/models/postgres/postgrestest/postgrestest.go
@@ -381,3 +381,28 @@ func getCCLFFiles(db *sql.DB, field, value string) ([]models.CCLFFile, error) {
 
 	return cclfFiles, nil
 }
+
+func GetJobKey(db *sql.DB, jobID int) ([]models.JobKey, error) {
+	sb := sqlbuilder.PostgreSQL.NewSelectBuilder().Select("id", "job_id", "file_name", "resource_type").From("job_keys")
+	sb.Where(sb.Equal("job_id", jobID))
+	query, args := sb.Build()
+	fmt.Println(query)
+	fmt.Println(args)
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var jobKeys []models.JobKey
+	for rows.Next() {
+		var jobKey models.JobKey
+		if err := rows.Scan(&jobKey.ID, &jobKey.JobID, &jobKey.FileName,
+			&jobKey.ResourceType); err != nil {
+			return nil, err
+		}
+		jobKeys = append(jobKeys, jobKey)
+	}
+	return jobKeys, err
+}

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -144,7 +144,7 @@ func (w *worker) ProcessJob(ctx context.Context, job models.Job, jobArgs models.
 }
 
 // writeBBDataToFile sends requests to BlueButton and writes the results to ndjson files.
-// A list of JobKeys are returned, containining the names of files that were created.
+// A list of JobKeys are returned, containing the names of files that were created.
 // Filesnames can be "blank.ndjson", "<uuid>.ndjson", or "<uuid>-error.ndjson".
 func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.APIClient,
 	cmsID string, jobArgs models.JobEnqueueArgs) (jobKeys []models.JobKey, err error) {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7786

## 🛠 Changes

- `processJob`: moved code to create job keys and update job status into its own function for testing
- `processJob`: moved file size check into `writeBBDataToFile`
- `processJob`: creating keys for each Job Key that is returned 
- `writeBBDataToFile`: changed return values to be a list of JobKeys and an error
- `writeBBDataToFile`: returning "*-error.ndjson" job key if it is created (was not being returned and did not have job keys previously)
- update to pre-commit / golangci-lint to check the pkg, as linting was failing on single files.

## ℹ️ Context for reviewers

error.ndjson files not having job keys written to the database and middleware checks for job keys failing to [serve HTTP](https://github.com/CMSgov/bcda-app/pull/909). These changes will return the ndjson file and pass the middleware check, if the file exists. 

## ✅ Acceptance Validation

Current tests pass, some tests modified, new test added. Lots of intertwined dependencies with this one; was difficult to test.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
