### PR TITLE
Remove stdout print statements

### DIFF
--- a/optout/local_file_handler.go
+++ b/optout/local_file_handler.go
@@ -12,6 +12,7 @@ import (
 )
 
 // LocalFileHandler manages files from local directories.
+// This handler should only be used for local dev/testing now.
 type LocalFileHandler struct {
 	Logger                 logrus.FieldLogger
 	PendingDeletionDir     string

--- a/optout/s3_file_handler.go
+++ b/optout/s3_file_handler.go
@@ -30,17 +30,14 @@ type S3FileHandler struct {
 // 2. stdout (Jenkins)
 
 func (handler *S3FileHandler) Infof(format string, rest ...interface{}) {
-	fmt.Printf(format, rest...)
 	handler.Logger.Infof(format, rest...)
 }
 
 func (handler *S3FileHandler) Warningf(format string, rest ...interface{}) {
-	fmt.Printf(format, rest...)
 	handler.Logger.Warningf(format, rest...)
 }
 
 func (handler *S3FileHandler) Errorf(format string, rest ...interface{}) {
-	fmt.Printf(format, rest...)
 	handler.Logger.Errorf(format, rest...)
 }
 


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

Remove print statements

## ℹ️ Context

These were causing the error alarm to go off. We used to duplicate messages to stdout and to the formatted JSON Logger since only stdout would be printed in Jenkins logs. Since we are running in lambda now, we can remove that.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Unit Testing
