### PR TITLE
Fix lambda handler paths

### DIFF
--- a/.github/workflows/cclf-import-dev-deploy.yml
+++ b/.github/workflows/cclf-import-dev-deploy.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - name: Build cclf-import zip file
+        env:
+          CGO_ENABLED: 0
         run: |
           go build -o bin/bootstrap ./lambda/cclf/main.go
           zip -j function.zip bin/bootstrap

--- a/.github/workflows/cclf-import-dev-deploy.yml
+++ b/.github/workflows/cclf-import-dev-deploy.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Build cclf-import zip file
         run: |
-          go build -o bin/cclf-import ./lambda/cclf/main.go
-          zip -j function.zip bin/cclf-import
+          go build -o bin/bootstrap ./lambda/cclf/main.go
+          zip -j function.zip bin/bootstrap
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/cclf-import-dev-deploy.yml
+++ b/.github/workflows/cclf-import-dev-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build cclf-import zip file
         run: |
           go build -o bin/cclf-import ./lambda/cclf/main.go
-          zip function.zip bin/cclf-import
+          zip -j function.zip bin/cclf-import
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/cclf-import-test-deploy.yml
+++ b/.github/workflows/cclf-import-test-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           CGO_ENABLED: 0
         run: |
           go build -o bin/cclf-import ./lambda/cclf/main.go
-          zip function.zip bin/cclf-import
+          zip -j function.zip bin/cclf-import
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/cclf-import-test-deploy.yml
+++ b/.github/workflows/cclf-import-test-deploy.yml
@@ -21,8 +21,8 @@ jobs:
         env:
           CGO_ENABLED: 0
         run: |
-          go build -o bin/cclf-import ./lambda/cclf/main.go
-          zip -j function.zip bin/cclf-import
+          go build -o bin/bootstrap ./lambda/cclf/main.go
+          zip -j function.zip bin/bootstrap
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/opt-out-import-dev-deploy.yml
+++ b/.github/workflows/opt-out-import-dev-deploy.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Build opt-out-import zip file
         run: |
-          go build -o bin/opt-out-import ./lambda/optout/main.go
-          zip -j function.zip bin/opt-out-import
+          go build -o bin/bootstrap ./lambda/optout/main.go
+          zip -j function.zip bin/bootstrap
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/opt-out-import-dev-deploy.yml
+++ b/.github/workflows/opt-out-import-dev-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build opt-out-import zip file
         run: |
           go build -o bin/opt-out-import ./lambda/optout/main.go
-          zip function.zip bin/opt-out-import
+          zip -j function.zip bin/opt-out-import
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/opt-out-import-dev-deploy.yml
+++ b/.github/workflows/opt-out-import-dev-deploy.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - name: Build opt-out-import zip file
+        env:
+          CGO_ENABLED: 0
         run: |
           go build -o bin/bootstrap ./lambda/optout/main.go
           zip -j function.zip bin/bootstrap

--- a/.github/workflows/opt-out-import-test-deploy.yml
+++ b/.github/workflows/opt-out-import-test-deploy.yml
@@ -21,8 +21,8 @@ jobs:
         env:
           CGO_ENABLED: 0
         run: |
-          go build -o bin/opt-out-import ./lambda/optout/main.go
-          zip -j function.zip bin/opt-out-import
+          go build -o bin/bootstrap ./lambda/optout/main.go
+          zip -j function.zip bin/bootstrap
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/opt-out-import-test-deploy.yml
+++ b/.github/workflows/opt-out-import-test-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           CGO_ENABLED: 0
         run: |
           go build -o bin/opt-out-import ./lambda/optout/main.go
-          zip function.zip bin/opt-out-import
+          zip -j function.zip bin/opt-out-import
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Remove `/bin/` directories from function zips using `zip -j`
- Rename files to `bootstrap`

## ℹ️ Context

Was looking at the lambda logs and saw some errors with trying to find the entrypoint. After reading the AWS documentation, I realized that it expects the zip file to have exactly one binary, which is specifically named `bootstrap` 😅

This was an oversight on my part — I thought if the handler was specified as `cclf-import` in the lambda config, it would look for that binary filename instead.

## 🧪 Validation

Verified in logs (doesn't complete successfully, we have another network issue to address..)

![CleanShot 2024-06-21 at 13 35 58@2x](https://github.com/CMSgov/bcda-app/assets/2308368/f3bd76fe-e6ee-48cc-a2e8-ce43f3713565)
