### PR TITLE
BCDA-8088: Prevent potential memory leaks in worker

### DIFF
--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -207,6 +207,7 @@ func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.A
 	defer utils.CloseFileAndLogError(f)
 
 	w := bufio.NewWriter(f)
+	defer w.Flush()
 	errorCount := 0
 	totalBeneIDs := float64(len(jobArgs.BeneficiaryIDs))
 	failThreshold := getFailureThreshold()
@@ -341,6 +342,7 @@ func appendErrorToFile(ctx context.Context, fileUUID string,
 	if err != nil {
 		err = errors.Wrap(err, "Unable to append error to file: OS error encountered while opening the file")
 		logger.Error(err)
+		return
 	}
 
 	defer utils.CloseFileAndLogError(f)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8088

## 🛠 Changes

Added deferral of closing the bufio writer as well as returning on failure to load file. 

## ℹ️ Context for reviewers

In troubleshooting some worker errors, it appears there may be a relation to memory issues. Before scaling up, two things stuck out to me in the worker flows: there is no defer statement for the io writer, meaning an untimely error could lead to a memory leak, and likewise there is a defer statement on a file whose potential error opening is not handled. 

## ✅ Acceptance Validation

Local tests pass, CI checks. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
