### PR TITLE
BCDA-8162: Update cli commands to be more inclusive.

### DIFF
--- a/bcda/auth/ssas.go
+++ b/bcda/auth/ssas.go
@@ -156,7 +156,7 @@ func (s SSASPlugin) getAuthDataFromClaims(claims *CommonClaims) (AuthData, error
 		return ad, entityNotFoundError
 	}
 	ad.ACOID = aco.UUID.String()
-	ad.Blacklisted = aco.Blacklisted()
+	ad.Blacklisted = aco.Denylisted()
 
 	return ad, nil
 }

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -625,9 +625,9 @@ func setUpApp() *cli.App {
 			},
 		},
 		{
-			Name:     "blacklist-aco",
+			Name:     "denylist-aco",
 			Category: constants.CliAuthToolsCategory,
-			Usage:    "Blacklists an ACO by their CMS ID",
+			Usage:    "Denylists an ACO by their CMS ID",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        constants.CliCMSIDArg,
@@ -639,15 +639,15 @@ func setUpApp() *cli.App {
 				td := &models.Termination{
 					TerminationDate: time.Now(),
 					CutoffDate:      time.Now(),
-					BlacklistType:   models.Involuntary,
+					DenylistType:    models.Involuntary,
 				}
-				return setBlacklistState(acoCMSID, td)
+				return setDenylistState(acoCMSID, td)
 			},
 		},
 		{
-			Name:     "unblacklist-aco",
+			Name:     "undenylist-aco",
 			Category: constants.CliAuthToolsCategory,
-			Usage:    "Unblacklists an ACO by their CMS ID",
+			Usage:    "Undenylists an ACO by their CMS ID",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:        constants.CliCMSIDArg,
@@ -656,7 +656,7 @@ func setUpApp() *cli.App {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return setBlacklistState(acoCMSID, nil)
+				return setDenylistState(acoCMSID, nil)
 			},
 		},
 	}
@@ -851,7 +851,7 @@ func cleanupJobData(jobID uint, rootDirs ...string) error {
 	return nil
 }
 
