### PR TITLE
BCDA-7889: Prevent creation of duplicate Jobs

### DIFF
--- a/bcda/web/middleware/ratelimit.go
+++ b/bcda/web/middleware/ratelimit.go
@@ -76,7 +76,6 @@ func hasDuplicates(ctx context.Context, pendingAndInProgressJobs []*models.Job, 
 	}
 
 	allResources := len(types) == 0
-	fmt.Println("Potaoto: ", newRequestUrl)
 
 	for _, job := range pendingAndInProgressJobs {
 		logger.Infof("Checking if new request is duplicate of pending or in-progress job %d\n", job.ID)

--- a/bcda/web/middleware/ratelimit_test.go
+++ b/bcda/web/middleware/ratelimit_test.go
@@ -29,6 +29,8 @@ func TestNoConcurrentJobs(t *testing.T) {
 			[]*models.Job{{RequestURL: constants.V1Path + constants.PatientExportPath}}},
 		{"DifferentType", RequestParameters{Version: "v1", ResourceTypes: []string{"Coverage"}},
 			[]*models.Job{{RequestURL: constants.V1Path + constants.PatientExportPath}}},
+		{"JobGroupExportJustPatient", RequestParameters{ResourceTypes: []string{"Patient"}, Version: "v2", RequestURL: "/v2/Group/all/$export?_type=Patient"},
+			[]*models.Job{{RequestURL: constants.V2Path + constants.PatientEOBPath, CreatedAt: time.Now()}}},
 	}
 
 	for _, tt := range tests {
@@ -65,6 +67,8 @@ func TestHasConcurrentJobs(t *testing.T) {
 		{"DuplicateType", RequestParameters{ResourceTypes: []string{"Patient"}, Version: "v1"}, nil},
 		{"JobAllResources", RequestParameters{ResourceTypes: []string{"Patient"}, Version: "v1"},
 			[]*models.Job{{RequestURL: constants.V1Path + constants.PatientExportPath, CreatedAt: time.Now()}}},
+		{"JobGroupExportDuplicateAll", RequestParameters{ResourceTypes: nil, Version: "v2", RequestURL: "/v2/Group/all/$export"},
+			[]*models.Job{{RequestURL: constants.V2Path + constants.GroupExportPath, CreatedAt: time.Now()}}},
 	}
 
 	for _, tt := range tests {

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -22,6 +22,7 @@ type RequestParameters struct {
 	Since         time.Time
 	ResourceTypes []string
 	Version       string // e.g. v1, v2
+	RequestURL    string
 }
 
 // requestkey is an unexported context key to avoid collisions
@@ -51,6 +52,7 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 
 		var rp RequestParameters
 		rp.Version = version
+		rp.RequestURL = r.URL.String()
 
 		//validate "_outputFormat" parameter
 		params, ok := r.URL.Query()["_outputFormat"]


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7889

## 🛠 Changes

Prevent same request URL from triggering duplicate job while in-progress or pending. 

## ℹ️ Context for reviewers

Currently, it's possible to spam the same request and create duplicates of the same job. This prevents that. 

## ✅ Acceptance Validation

Addition of unit tests for handling this use case.
Local validation (by temporarily removing the code in router.go that only applies rate limiting in prod). 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
