### PR TITLE
Ensure temp directory is cleared on process start

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "BB_CLIENT_KEY_FILE": "${workspaceFolder}/shared_files/decrypted/bfd-dev-test-key.pem",
         "FHIR_PAYLOAD_DIR": "${workspaceFolder}/bcdaworker/data",
         "FHIR_STAGING_DIR": "${workspaceFolder}/bcdaworker/tmpdata",
+        "FHIR_TEMP_DIR": "${workspaceFolder}/bcdaworker/TEMP",
         "FHIR_ARCHIVE_DIR": "${workspaceFolder}/bcdaworker/archive",
     },
     "go.testEnvFile": "${workspaceFolder}/shared_files/decrypted/local.env",

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -34,6 +35,30 @@ func createWorkerDirs() {
 	if err != nil {
 		log.Worker.Fatal(err)
 	}
+	err = clearTempDirectory(localTemp)
+	if err != nil {
+		log.Worker.Fatal(err)
+	}
+
+}
+func clearTempDirectory(tempDir string) error {
+	err := filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == tempDir {
+			return nil
+		}
+		if info.IsDir() {
+			return os.RemoveAll(path)
+		}
+		return os.Remove(path)
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func waitForSig() {

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/CMSgov/bcda-app/conf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClearTempDirectory(t *testing.T) {
+	tempDirPrefix := conf.GetEnv("FHIR_TEMP_DIR")
+	tempDir, err := os.MkdirTemp(tempDirPrefix, "bananas")
+	defer os.RemoveAll(tempDir)
+	assert.NoError(t, err)
+
+	nestedDir := filepath.Join(tempDir, "nested")
+	err = os.Mkdir(nestedDir, 0755)
+	assert.DirExists(t, nestedDir)
+	assert.NoError(t, err)
+
+	tempFile := filepath.Join(tempDir, "tmp.txt")
+	err = os.WriteFile(tempFile, []byte("test data"), 0644)
+	assert.NoError(t, err)
+
+	dir, err := os.ReadDir(tempDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(dir)) //We've created a file/directory, so we expect something.
+
+	err = clearTempDirectory(tempDir)
+	assert.NoError(t, err)
+
+	dir, err = os.ReadDir(tempDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(dir)) //Expect that there will be no entries after cleaning.
+
+	err = clearTempDirectory("/fakedir") //Expect an error when there's an incorrect directory passed
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

Ensure that the temporary directory is emptied upon process start.

## ℹ️ Context for reviewers

After changing the worker's logic to write to EBS volumes prior to writing compressed files to EFS, some monitoring showed that if the bcda worker process exits in a non-graceful manner, data could accumulate on the EBS volume and cause out of space errors. This PR ensures that when the process starts, the temporary directory is cleared. 

## ✅ Acceptance Validation

Added unit tests that pass. 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
