### PR TITLE
PLT-366 Add opt-out-import workflows

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     paths-ignore:
-      - .github/workflows/opt-out-*
+      - .github/workflows/opt-out-import-*
       - optout/**
   pull_request:
     paths-ignore:
-      - .github/workflows/opt-out-*
+      - .github/workflows/opt-out-import-*
       - optout/**
 
 env:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - .github/workflows/opt-out-*
+      - optout/**
   pull_request:
+    paths-ignore:
+      - .github/workflows/opt-out-*
+      - optout/**
 
 env:
   COMPOSE_INTERACTIVE_NO_CLI: 1

--- a/.github/workflows/opt-out-import-dev-deploy.yml
+++ b/.github/workflows/opt-out-import-dev-deploy.yml
@@ -1,0 +1,38 @@
+name: opt-out-import dev deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - optout/**
+      - .github/workflows/opt-out-import-dev-deploy.yml
+  workflow_dispatch:
+
+jobs:
+  test:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./optout
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Build opt-out-import zip file
+        run: |
+          go build -o bootstrap main.go parsers.go utils.go models.go db.go
+          zip function.zip bootstrap
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-dev-github-actions
+      - name: Upload and reload
+        run: |
+          aws s3 cp --no-progress function.zip \
+            s3://bcda-dev-opt-out-import-function/function-${{ github.sha }}.zip
+          aws lambda update-function-code --function-name bcda-dev-opt-out-import \
+            --s3-bucket bcda-dev-opt-out-import-function --s3-key function-${{ github.sha }}.zip

--- a/.github/workflows/opt-out-import-prod-deploy.yml
+++ b/.github/workflows/opt-out-import-prod-deploy.yml
@@ -1,0 +1,24 @@
+name: opt-out-import prod deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-prod-github-actions
+      - name: Promote lambda code from test to prod
+        run: |
+          aws s3 cp --no-progress \
+            s3://bcda-test-opt-out-import-function/function-${{ github.sha }}.zip \
+            s3://bcda-prod-opt-out-import-function/function-${{ github.sha }}.zip
+          aws lambda update-function-code --function-name bcda-prod-opt-out-import \
+            --s3-bucket bcda-prod-opt-out-import-function --s3-key function-${{ github.sha }}.zip

--- a/.github/workflows/opt-out-import-test-deploy.yml
+++ b/.github/workflows/opt-out-import-test-deploy.yml
@@ -1,0 +1,35 @@
+name: opt-out-import test deploy
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./optout
+    environment: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Build opt-out-import zip file
+        env:
+          CGO_ENABLED: 0
+        run: |
+          go build -o bootstrap main.go parsers.go utils.go models.go db.go
+          zip function.zip bootstrap
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
+      - name: Upload and reload
+        run: |
+          aws s3 cp --no-progress function.zip \
+            s3://bcda-test-opt-out-import-function/function-${{ github.sha }}.zip
+          aws lambda update-function-code --function-name bcda-test-opt-out-import \
+            --s3-bucket bcda-test-opt-out-import-function --s3-key function-${{ github.sha }}.zip

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -1,0 +1,51 @@
+name: opt-out-import test integration
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/opt-out-import-test-integration.yml
+      - .github/workflows/opt-out-import-test-deploy.yml
+      - optout/**
+  workflow_dispatch:
+
+# Ensure we have only one integration test running at a time
+concurrency:
+  group: opt-out-import-test-integration
+
+jobs:
+  # Deploy first if triggered by pull_request
+  deploy:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/opt-out-import-test-deploy.yml
+    secrets: inherit
+
+  trigger:
+    if: ${{ always() }}
+    needs: deploy
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./optout
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-opt-out-import-function
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          # Note that we use the BFD role with access to the bucket
+          role-to-assume: arn:aws:iam::${{ secrets.BFD_ACCOUNT_ID }}:role/bfd-test-eft-bcda-bucket-role
+          role-chaining: true
+          role-skip-session-tagging: true
+      - name: Upload test file to the BFD bucket to trigger lambda function via SNS message
+        run: |
+          aws s3 cp --no-progress synthetic_test_data/T.NGD.DPC.RSP.D240123.T1122001.IN \
+            s3://bfd-test-eft/bfdeft01/bcda/in/T.NGD.DPC.RSP.D$(date +'%y%m%d').T$(date +'%H%M%S')1.IN
+
+  # TODO Check bucket for response file
+  # TODO Run another job to check database for update

--- a/.github/workflows/opt-out-import-unit.yml
+++ b/.github/workflows/opt-out-import-unit.yml
@@ -1,0 +1,20 @@
+name: opt-out-import unit tests
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/opt-out-import-unit.yml
+      - optout/**
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./optout
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Run unit tests for opt-out-import lambda
+        run: go test


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-366

## 🛠 Changes

Added workflows for the optout lambda for BCDA.

## ℹ️ Context for reviewers

These files have been copied over from the dpc-app repo. I've made some adjustments for BCDA but more will likely still need to be made to tailor to specifics in the BCDA function.

Related ticket at https://jira.cms.gov/browse/BCDA-7898.

## ✅ Acceptance Validation

This PR will need to be merged before we can test these workflows, so we should get them in pretty good shape then merge, and follow up with another PR to fix any further issues.

## 🔒 Security Implications

None.
