### PR TITLE
BCDA-8120: Parse Accept-Encoding to search for 'gzip'

### DIFF
--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -287,7 +288,7 @@ func ServeData(w http.ResponseWriter, r *http.Request) {
 
 	var useGZIP bool
 	for _, header := range r.Header.Values("Accept-Encoding") {
-		if header == "gzip" {
+		if strings.Contains(header, "gzip") {
 			useGZIP = true
 			break
 		}

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -365,6 +365,7 @@ func (s *APITestSuite) TestServeData() {
 		{"gzip-deflate", []string{"gzip, deflate"}, true},
 		{"gzip-deflate-br-handle", []string{"gzip,deflate, br"}, true},
 		{"gzip", []string{"deflate", "br", "gzip"}, true},
+		{"non-gzip w/ deflate and br", []string{"deflate", "br"}, false},
 		{"non-gzip", nil, false},
 	}
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8120

## 🛠 Changes

Update gzip logic to properly identify a gzip header

## ℹ️ Context for reviewers

>90% of requests to BCDA pass along a valid Accept-Encoding including gzip, but the current method of parsing is only recognizing "gzip" if that header exactly equals "gzip". This PR fixes that and searches for "gzip" and becomes agnostic to whatever else accompanies in that header. 

## ✅ Acceptance Validation

Added unit tests showing examples of headers we see in production

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
