### PR TITLE
BCDA-8082: Add explicit logging for when a job fails

### DIFF
--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -125,6 +125,8 @@ func (w *worker) ProcessJob(ctx context.Context, job models.Job, jobArgs models.
 			err = errors.Wrap(err, fmt.Sprintf("Error updating the job status to %s", models.JobStatusFailed))
 			logger.Error(err)
 			return err
+		} else {
+			logger.Error("Job failed. Job ID: %s", job.ID)
 		}
 	}
 

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -126,7 +126,7 @@ func (w *worker) ProcessJob(ctx context.Context, job models.Job, jobArgs models.
 			logger.Error(err)
 			return err
 		} else {
-			logger.Error("Job failed. Job ID: %s", job.ID)
+			logger.Error("Job failed. Job ID: %d", job.ID)
 		}
 	}
 

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -126,7 +126,7 @@ func (w *worker) ProcessJob(ctx context.Context, job models.Job, jobArgs models.
 			logger.Error(err)
 			return err
 		} else {
-			logger.Error("Job failed. Job ID: %d", job.ID)
+			logger.Error("Job failed. Job ID: ", job.ID)
 		}
 	}
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8082

## 🛠 Changes

Added explicit log for when a job is marked as failed. 

## ℹ️ Context for reviewers

Currently, job-based failures are picked up via a new relic query on 500 status codes. This alerting is based upon a customer requesting data for a job that has a status of Failed. We have an opportunity to be alerted and take potential corrective action to the environment, in case there's a larger issue (we rarely actually have failed jobs). 

## ✅ Acceptance Validation

Ignore the %d, not sure why I was treating it as a printf statement at first. latest commit has it removed. 
![image](https://github.com/CMSgov/bcda-app/assets/120701369/a8f153ba-2bfc-4e80-a1f1-49c6c219f43d)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
