### PR TITLE
BCDA-7886: Remove error files from output array in Jobs

### DIFF
--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -254,6 +254,9 @@ func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
 	assert.Equal(s.T(), true, rb.RequiresAccessToken)
 	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
 	assert.Equal(s.T(), dataurl, rb.Files[0].URL)
+	for _, file := range rb.Files {
+		assert.NotContains(s.T(), file.URL, "-error.ndjson")
+	}
 	assert.Equal(s.T(), "OperationOutcome", rb.Errors[0].Type)
 	assert.Equal(s.T(), errorurl, rb.Errors[0].URL)
 

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -271,6 +271,9 @@ func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
 	assert.Equal(s.T(), true, rb.RequiresAccessToken)
 	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
 	assert.Equal(s.T(), dataurl, rb.Files[0].URL)
+	for _, file := range rb.Files {
+		assert.NotContains(s.T(), file.URL, "-error.ndjson")
+	}
 	assert.Equal(s.T(), "OperationOutcome", rb.Errors[0].Type)
 	assert.Equal(s.T(), errorurl, rb.Errors[0].URL)
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7886

## 🛠 Changes

Added a check to ensure that error files are not added to the "output" array, only the error array. 

## ℹ️ Context for reviewers

After fixing the unpopulated error files, a report of these files showing up in output + error arrays appeared in the google group:
https://groups.google.com/g/bc-api/c/UgcO1KQSyaU


## ✅ Acceptance Validation

Added tests to ensure that output array contains no files with "-error.ndjson" while keeping tests to check for -error.ndjson in error array. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
