### PR TITLE
BCDA-7980: Implement gzip compression for files stored on EFS

### DIFF
--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -179,11 +179,12 @@ func compressFiles(ctx context.Context, tempDir string, stagingDir string) error
 	gzipLevel, err := strconv.Atoi(os.Getenv("COMPRESSION_LEVEL"))
 	if err != nil || gzipLevel < 1 || gzipLevel > 9 { //levels 1-9 supported by BCDA.
 		gzipLevel = gzip.DefaultCompression
-		logger.Warnf("COMPRESSION_LEVEL not set to appropriate value.")
+		logger.Warnf("COMPRESSION_LEVEL not set to appropriate value; using default.")
 	}
 	for _, f := range files {
 		oldPath := fmt.Sprintf("%s/%s", tempDir, f.Name())
 		newPath := fmt.Sprintf("%s/%s", stagingDir, f.Name())
+		//Anonymous function to ensure defer statements run
 		err := func() error {
 			inputFile, err := os.Open(filepath.Clean(oldPath))
 			if err != nil {

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -177,6 +177,9 @@ func compressFiles(tempDir string, stagingDir string) error {
 	if err != nil {
 		gzipLevel = gzip.DefaultCompression
 	}
+	if gzipLevel < 1 || gzipLevel > 9 { //levels 1-9 supported by BCDA.
+		gzipLevel = gzip.DefaultCompression
+	}
 	for _, f := range files {
 		oldPath := fmt.Sprintf("%s/%s", tempDir, f.Name())
 		newPath := fmt.Sprintf("%s/%s", stagingDir, f.Name())

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -174,10 +174,7 @@ func compressFiles(tempDir string, stagingDir string) error {
 		return err
 	}
 	gzipLevel, err := strconv.Atoi(os.Getenv("COMPRESSION_LEVEL"))
-	if err != nil {
-		gzipLevel = gzip.DefaultCompression
-	}
-	if gzipLevel < 1 || gzipLevel > 9 { //levels 1-9 supported by BCDA.
+	if err != nil || gzipLevel < 1 || gzipLevel > 9 { //levels 1-9 supported by BCDA.
 		gzipLevel = gzip.DefaultCompression
 	}
 	for _, f := range files {

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -578,12 +578,13 @@ func (s *WorkerTestSuite) TestCreateDir() {
 	assert.NoError(s.T(), err)
 }
 
-func (s *WorkerTestSuite) TestMoveFiles() {
-	//negative case
-	err := moveFiles("/", "fake_dir")
+func (s *WorkerTestSuite) TestCompressFiles() {
+	//negative cases.
+	err := compressFiles("/", "fake_dir")
 	assert.Error(s.T(), err)
-	err = moveFiles("/proc/fakedir", "fake_dir")
+	err = compressFiles("/proc/fakedir", "fake_dir")
 	assert.Error(s.T(), err)
+
 	//positive case, create two temporary directories + a file, and move a file between them.
 	tempDir1, err := os.MkdirTemp("", "*")
 	if err != nil {
@@ -597,12 +598,16 @@ func (s *WorkerTestSuite) TestMoveFiles() {
 	if err != nil {
 		s.FailNow(err.Error())
 	}
-	err = moveFiles(tempDir1, tempDir2)
+	err = compressFiles(tempDir1, tempDir2)
 	assert.NoError(s.T(), err)
 	files, _ := os.ReadDir(tempDir2)
 	assert.Len(s.T(), files, 1)
 	files, _ = os.ReadDir(tempDir1)
-	assert.Len(s.T(), files, 0)
+	assert.Len(s.T(), files, 1)
+
+	//One more negative case, when the destination is not able to be moved.
+	err = compressFiles(tempDir2, "/proc/fakedir")
+	assert.Error(s.T(), err)
 
 }
 

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -578,6 +578,31 @@ func (s *WorkerTestSuite) TestCreateDir() {
 	assert.NoError(s.T(), err)
 }
 
+func (s *WorkerTestSuite) TestCompressFilesGzipLevel() {
+	//In short, none of these should produce errors when being run.
+	tempDir1, err := os.MkdirTemp("", "*")
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+	tempDir2, err := os.MkdirTemp("", "*")
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	os.Setenv("COMPRESSION_LEVEL", "potato")
+	err = compressFiles(tempDir1, tempDir2)
+	assert.NoError(s.T(), err)
+
+	os.Setenv("COMPRESSION_LEVEL", "1")
+	err = compressFiles(tempDir1, tempDir2)
+	assert.NoError(s.T(), err)
+
+	os.Setenv("COMPRESSION_LEVEL", "11")
+	err = compressFiles(tempDir1, tempDir2)
+	assert.NoError(s.T(), err)
+
+}
+
 func (s *WorkerTestSuite) TestCompressFiles() {
 	//negative cases.
 	err := compressFiles("/", "fake_dir")

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -590,24 +590,24 @@ func (s *WorkerTestSuite) TestCompressFilesGzipLevel() {
 	}
 
 	os.Setenv("COMPRESSION_LEVEL", "potato")
-	err = compressFiles(tempDir1, tempDir2)
+	err = compressFiles(s.logctx, tempDir1, tempDir2)
 	assert.NoError(s.T(), err)
 
 	os.Setenv("COMPRESSION_LEVEL", "1")
-	err = compressFiles(tempDir1, tempDir2)
+	err = compressFiles(s.logctx, tempDir1, tempDir2)
 	assert.NoError(s.T(), err)
 
 	os.Setenv("COMPRESSION_LEVEL", "11")
-	err = compressFiles(tempDir1, tempDir2)
+	err = compressFiles(s.logctx, tempDir1, tempDir2)
 	assert.NoError(s.T(), err)
 
 }
 
 func (s *WorkerTestSuite) TestCompressFiles() {
 	//negative cases.
-	err := compressFiles("/", "fake_dir")
+	err := compressFiles(s.logctx, "/", "fake_dir")
 	assert.Error(s.T(), err)
-	err = compressFiles("/proc/fakedir", "fake_dir")
+	err = compressFiles(s.logctx, "/proc/fakedir", "fake_dir")
 	assert.Error(s.T(), err)
 
 	//positive case, create two temporary directories + a file, and move a file between them.
@@ -623,7 +623,7 @@ func (s *WorkerTestSuite) TestCompressFiles() {
 	if err != nil {
 		s.FailNow(err.Error())
 	}
-	err = compressFiles(tempDir1, tempDir2)
+	err = compressFiles(s.logctx, tempDir1, tempDir2)
 	assert.NoError(s.T(), err)
 	files, _ := os.ReadDir(tempDir2)
 	assert.Len(s.T(), files, 1)
@@ -631,7 +631,7 @@ func (s *WorkerTestSuite) TestCompressFiles() {
 	assert.Len(s.T(), files, 1)
 
 	//One more negative case, when the destination is not able to be moved.
-	err = compressFiles(tempDir2, "/proc/fakedir")
+	err = compressFiles(s.logctx, tempDir2, "/proc/fakedir")
 	assert.Error(s.T(), err)
 
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7980

## 🛠 Changes

Instead of attempting to move files, we write a gzip-encoded file to EFS and delete the temporary files after each job key

## ℹ️ Context for reviewers

This is the final ticket in the gzip epic, yay! 
Adds a new environment variable, COMPRESSION_LEVEL, that can be set between 1-9
Files are stored as gzip-encoded content, previous PRs ensure that the /data/ endpoint are content-encoding aware, and can return un-encoded content if requested, while ensuring significant gains for the 90+% of requests that do request gzip-encoded content.

## ✅ Acceptance Validation

Smoke tests + unit tests pass.
I've also performed manual validation utilizing the dev server. Throughput is as expected.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
