### PR TITLE
N/A: Update BCDA to allow http/2 and http/1.1

### DIFF
--- a/bcda/servicemux/servicemux.go
+++ b/bcda/servicemux/servicemux.go
@@ -120,6 +120,7 @@ func (sm *ServiceMux) serveHTTPS(tlsCertPath, tlsKeyPath string) {
 			tls.X25519,
 		},
 		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2", "http/1.1"},
 	}
 
 	sm.Listener = tls.NewListener(sm.Listener, &sm.TLSConfig)


### PR DESCRIPTION
## 🎫 Ticket

N/A, testing.

## 🛠 Changes

Allow http2 in addition to http/1.1

## ℹ️ Context for reviewers

Golang has support for HTTP/2 by default, but not with the http server package we are using, we need to specify "nextprotos" to support HTTP/2. I took an earlier stab late last year at this, but will take a more methodical approach on the side to see if we can improve connection capacity / throughput via enabling HTTP/2 on bcda-app, followed by ssas-app. 

## ✅ Acceptance Validation

Testing in dev environment in combination with BCDA-ops update to target group to target HTTP/2.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
