### PR TITLE
BCDA-7900: Add verification to CCLF import integration test

### DIFF
--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Upload test file to the BFD bucket to trigger lambda function via SNS message
         id: createfile
         run: |
-          fname=T.BCD.A5451.ZCY24.D$(date +'%y%m%d').T$(date +'%H%M%S')1
+          fname=T.BCD.A0001.ZCY24.D$(date +'%y%m%d').T$(date +'%H%M%S')1
           echo "FILENAME=$fname" >> "$GITHUB_OUTPUT"
-          aws s3 cp --no-progress ../shared_files/cclf/archives/valid/T.BCD.ACOB.ZC0Y18.D181120.T0001000 \
+          aws s3 cp --no-progress ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000 \
             s3://bfd-test-eft/bfdeft01/bcda/in/test/$fname
 
   verify:

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -56,11 +56,11 @@ jobs:
           unzip ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000
 
           # Clone the synthetic zip file with updated years
-          new_dir="${year}.D${date}.T${time}"
+          new_dir="D${date}.T${time}"
           mkdir $new_dir
-          mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $newdir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}
-          mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $newdir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}
-          mv T.BCD.A0001.ZC0Y18.D181120.T1000011 $newdir/T.BCD.A0001.ZC0Y${year}.D${date}.T${time}
+          mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $new_dir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}
+          mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $new_dir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}
+          mv T.BCD.A0001.ZC0Y18.D181120.T1000011 $new_dir/T.BCD.A0001.ZC0Y${year}.D${date}.T${time}
           zip -jr $fname $newdir
 
           aws s3 cp --no-progress ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000 \

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -51,7 +51,8 @@ jobs:
           date=$(date +'%y%m%d')
           time=$(date +'%H%M%S')
           fname=T.BCD.A0001.ZCY24.D${date}.T${time}1
-          echo "FILENAME=$fname" >> "$GITHUB_OUTPUT"
+          cclf8_fname=T.BCD.A0001.ZC8Y24.D${date}.T${time}1
+          echo "FILENAME=$cclf8_fname" >> "$GITHUB_OUTPUT"
 
           unzip ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000
 
@@ -104,7 +105,7 @@ jobs:
                 echo "CCLF beneficiaries query returned zero results or command failed"
                 exit 1
               fi
-              if [[ "$CCLF_BENES" != "6" ]]; then
+              if [[ $(echo $CCLF_BENES | xargs) != "6" ]]; then
                 echo "expected 6 beneficiaries imported from file, received $CCLF_BENES".
                 exit 1
               fi

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -58,9 +58,9 @@ jobs:
           # Clone the synthetic zip file with updated years
           new_dir="D${date}.T${time}"
           mkdir $new_dir
-          mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $new_dir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}
-          mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $new_dir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}
-          mv T.BCD.A0001.ZC0Y18.D181120.T1000011 $new_dir/T.BCD.A0001.ZC0Y${year}.D${date}.T${time}
+          mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $new_dir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}1
+          mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $new_dir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}1
+          mv T.BCD.A0001.ZC0Y18.D181120.T1000011 $new_dir/T.BCD.A0001.ZC0Y${year}.D${date}.T${time}1
           zip -jr $fname $new_dir
 
           aws s3 cp --no-progress $fname \

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -55,7 +55,8 @@ jobs:
 
           unzip ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000
 
-          new_dir='${year}.D${date}.T${time}'
+          # Clone the synthetic zip file with updated years
+          new_dir="${year}.D${date}.T${time}"
           mkdir $new_dir
           mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $newdir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}
           mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $newdir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -29,6 +29,8 @@ jobs:
     defaults:
       run:
         working-directory: bcda
+    outputs:
+      filename: ${{ steps.createfile.outputs.FILENAME }}
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
@@ -43,9 +45,54 @@ jobs:
           role-chaining: true
           role-skip-session-tagging: true
       - name: Upload test file to the BFD bucket to trigger lambda function via SNS message
+        id: createfile
         run: |
