### PR TITLE
BCDA-8088: ensure connection pool is properly released

### DIFF
--- a/bcdaworker/queueing/manager/que.go
+++ b/bcdaworker/queueing/manager/que.go
@@ -97,6 +97,7 @@ func StartQue(log logrus.FieldLogger, numWorkers int) *masterQueue {
 
 // StopQue cleans up any resources created
 func (q *masterQueue) StopQue() {
+	q.queDB.Close()
 	q.quePool.Shutdown()
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8088

## 🛠 Changes

Ensure that pgx pool is closed/released when worker is shut down

## ℹ️ Context for reviewers

While looking for potential spots where memory leaks could occur, it appears that while the workers are shut down, I'm unable to see an existing point where connections in a created pool are released. Our use of a deprecated queueing system has some drawbacks (and workarounds) built into it, so this may help reduce memory usage / cpu time dedicated to purging memory during a job, in conjunction with the existing PR for 8088

## ✅ Acceptance Validation

Passes tests locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
