### PR TITLE
remove codecov from ci

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Run all tests
         run: |
           make test
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: ./test_results/latest/testcoverage.out
 
   sonar-quality-gate:
     name: Sonarqube Quality Gate

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -49,19 +49,6 @@ jobs:
       - name: Run all tests
         run: |
           make test
-      - name: Generate codecov report
-        uses: codecov/codecov-action@v2
-        with:
-          files: ./test_results/latest/testcoverage.out # optional
-          flags: unittests # optional
-          name: codecov-umbrella # optional
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
-        with:
-          name: code-coverage-report
-          path: ./test_results/latest/testcoverage.out
 
   sonar-quality-gate:
     name: Sonarqube Quality Gate


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

removing codecov from CI, since sonarqube is doing the same thing and tokenless is hitting a github api limit. 

## ℹ️ Context for reviewers

[Link to discussion](https://github.com/codecov/feedback/issues/126#:~:text=Tokenless%20generally%20works%20by%20making%20an%20API%20call%20to%20GitHub%20to%20confirm%20that%20the%20repo%20and%20commit%20are%20the%20correct%20values.%20Making%20this%20call%20for%20thousands%20of%20repositories%20causes%20our%20GitHub%20token%20to%20hit%20the%20limit%20causing%20the%20issues%20that%20many%20of%20you%20have%20seen) on tokenless codecov generation and rate limiting. 

## ✅ Acceptance Validation

n/a

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
