### PR TITLE
Remove deadline from golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,10 @@ package:
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
 
-LINT_TIMEOUT ?= 3m
 lint:
 	docker-compose -f docker-compose.test.yml build tests
 	docker-compose -f docker-compose.test.yml run \
-	--rm tests golangci-lint run --exclude="(conf\.(Un)?[S,s]etEnv)" --exclude="github\.com\/stretchr\/testify\/suite\.Suite contains sync\.RWMutex" --deadline=$(LINT_TIMEOUT) --verbose
+	--rm tests golangci-lint run --exclude="(conf\.(Un)?[S,s]etEnv)" --exclude="github\.com\/stretchr\/testify\/suite\.Suite contains sync\.RWMutex" --verbose
 	docker-compose -f docker-compose.test.yml run --rm tests gosec ./... ./optout
 
 smoke-test:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,11 @@ package:
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-app packaging $(version)
 
 
+LINT_TIMEOUT ?= 3m
 lint:
 	docker-compose -f docker-compose.test.yml build tests
 	docker-compose -f docker-compose.test.yml run \
-	--rm tests golangci-lint run --exclude="(conf\.(Un)?[S,s]etEnv)" --exclude="github\.com\/stretchr\/testify\/suite\.Suite contains sync\.RWMutex" --verbose
+	--rm tests golangci-lint run --exclude="(conf\.(Un)?[S,s]etEnv)" --exclude="github\.com\/stretchr\/testify\/suite\.Suite contains sync\.RWMutex" --timeout=$(LINT_TIMEOUT) --verbose
 	docker-compose -f docker-compose.test.yml run --rm tests gosec ./... ./optout
 
 smoke-test:


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

Removed deadline parameter from golangci-lint

## ℹ️ Context for reviewers

--deadline option is deprecated as of 3/19/24 (https://github.com/golangci/golangci-lint/releases/tag/v1.57.0)  and will cause CI failures 

## ✅ Acceptance Validation

Linter no longer throws a build error in bcda-app or bcda-ssas-app

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
