### PR TITLE
BCDA-7851: Compare _since parameter in Group endpoint with CCLF file processing date

### DIFF
--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -100,6 +100,9 @@ type CCLFFile struct {
 	PerformanceYear int
 	ImportStatus    string
 	Type            CCLFFileType
+	// CreatedAt is automatically set by the database. This is only
+	// set/pulled when querying data in the DB.
+	CreatedAt time.Time
 }
 
 // "The MBI has 11 characters, like the Health Insurance Claim Number (HICN), which can have up to 11."

--- a/bcda/models/postgres/repository.go
+++ b/bcda/models/postgres/repository.go
@@ -117,9 +117,9 @@ func (r *Repository) GetCCLFFileExistsByName(ctx context.Context, name string) (
 	return true, nil
 }
 
-func (r *Repository) GetLatestCCLFFile(ctx context.Context, cmsID string, cclfNum int, importStatus string, lowerBound, upperBound time.Time, fileType models.CCLFFileType) (*models.CCLFFile, error) {
+func (r *Repository) GetLatestCCLFFile(ctx context.Context, cmsID string, cclfNum int, importStatus string, lowerBound time.Time, upperBound time.Time, fileType models.CCLFFileType) (*models.CCLFFile, error) {
 	sb := sqlFlavor.NewSelectBuilder()
-	sb.Select("id", "name", "timestamp", "performance_year")
+	sb.Select("id", "name", "timestamp", "performance_year", "created_at")
 	sb.From("cclf_files")
 	sb.Where(
 		sb.Equal("aco_cms_id", cmsID),
@@ -145,11 +145,12 @@ func (r *Repository) GetLatestCCLFFile(ctx context.Context, cmsID string, cclfNu
 			sb.LessEqualThan("timestamp", upperBound),
 		)
 	}
+
 	sb.OrderBy("performance_year DESC, timestamp DESC").Limit(1)
 
 	query, args := sb.Build()
 	row := r.QueryRowContext(ctx, query, args...)
-	if err := row.Scan(&cclfFile.ID, &cclfFile.Name, &cclfFile.Timestamp, &cclfFile.PerformanceYear); err != nil {
+	if err := row.Scan(&cclfFile.ID, &cclfFile.Name, &cclfFile.Timestamp, &cclfFile.PerformanceYear, &cclfFile.CreatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -141,7 +141,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			if tt.result == nil {
 				assert.Nil(t, cclfFile)
 			} else {
-				assert.Equal(t, tt.result, cclfFile)
+				assertEqualCCLFFile(assert.New(t), *tt.result, *cclfFile)
 			}
 		})
 	}

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -1013,6 +1013,9 @@ func assertEqualCCLFFile(assert *assert.Assertions, expected, actual models.CCLF
 	expected.Timestamp = expected.Timestamp.UTC()
 	actual.Timestamp = actual.Timestamp.UTC()
 
+	// sync CreatedAt timestamps so we can ignore differences between in-memory and saved data
+	expected.CreatedAt = actual.Timestamp.UTC()
+
 	assert.Equal(expected, actual)
 }
 

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -1015,6 +1015,7 @@ func assertEqualCCLFFile(assert *assert.Assertions, expected, actual models.CCLF
 
 	// sync CreatedAt timestamps so we can ignore differences between in-memory and saved data
 	expected.CreatedAt = actual.CreatedAt.UTC()
+	actual.CreatedAt = actual.CreatedAt.UTC()
 
 	assert.Equal(expected, actual)
 }

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -1014,7 +1014,7 @@ func assertEqualCCLFFile(assert *assert.Assertions, expected, actual models.CCLF
 	actual.Timestamp = actual.Timestamp.UTC()
 
 	// sync CreatedAt timestamps so we can ignore differences between in-memory and saved data
-	expected.CreatedAt = actual.Timestamp.UTC()
+	expected.CreatedAt = actual.CreatedAt.UTC()
 
 	assert.Equal(expected, actual)
 }

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -61,7 +61,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Time{},
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year, created_at FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -69,7 +69,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Time{},
 			models.FileTypeRunout,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year, created_at FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeRunout),
 		},
 		{
@@ -77,7 +77,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Now(),
 			time.Time{},
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year, created_at FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -85,7 +85,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Now(),
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp <= $5 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year, created_at FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp <= $5 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -93,7 +93,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Now(),
 			time.Now(),
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 AND timestamp <= $6 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year, created_at FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 AND timestamp >= $5 AND timestamp <= $6 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			getCCLFFile(cclfNum, cmsID, importStatus, models.FileTypeDefault),
 		},
 		{
@@ -101,7 +101,7 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 			time.Time{},
 			time.Time{},
 			models.FileTypeDefault,
-			`SELECT id, name, timestamp, performance_year FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
+			`SELECT id, name, timestamp, performance_year, created_at FROM cclf_files WHERE aco_cms_id = $1 AND cclf_num = $2 AND import_status = $3 AND type = $4 ORDER BY performance_year DESC, timestamp DESC LIMIT 1`,
 			nil,
 		},
 	}
@@ -131,8 +131,8 @@ func (r *RepositoryTestSuite) TestGetLatestCCLFFile() {
 				query.WillReturnError(sql.ErrNoRows)
 			} else {
 				query.WillReturnRows(sqlmock.
-					NewRows([]string{"id", "name", "timestamp", "performance_year"}).
-					AddRow(tt.result.ID, tt.result.Name, tt.result.Timestamp, tt.result.PerformanceYear))
+					NewRows([]string{"id", "name", "timestamp", "performance_year", "created_at"}).
+					AddRow(tt.result.ID, tt.result.Name, tt.result.Timestamp, tt.result.PerformanceYear, time.Now()))
 			}
 			cclfFile, err := repository.GetLatestCCLFFile(context.Background(), cmsID, cclfNum, importStatus, tt.lowerBound, tt.upperBound,
 				tt.fileType)

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -359,6 +359,23 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 		return nil, nil, CCLFNotFoundError{8, conditions.CMSID, conditions.fileType, cutoffTime}
 	}
 
+	// If the _since parameter is more recent than the latest CCLF file processing date,
+	// all beneficiaries should be considered pre-existing benes.
+	if !conditions.Since.IsZero() && cclfFileNew.CreatedAt.Sub(conditions.Since) < 0 {
+		// Retrieve all of the benes associated with this CCLF file.
+		benes, err := s.getBenesByFileID(ctx, cclfFileNew.ID, conditions)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if len(benes) == 0 {
+			return nil, nil, fmt.Errorf("Found 0 new or existing beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
+				conditions.CMSID, cclfFileNew.ID)
+		}
+
+		return newBeneficiaries, beneficiaries, nil
+	}
+
 	// Retrieve an older CCLF file for beneficiary comparison.
 	// This should be older than cclfFileNew AND prior to the "since" parameter, if provided.
 	//
@@ -369,8 +386,8 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 	//
 	oldFileUpperBound := conditions.Since
 
-	// If the _since parameter is more recent than the latest CCLF file, set the upper bound
-	// for the older file to be prior to cclfFileNew.Timestamp.
+	// If the _since parameter is more recent than the latest CCLF file timestamp, set the upper bound
+	// for the older file to be prior to the newest file's timestamp.
 	if !conditions.Since.IsZero() && cclfFileNew.Timestamp.Sub(conditions.Since) < 0 {
 		oldFileUpperBound = cclfFileNew.Timestamp.Add(-1 * time.Second)
 	}
@@ -384,6 +401,7 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 	if cclfFileOld == nil {
 		s.logger.Infof("Unable to find CCLF8 File for cmsID %s prior to date: %s; all beneficiaries will be considered NEW",
 			conditions.CMSID, conditions.Since)
+
 		newBeneficiaries, err = s.getBenesByFileID(ctx, cclfFileNew.ID, conditions)
 		if err != nil {
 			return nil, nil, err

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -373,7 +373,7 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 				conditions.CMSID, cclfFileNew.ID)
 		}
 
-		return newBeneficiaries, beneficiaries, nil
+		return newBeneficiaries, benes, nil
 	}
 
 	// Retrieve an older CCLF file for beneficiary comparison.

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -1154,6 +1154,7 @@ func getCCLFFile(id uint, isRunout bool, forceIncorrect bool) *models.CCLFFile {
 	return &models.CCLFFile{
 		ID:              id,
 		PerformanceYear: performanceYear,
+		CreatedAt:       time.Now(),
 	}
 }
 

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -461,12 +461,21 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries_RecentSinceParamet
 			assert.Len(oldBenes, len(tt.expectedOldMBIIndexes))
 			assert.Len(newBenes, len(tt.expectedNewMBIIndexes))
 
-			for idx, mbiIdx := range tt.expectedOldMBIIndexes {
-				assert.Equal(generatedMbis[mbiIdx], oldBenes[idx].MBI, "MBI %s should be found in old MBI map %v", oldBenes[idx].MBI, oldBenes)
+			contains := func(arr []*models.CCLFBeneficiary, mbi string) bool {
+				for _, bene := range arr {
+					if bene.MBI == mbi {
+						return true
+					}
+				}
+				return false
 			}
 
-			for idx, mbiIdx := range tt.expectedNewMBIIndexes {
-				assert.Equal(generatedMbis[mbiIdx], newBenes[idx].MBI, "MBI %s should be found in new MBI map %v", newBenes[idx].MBI, newBenes)
+			for _, mbiIdx := range tt.expectedOldMBIIndexes {
+				assert.True(contains(oldBenes, generatedMbis[mbiIdx]), "MBI %s should be found in old MBI map %v", generatedMbis[mbiIdx], oldBenes)
+			}
+
+			for _, mbiIdx := range tt.expectedNewMBIIndexes {
+				assert.True(contains(newBenes, generatedMbis[mbiIdx]), "MBI %s should be found in new MBI map %v", generatedMbis[mbiIdx], newBenes)
 			}
 		})
 	}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7851

## 🛠 Changes

- Modify new beneficiaries check to compare `_since` parameter against the latest CCLF file processing date instead of attribution timestamp

## ℹ️ Context for reviewers

Currently, the since parameter is not implemented _optimally per the spec on the Bulk FHIR IG (https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters) . 

The current logic can lead to instances (especially around EOY) where users can receive excessive historical data due to comparisons with a previous PY file for comparing beneficiary rolls. 

The issue that ACOs have run into is that today, the timestamp is being used for comparisons, but there can be a week+ delay of when a file is generated, and when it is processed.

Instead, the new beneficiaries check should be calculated from the user's point of view (using the file processing time), _not_ based on the upstream attribution/CCLF file timestamp.

## ✅ Acceptance Validation

- Unit testing

## 🔒 Security Implications

No new data implications.

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
