### PR TITLE
BCDA-7889: Updating rate limiters to limit duplicate jobs. 

### DIFF
--- a/bcda/web/middleware/ratelimit.go
+++ b/bcda/web/middleware/ratelimit.go
@@ -105,9 +105,16 @@ func hasDuplicates(ctx context.Context, pendingAndInProgressJobs []*models.Job, 
 			logger.Info("Existing job timed out -- ignoring existing job")
 			continue
 		}
+		//Error is ignored here due to url.Parse handling above.
+		unescapedOldJobURL, _ := url.QueryUnescape(req.Path + "?" + req.RawQuery)
 
+		unescapedNewJobURL, err := url.QueryUnescape(newRequestUrl)
+		if err != nil {
+			logger.Info("Unable to unescape new job URL -- ignoring new job")
+			continue
+		}
 		// Ensure that the requestUrls are not the same
-		if job.RequestURL == newRequestUrl {
+		if unescapedOldJobURL == unescapedNewJobURL {
 			logger.Info("New request has the same requestUrl as existing job -- disallowing request")
 			return true
 		}

--- a/bcda/web/middleware/ratelimit_test.go
+++ b/bcda/web/middleware/ratelimit_test.go
@@ -110,3 +110,30 @@ func getRequest(rp RequestParameters) *http.Request {
 	// Since we're supplying the request parameters in the context, the actual req URL does not matter
 	return httptest.NewRequest("GET", "/api/v1/Patient", nil).WithContext(ctx)
 }
+
+func TestHasDuplicatesFullString(t *testing.T) {
+	ctx := context.Background()
+	ctx = logAPI.NewStructuredLoggerEntry(log.New(), ctx)
+	otherJobs := []*models.Job{
+		{ID: 1, RequestURL: "https://api.abcd.123.net/api/v2/Group/runout/$export?_since=2024-02-11T00%3A00%3A00.0000-00%3A00&_type=Patient%2CCoverage%2CExplanationOfBenefit", CreatedAt: time.Now(), Status: models.JobStatusPending},
+		{ID: 2, RequestURL: "http://localhost:3000/api/v2/Group/all/$export?_since=2024-02-15T00%3A00%3A00.0000-00%3A00&_type=Patient%2CCoverage%2CExplanationOfBenefit", CreatedAt: time.Now().Add(-3 * 24 * time.Hour), Status: models.JobStatusExpired},
+		{ID: 1, RequestURL: "https://api.abcd.123.net/api/v2/Group/runout/$export?_since=2024-02-11T00%3A00%3A00.0000-00%3A00", CreatedAt: time.Now(), Status: models.JobStatusPending},
+	}
+
+	tests := []struct {
+		name          string
+		rp            RequestParameters
+		expectedValue bool
+	}{
+		{"TestUnparseableNewJob", RequestParameters{ResourceTypes: nil, Version: "v2", RequestURL: "/path%zz%20with%20spaces?query=value"}, false},
+		{"TestNewDuplicateJobWithEscaping", RequestParameters{ResourceTypes: []string{"Patient", "Coverage", "ExplanationOfBenefit"}, Version: "v2", RequestURL: "/api/v2/Group/runout/$export?_since=2024-02-11T00%3A00%3A00.0000-00%3A00&_type=Patient%2CCoverage%2CExplanationOfBenefit"}, true},
+		{"TestNewDuplicateJobSubsetOfTypes", RequestParameters{ResourceTypes: []string{"Patient"}, Version: "v2", RequestURL: "/api/v2/Group/runout/$export?_since=2024-02-11T04%3A00%3A00.0000-00%3A00&_type=Patient"}, true},
+	}
+
+	for _, tt := range tests {
+
+		responseBool := hasDuplicates(ctx, otherJobs, tt.rp.ResourceTypes, tt.rp.Version, tt.rp.RequestURL)
+		assert.Equal(t, tt.expectedValue, responseBool)
+	}
+
+}

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -47,7 +47,8 @@ func NewAPIRouter() http.Handler {
 	if conf.GetEnv("DEPLOYMENT_TARGET") != "prod" {
 		r.Get("/", userGuideRedirect)
 		r.Get(`/{:(user_guide|encryption|decryption_walkthrough).html}`, userGuideRedirect)
-	} else {
+	}
+	if conf.GetEnv("DEPLOYMENT_TARGET") == "prod" || conf.GetEnv("DEPLOYMENT_TARGET") == "test" {
 		// Apply rate limiting on production only
 		requestValidators = append(requestValidators, middleware.CheckConcurrentJobs)
 	}

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -49,7 +49,7 @@ func NewAPIRouter() http.Handler {
 		r.Get(`/{:(user_guide|encryption|decryption_walkthrough).html}`, userGuideRedirect)
 	}
 	if conf.GetEnv("DEPLOYMENT_TARGET") == "prod" || conf.GetEnv("DEPLOYMENT_TARGET") == "test" {
-		// Apply rate limiting on production only
+		// Apply rate limiting on test +  production only
 		requestValidators = append(requestValidators, middleware.CheckConcurrentJobs)
 	}
 

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -466,6 +466,7 @@ func (s *RouterTestSuite) TestRateLimitRoutes() {
 		hasRateLimit bool
 	}{
 		{"dev", false},
+		{"test", true},
 		{"prod", true},
 	}
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7889

## 🛠 Changes

Unescapes job requests for comparisons to expand de-duplication of requests.

## ℹ️ Context for reviewers

The first go around at this ticket blocked full $export operations, not duplicates with _since, due to one comparison using url-encoded characters, and the other using a raw string. 

## ✅ Acceptance Validation

Added method-level unit tests for hasDuplicates function. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
