### PR TITLE
BCDA-7894: Only count regular keys

### DIFF
--- a/bcdaworker/repository/postgres/repository.go
+++ b/bcdaworker/repository/postgres/repository.go
@@ -155,7 +155,7 @@ func (r *Repository) CreateJobKey(ctx context.Context, jobKey models.JobKey) err
 func (r *Repository) GetJobKeyCount(ctx context.Context, jobID uint) (int, error) {
 	sb := sqlFlavor.NewSelectBuilder().Select("COUNT(1)").From("job_keys")
 	sb.Where(sb.Equal("job_id", jobID))
-	sb.Where(sb.NotLike("file_name", "%-error.ndjson")) //Ignore error files from completed count.
+	sb.Where(sb.NotLike("file_name", "%-error.ndjson%")) //Ignore error files from completed count.
 
 	query, args := sb.Build()
 	var count int


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7894

## 🛠 Changes

Adds additional wildcard param to ensure that -error.ndjson files are properly left uncounted. 

## ℹ️ Context for reviewers

I forgot a % at the end of the query. 

## ✅ Acceptance Validation

Go behavior matches postgres query used to build the original PR. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
