### PR TITLE
BCDA-8088: Ensure fhirBundleToResourceNDJSON properly flushes buffer

### DIFF
--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -376,7 +376,8 @@ func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmod
 				responseutils.InternalErr, fmt.Sprintf("Error marshaling %s to JSON for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), jobID)
 			continue
 		}
-		_, err = w.WriteString(string(entryJSON) + "\n")
+
+		_, err = w.Write(append(entryJSON, '\n'))
 		if err != nil {
 			logger.Error(err)
 			appendErrorToFile(ctx, fileUUID, fhircodes.IssueTypeCode_EXCEPTION,

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -361,6 +361,7 @@ func appendErrorToFile(ctx context.Context, fileUUID string,
 func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, fileUUID string, jobID int) {
 	close := metrics.NewChild(ctx, "fhirBundleToResourceNDJSON")
 	defer close()
+	defer w.Flush()
 	logger := log.GetCtxLogger(ctx)
 	for _, entry := range b.Entries {
 		if entry["resource"] == nil {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8088

## 🛠 Changes

Ensure that buffer is flushed after each beneficiary's data is written. 

## ℹ️ Context for reviewers

Hopefully the last of these associated with 8088! Was able to ssh into workers while observing memory explosion. This should prevent runaway buffer size during job execution by ensuring that the buffer is flushed after each execution of fhirBundleToResourceNDJSON. 

## ✅ Acceptance Validation

Passes local tests + verified integrity / consistency of jobs in dev environment with this branch. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
