### PR TITLE
BCDA-8282: Update Makefile for bcda-app

### DIFF
--- a/Dockerfiles/Dockerfile.bcda_prod
+++ b/Dockerfiles/Dockerfile.bcda_prod
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.19-alpine3.18 AS builder
+FROM golang:1.21-alpine3.20 AS builder
 
 RUN apk update upgrade
 
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install -v 
 
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.19-alpine3.18
+FROM golang:1.21-alpine3.20
 ARG ENVIRONMENT
 # only add dev packages if the environment argument was set to development
 RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash

--- a/Dockerfiles/Dockerfile.bcdaworker_prod
+++ b/Dockerfiles/Dockerfile.bcdaworker_prod
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.19-alpine3.18 AS builder
+FROM golang:1.21-alpine3.20 AS builder
 
 RUN apk update upgrade
 
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install -v
 
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.19-alpine3.18
+FROM golang:1.21-alpine3.20
 ARG ENVIRONMENT
 # only add dev packages if the environment argument was set to development
 RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash

--- a/Dockerfiles/Dockerfile.documentation
+++ b/Dockerfiles/Dockerfile.documentation
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.18
+FROM golang:1.21-alpine3.20
 
 ARG swaggerVersion=3.38.0
 # Ensure swaggerVersion is available in the CMD

--- a/Dockerfiles/Dockerfile.package
+++ b/Dockerfiles/Dockerfile.package
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.15
+FROM golang:1.21-alpine3.20
 
 ENV CGO_ENABLED=0
 

--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.19-alpine3.18 AS base
+FROM golang:1.21-alpine3.20 AS base
 
 RUN apk update upgrade
 RUN apk add git
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go install -v ./ssas/service/main
 
-FROM golang:1.19-alpine3.18 AS prod
+FROM golang:1.21-alpine3.20 AS prod
 
 RUN apk update upgrade
 RUN apk add openssl

--- a/Makefile
+++ b/Makefile
@@ -213,3 +213,22 @@ package-cclf-import: export GOOS=linux
 package-cclf-import: export GOARCH=amd64
 package-cclf-import:
 	cd bcda && go build -o bin/cclf-import ./lambda/cclf/main.go
+
+# Build and publish images to ECR
+build-api:
+	docker build -t bcda-api:latest -f Dockerfiles/Dockerfile.bcda_prod .
+
+publish-api:
+	$(eval ECR_URL=$(shell aws ecr describe-repositories --repository-names bcda-api | jq -r '.repositories[0].repositoryUri')) 
+	docker tag bcda-api:latest '${ECR_URL}:latest'
+	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${ECR_URL}'
+	docker push '${ECR_URL}:latest'
+
+build-worker:
+	docker build -t bcda-worker:latest -f Dockerfiles/Dockerfile.worker_prod .
+
+publish-worker:
+	$(eval ECR_URL=$(shell aws ecr describe-repositories --repository-names bcda-worker | jq -r '.repositories[0].repositoryUri')) 
+	docker tag bcda-worker:latest '${ECR_URL}:latest'
+	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${ECR_URL}'
+	docker push '${ECR_URL}:latest'

--- a/Makefile
+++ b/Makefile
@@ -216,19 +216,25 @@ package-cclf-import:
 
 # Build and publish images to ECR
 build-api:
-	docker build -t bcda-api:latest -f Dockerfiles/Dockerfile.bcda_prod .
+	$(eval ACCOUNT_ID =$(shell aws sts get-caller-identity --output text --query Account))
+	$(eval CURRENT_COMMIT=$(shell git log -n 1 --pretty=format:'%h'))
+	$(eval DOCKER_REGISTRY_URL=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/bcda-api)
+	docker build -t ${DOCKER_REGISTRY_URL}:latest-test -t '${DOCKER_REGISTRY_URL}:${CURRENT_COMMIT}' -f Dockerfiles/Dockerfile.bcda_prod .
 
-publish-api:
-	$(eval ECR_URL=$(shell aws ecr describe-repositories --repository-names bcda-api | jq -r '.repositories[0].repositoryUri')) 
-	docker tag bcda-api:latest '${ECR_URL}:latest'
-	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${ECR_URL}'
-	docker push '${ECR_URL}:latest'
+publish-api:	
+	$(eval ACCOUNT_ID =$(shell aws sts get-caller-identity --output text --query Account))
+	$(eval DOCKER_REGISTRY_URL=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/bcda-api)
+	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${DOCKER_REGISTRY_URL}'
+	docker image push '${DOCKER_REGISTRY_URL}' -a
 
 build-worker:
-	docker build -t bcda-worker:latest -f Dockerfiles/Dockerfile.bcdaworker_prod .
+	$(eval ACCOUNT_ID =$(shell aws sts get-caller-identity --output text --query Account))
+	$(eval CURRENT_COMMIT=$(shell git log -n 1 --pretty=format:'%h'))
+	$(eval DOCKER_REGISTRY_URL=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/bcda-worker)
+	docker build -t ${DOCKER_REGISTRY_URL}:latest-test -t '${DOCKER_REGISTRY_URL}:${CURRENT_COMMIT}' -f Dockerfiles/Dockerfile.bcdaworker_prod .
 
 publish-worker:
-	$(eval ECR_URL=$(shell aws ecr describe-repositories --repository-names bcda-worker | jq -r '.repositories[0].repositoryUri')) 
-	docker tag bcda-worker:latest '${ECR_URL}:latest'
-	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${ECR_URL}'
-	docker push '${ECR_URL}:latest'
+	$(eval ACCOUNT_ID =$(shell aws sts get-caller-identity --output text --query Account))
+	$(eval DOCKER_REGISTRY_URL=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/bcda-worker)
+	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${DOCKER_REGISTRY_URL}'
+	docker image push '${DOCKER_REGISTRY_URL}' -a

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ publish-api:
 	docker push '${ECR_URL}:latest'
 
 build-worker:
-	docker build -t bcda-worker:latest -f Dockerfiles/Dockerfile.worker_prod .
+	docker build -t bcda-worker:latest -f Dockerfiles/Dockerfile.bcdaworker_prod .
 
 publish-worker:
 	$(eval ECR_URL=$(shell aws ecr describe-repositories --repository-names bcda-worker | jq -r '.repositories[0].repositoryUri')) 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8282

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Added makefile commands for build-api, publish-api, build-worker, and publish-worker

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
In order to deploy BCDA on ECS, it is necessary to publish container images to an ECR repository. This PR creates the Makefile commands to enable that. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
TBD