### PR TITLE
BCDA-7868: Update Error responses in middleware

### DIFF
--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -448,7 +448,7 @@ func (s *APITestSuite) TestJobStatusWithWrongACO() {
 	req := s.createJobStatusRequest(uuid.Parse(constants.LargeACOUUID), j.ID)
 
 	handler.ServeHTTP(s.rr, req)
-	assert.Equal(s.T(), http.StatusNotFound, s.rr.Code)
+	assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
 }
 
 func (s *APITestSuite) TestJobsStatus() {

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -342,13 +342,14 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchReturn404WhenMismatchingDa
 	jobID := strconv.Itoa(int(j.ID))
 
 	tests := []struct {
-		name  string
-		jobID string
-		ACOID string
+		name    string
+		jobID   string
+		ACOID   string
+		errCode int
 	}{
-		{"Invalid JobID", "someNonNumericInput", j.ACOID.String()},
-		{"Mismatching JobID", "0", j.ACOID.String()},
-		{"Mismatching ACOID", jobID, uuid.New()},
+		{"Invalid JobID", "someNonNumericInput", j.ACOID.String(), http.StatusBadRequest},
+		{"Mismatching JobID", "0", j.ACOID.String(), http.StatusNotFound},
+		{"Mismatching ACOID", jobID, uuid.New(), http.StatusUnauthorized},
 	}
 
 	handler := auth.RequireTokenJobMatch(mockHandler)
@@ -371,7 +372,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchReturn404WhenMismatchingDa
 
 			req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
 			handler.ServeHTTP(s.rr, req)
-			assert.Equal(s.T(), http.StatusNotFound, s.rr.Code)
+			assert.Equal(s.T(), tt.errCode, s.rr.Code)
 		})
 	}
 }
@@ -433,7 +434,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchReturn404WhenNoAuthDataPro
 	handler := auth.RequireTokenJobMatch(mockHandler)
 
 	handler.ServeHTTP(s.rr, req)
-	assert.Equal(s.T(), http.StatusNotFound, s.rr.Code)
+	assert.Equal(s.T(), http.StatusUnauthorized, s.rr.Code)
 }
 
 // unit test


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7868

## 🛠 Changes

Updated response codes to more appropriate responses. 

## ℹ️ Context for reviewers

BCDA has been returning 404 errors for instances such as tokens being expired, etc, in middleware, even when the response may not be appropriate. 

## ✅ Acceptance Validation

Modified unit tests to handle the new statuses. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