-func setBlacklistState(cmsID string, td *models.Termination) error {
+func setDenylistState(cmsID string, td *models.Termination) error {
 	aco, err := r.GetACOByCMSID(context.Background(), cmsID)
 	if err != nil {
 		return err

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -69,10 +69,10 @@ type ACO struct {
 	TerminationDetails *Termination `json:"termination"`
 }
 
-// Blacklisted returns bool based on TerminationDetails.
-func (aco *ACO) Blacklisted() bool {
+// Denylisted returns bool based on TerminationDetails.
+func (aco *ACO) Denylisted() bool {
 	if aco.TerminationDetails != nil {
-		if aco.TerminationDetails.BlacklistType == Involuntary || aco.TerminationDetails.BlacklistType == Voluntary {
+		if aco.TerminationDetails.DenylistType == Involuntary || aco.TerminationDetails.DenylistType == Voluntary {
 			return true
 		} else {
 			return false

--- a/bcda/models/models_test.go
+++ b/bcda/models/models_test.go
@@ -30,23 +30,23 @@ func (s *ModelsTestSuite) TestJobStatusMessage() {
 	assert.Equal(s.T(), string(JobStatusCompleted), j.StatusMessage())
 }
 
-func (s *ModelsTestSuite) TestACOBlacklist() {
-	blackListDate := time.Date(2020, time.December, 31, 23, 59, 59, 0, time.Local)
-	blackListValues := []Termination{
+func (s *ModelsTestSuite) TestACODenylist() {
+	denyListDate := time.Date(2020, time.December, 31, 23, 59, 59, 0, time.Local)
+	denyListValues := []Termination{
 		{
-			TerminationDate: blackListDate,
-			CutoffDate:      blackListDate,
-			BlacklistType:   Involuntary,
+			TerminationDate: denyListDate,
+			CutoffDate:      denyListDate,
+			DenylistType:    Involuntary,
 		},
 		{
-			TerminationDate: blackListDate,
-			CutoffDate:      blackListDate,
-			BlacklistType:   Voluntary,
+			TerminationDate: denyListDate,
+			CutoffDate:      denyListDate,
+			DenylistType:    Voluntary,
 		},
 		{
-			TerminationDate: blackListDate,
-			CutoffDate:      blackListDate,
-			BlacklistType:   Limited,
+			TerminationDate: denyListDate,
+			CutoffDate:      denyListDate,
+			DenylistType:    Limited,
 		},
 	}
 	tests := []struct {
@@ -54,9 +54,9 @@ func (s *ModelsTestSuite) TestACOBlacklist() {
 		td             *Termination
 		expectedResult bool
 	}{
-		{"Details Involuntary", &blackListValues[0], true},
-		{"Details Voluntary", &blackListValues[1], true},
-		{"Details Limited", &blackListValues[2], false},
+		{"Details Involuntary", &denyListValues[0], true},
+		{"Details Voluntary", &denyListValues[1], true},
+		{"Details Limited", &denyListValues[2], false},
 		{"Details Missing", &Termination{}, true},
 		{"Null", nil, false},
 	}
@@ -67,10 +67,10 @@ func (s *ModelsTestSuite) TestACOBlacklist() {
 			aco := ACO{
 				UUID:               uuid.NewUUID(),
 				CMSID:              &cmsID,
-				Name:               "Blacklisted ACO",
+				Name:               "Denylisted ACO",
 				TerminationDetails: tt.td,
 			}
-			assert.Equal(s.T(), aco.Blacklisted(), tt.expectedResult)
+			assert.Equal(s.T(), aco.Denylisted(), tt.expectedResult)
 		})
 	}
 }

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -408,7 +408,7 @@ func (r *RepositoryTestSuite) TestACOMethods() {
 	termination := &models.Termination{
 		TerminationDate:     now,
 		CutoffDate:          now.Add(time.Hour).Round(time.Millisecond),
-		BlacklistType:       models.Voluntary,
+		DenylistType:        models.Voluntary,
 		AttributionStrategy: models.AttributionHistorical,
 		OptOutStrategy:      models.OptOutLatest,
 		ClaimsStrategy:      models.ClaimsHistorical,

--- a/bcda/models/termination.go
+++ b/bcda/models/termination.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-type Blacklist uint8
+type Denylist uint8
 
 const (
 	// Involuntary means the caller had access revoked immediately
-	Involuntary Blacklist = iota
+	Involuntary Denylist = iota
 	// Voluntary means the caller had limited access then had their access completely revoked
 	Voluntary
 	// Limited means the caller has limited access to the service
@@ -41,7 +41,7 @@ type Termination struct {
 	TerminationDate time.Time // When caller moved from full to limited access
 	CutoffDate      time.Time // When caller moved to no access
 
-	BlacklistType       Blacklist
+	DenylistType        Denylist
 	AttributionStrategy Attribution
 	OptOutStrategy      OptOut
 	ClaimsStrategy      Claims

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -325,7 +325,7 @@ func createExpectedAuthData(cmsID string, aco models.ACO) auth.AuthData {
 		ACOID:       cmsID,
 		CMSID:       cmsID,
 		TokenID:     uuid.NewRandom().String(),
-		Blacklisted: aco.Blacklisted(),
+		Blacklisted: aco.Denylisted(),
 	}
 }
 
@@ -370,7 +370,7 @@ func (s *RouterTestSuite) TestBlacklistedACOReturn403WhenACOBlacklisted() {
 
 		TerminationDate: time.Date(2020, time.December, 31, 23, 59, 59, 0, time.Local),
 		CutoffDate:      time.Date(2020, time.December, 31, 23, 59, 59, 0, time.Local),
-		BlacklistType:   models.Involuntary,
+		DenylistType:    models.Involuntary,
 	}
 
 	aco := createACO(cmsID, blackListValue)
@@ -391,7 +391,7 @@ func (s *RouterTestSuite) TestBlacklistedACOReturn403WhenACOBlacklisted() {
 		for _, path := range config.paths {
 
 			s.T().Run(fmt.Sprintf("blacklist-value-%v-%s", blackListValue, path), func(t *testing.T) {
-				fmt.Println(aco.Blacklisted())
+				fmt.Println(aco.Denylisted())
 				fmt.Println(aco.UUID.String())
 				postgrestest.UpdateACO(t, db, aco)
 				rr := httptest.NewRecorder()
@@ -436,7 +436,7 @@ func (s *RouterTestSuite) TestBlacklistedACOReturnNOT403WhenACONOTBlacklisted() 
 		for _, path := range config.paths {
 
 			s.T().Run(fmt.Sprintf("blacklist-value-%v-%s", nil, path), func(t *testing.T) {
-				fmt.Println(aco.Blacklisted())
+				fmt.Println(aco.Denylisted())
 				fmt.Println(aco.UUID.String())
 				postgrestest.UpdateACO(t, db, aco)
 				rr := httptest.NewRecorder()

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -399,7 +399,7 @@ func (s *MigrationTestSuite) TestBCDAMigration() {
 					TerminationDetails: &models.Termination{
 						TerminationDate: time.Date(2020, time.December, 31, 23, 59, 59, 0, time.Local),
 						CutoffDate:      time.Date(2020, time.December, 31, 23, 59, 59, 0, time.Local),
-						BlacklistType:   models.Involuntary,
+						DenylistType:    models.Involuntary,
 					}}
 
 				defer postgrestest.DeleteACO(t, db, aco.UUID)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8162

## 🛠 Changes

Updated cli references + models to blacklist, updated to denylist.

## ℹ️ Context

As part of making BCDA's code more inclusive, we are removing the terms "blacklist" and "whitelist." 

## 🧪 Validation

Smoke tests + unit tests passing. Note, there is going to be an associated PR to the jenkins job for the denylist that references the new cli command name.