-          aws s3 cp --no-progress ../shared_files/cclf/files/synthetic/test/small/ZC0 \
-            s3://bfd-test-eft/bfdeft01/bcda/in/T.NGD.DPC.RSP.D$(date +'%y%m%d').T$(date +'%H%M%S')1.IN
+          fname=T.BCD.A5451.ZCY24.D$(date +'%y%m%d').T$(date +'%H%M%S')1
+          echo "FILENAME=$fname" >> "$GITHUB_OUTPUT"
+          aws s3 cp --no-progress ../shared_files/cclf/archives/valid/T.BCD.ACOB.ZC0Y18.D181120.T0001000 \
+            s3://bfd-test-eft/bfdeft01/bcda/in/test/$fname
 
-  # TODO Check bucket for response file
-  # TODO Run another job to check database for update
+  verify:
+    needs: trigger
+    runs-on: self-hosted
+    env: 
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
+      - name: Install psql
+        run: |
+            sudo amazon-linux-extras install postgresql14
+      - name: Get database credentials
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            CONNECTION_INFO=/bcda/test/api/DATABASE_URL
+      - name: Verify suppression file was ingested
+        env:
+          FILENAME: ${{needs.trigger.outputs.filename}}
+        # CAUTION: if changing the script below, validate that sensitive information is not printed in the workflow
+        run: |
+          HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-test-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
+          CONNECTION_URL=$(echo $CONNECTION_INFO 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
+          CCLF_FILE=`psql -t "$CONNECTION_URL" -c "SELECT id FROM cclf_files WHERE name = '$FILENAME' LIMIT 1" 2>&1`
+          if [[ $? -ne 0 || -z $CCLF_FILE ]]; then
+            echo "cclf_file query returned zero results or command failed"
+            exit 1
+          else
+            CCLF_BENES=`psql -t "$CONNECTION_URL" -c "SELECT count(mbi) FROM cclf_beneficiaries WHERE file_id = $CCLF_FILE" 2>&1`
+              if [[ $? -ne 0 || -z $CCLF_BENES ]]; then
+                echo "suppressions query returned zero results or command failed"
+                exit 1
+              fi
+              if [[ "$CCLF_BENES" != "6" ]]; then
+                echo "expected 6 beneficiaries imported from file, received $CCLF_BENES".
+                exit 1
+              fi
+          fi
+            

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -53,7 +53,7 @@ jobs:
           fname=T.BCD.A0001.ZCY24.D${date}.T${time}1
           echo "FILENAME=$fname" >> "$GITHUB_OUTPUT"
 
-          unzip ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY${year}.D${date}.T${time}
+          unzip ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000
 
           new_dir='${year}.D${date}.T${time}'
           mkdir $new_dir

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -1,3 +1,5 @@
+# Integration test that triggers a CCLF import in the test environment and 
+# verifies the imported data in the test database for ACO A0001.
 name: cclf-import test integration
 
 on:
@@ -95,11 +97,15 @@ jobs:
         run: |
           HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-test-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
           CONNECTION_URL=$(echo $CONNECTION_INFO 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
+
+          # Verify that we a record of the CCLF file in the database
           CCLF_FILE=`psql -t "$CONNECTION_URL" -c "SELECT id FROM cclf_files WHERE name = '$FILENAME' LIMIT 1" 2>&1`
           if [[ $? -ne 0 || -z $CCLF_FILE ]]; then
             echo "cclf_file query returned zero results or command failed"
             exit 1
           else
+            
+            # Verify that the correct number of benes were imported into the database.
             CCLF_BENES=`psql -t "$CONNECTION_URL" -c "SELECT count(mbi) FROM cclf_beneficiaries WHERE file_id = $CCLF_FILE" 2>&1`
               if [[ $? -ne 0 || -z $CCLF_BENES ]]; then
                 echo "CCLF beneficiaries query returned zero results or command failed"

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -98,7 +98,7 @@ jobs:
           HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-test-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
           CONNECTION_URL=$(echo $CONNECTION_INFO 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
 
-          # Verify that we a record of the CCLF file in the database
+          # Verify that we have a record of the CCLF file in the database
           CCLF_FILE=`psql -t "$CONNECTION_URL" -c "SELECT id FROM cclf_files WHERE name = '$FILENAME' LIMIT 1" 2>&1`
           if [[ $? -ne 0 || -z $CCLF_FILE ]]; then
             echo "cclf_file query returned zero results or command failed"

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -61,9 +61,9 @@ jobs:
           mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $new_dir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}
           mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $new_dir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}
           mv T.BCD.A0001.ZC0Y18.D181120.T1000011 $new_dir/T.BCD.A0001.ZC0Y${year}.D${date}.T${time}
-          zip -jr $fname $newdir
+          zip -jr $fname $new_dir
 
-          aws s3 cp --no-progress ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000 \
+          aws s3 cp --no-progress $fname \
             s3://bfd-test-eft/bfdeft01/bcda/in/test/$fname
 
   verify:

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           params: |
             CONNECTION_INFO=/bcda/test/api/DATABASE_URL
-      - name: Verify suppression file was ingested
+      - name: Verify CCLF file was ingested
         env:
           FILENAME: ${{needs.trigger.outputs.filename}}
         # CAUTION: if changing the script below, validate that sensitive information is not printed in the workflow
@@ -87,7 +87,7 @@ jobs:
           else
             CCLF_BENES=`psql -t "$CONNECTION_URL" -c "SELECT count(mbi) FROM cclf_beneficiaries WHERE file_id = $CCLF_FILE" 2>&1`
               if [[ $? -ne 0 || -z $CCLF_BENES ]]; then
-                echo "suppressions query returned zero results or command failed"
+                echo "CCLF beneficiaries query returned zero results or command failed"
                 exit 1
               fi
               if [[ "$CCLF_BENES" != "6" ]]; then

--- a/.github/workflows/cclf-import-test-integration.yml
+++ b/.github/workflows/cclf-import-test-integration.yml
@@ -47,8 +47,21 @@ jobs:
       - name: Upload test file to the BFD bucket to trigger lambda function via SNS message
         id: createfile
         run: |
-          fname=T.BCD.A0001.ZCY24.D$(date +'%y%m%d').T$(date +'%H%M%S')1
+          year=$(date +'%y')
+          date=$(date +'%y%m%d')
+          time=$(date +'%H%M%S')
+          fname=T.BCD.A0001.ZCY24.D${date}.T${time}1
           echo "FILENAME=$fname" >> "$GITHUB_OUTPUT"
+
+          unzip ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY${year}.D${date}.T${time}
+
+          new_dir='${year}.D${date}.T${time}'
+          mkdir $new_dir
+          mv T.BCD.A0001.ZC8Y18.D181120.T1000009 $newdir/T.BCD.A0001.ZC8Y${year}.D${date}.T${time}
+          mv T.BCD.A0001.ZC9Y18.D181120.T1000010 $newdir/T.BCD.A0001.ZC9Y${year}.D${date}.T${time}
+          mv T.BCD.A0001.ZC0Y18.D181120.T1000011 $newdir/T.BCD.A0001.ZC0Y${year}.D${date}.T${time}
+          zip -jr $fname $newdir
+
           aws s3 cp --no-progress ../shared_files/cclf/archives/valid2/T.BCD.A0001.ZCY18.D181120.T1000000 \
             s3://bfd-test-eft/bfdeft01/bcda/in/test/$fname
 

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -1,3 +1,5 @@
+# Integration test that triggers an Opt Out import in the test environment and 
+# verifies the imported data in the test database.
 name: opt-out-import test integration
 
 on:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7900

## 🛠 Changes

- Copied opt-out import integration test to CCLF workflow
- Made some edits to support CCLF imports

## ℹ️ Context

After getting the opt-out import integration tests merged, realized that it wasn't applied to the CCLF import workflow. Now that we are relying on the CCLF lambda, we want to ensure future changes do not break expected functionality.

## 🧪 Validation

Updated integration test works successfully.
