### PR TITLE
BCDA-8231: Log additional Opt Out details for Splunk dashboard

### DIFF
--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -206,6 +206,7 @@ func (importer OptOutImporter) importSuppressionMetadata(metadata *optout.OptOut
 	}
 
 	importer.Logger.Infof("Successfully imported %d records from suppression file %s.", importedCount, metadata)
+	importer.Logger.Infof("foo bar")
 	return nil
 }
 

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -140,7 +140,6 @@ func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFile
 			optInCount++
 		case "N":
 			optOutCount++
-			return nil
 		}
 		return nil
 	})
@@ -149,7 +148,7 @@ func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFile
 		importer.updateImportStatus(metadata, optout.ImportFail)
 		return err
 	}
-	importer.Logger.WithFields(logrus.Fields{"created_opt_outs_count": optOutCount, "created_opt_ins_count": optInCount}).Info()
+	importer.Logger.WithFields(logrus.Fields{"created_opt_outs_count": optOutCount, "created_opt_ins_count": optInCount}).Infof("Successfully imported file: %s", metadata.Name)
 	importer.updateImportStatus(metadata, optout.ImportComplete)
 	return nil
 }

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -120,6 +120,8 @@ func (importer OptOutImporter) validate(metadata *optout.OptOutFilenameMetadata)
 }
 
 func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFilenameMetadata) error {
+	optOutCount := 0
+	optInCount := 0
 	err := importer.importSuppressionMetadata(metadata, func(fileID uint, b []byte) error {
 		suppression, err := optout.ParseRecord(metadata, b)
 
@@ -133,6 +135,13 @@ func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFile
 			importer.Logger.Error(err)
 			return err
 		}
+		switch suppression.PrefIndicator {
+		case "Y":
+			optInCount++
+		case "N":
+			optOutCount++
+			return nil
+		}
 		return nil
 	})
 
@@ -140,6 +149,7 @@ func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFile
 		importer.updateImportStatus(metadata, optout.ImportFail)
 		return err
 	}
+	importer.Logger.WithFields(logrus.Fields{"created_opt_outs_count": optOutCount, "created_opt_ins_count": optInCount}).Info()
 	importer.updateImportStatus(metadata, optout.ImportComplete)
 	return nil
 }

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -149,7 +149,6 @@ func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFile
 		importer.updateImportStatus(metadata, optout.ImportFail)
 		return err
 	}
-	importer.Logger.Infof("foo bar")
 	importer.Logger.WithFields(logrus.Fields{"created_opt_outs_count": optOutCount, "created_opt_ins_count": optInCount}).Info()
 	importer.updateImportStatus(metadata, optout.ImportComplete)
 	return nil

--- a/bcda/suppression/suppression.go
+++ b/bcda/suppression/suppression.go
@@ -149,6 +149,7 @@ func (importer OptOutImporter) ImportSuppressionData(metadata *optout.OptOutFile
 		importer.updateImportStatus(metadata, optout.ImportFail)
 		return err
 	}
+	importer.Logger.Infof("foo bar")
 	importer.Logger.WithFields(logrus.Fields{"created_opt_outs_count": optOutCount, "created_opt_ins_count": optInCount}).Info()
 	importer.updateImportStatus(metadata, optout.ImportComplete)
 	return nil
@@ -206,7 +207,6 @@ func (importer OptOutImporter) importSuppressionMetadata(metadata *optout.OptOut
 	}
 
 	importer.Logger.Infof("Successfully imported %d records from suppression file %s.", importedCount, metadata)
-	importer.Logger.Infof("foo bar")
 	return nil
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8231

## 🛠 Changes

Logging statements during opt out ingestion will now output a count when completed successfully.

## ℹ️ Context

These log statements will support a dashboard that can be used team-wide to view metrics/stats on the latest file import.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Unit test modified + passing and verified that logs were in splunk after deploying dev changes to test environment. 

Log message: 

```
{"application":"bcda-test-opt-out-import",
"created_opt_ins_count":2,
"created_opt_outs_count":1,
"environment":"test",
"file":"/home/runner/work/bcda-app/bcda-app/bcda/suppression/suppression.go:152",
"func":"github.com/CMSgov/bcda-app/bcda/suppression.OptOutImporter.ImportSuppressionData",
"level":"info",
"msg":"",
"time":"2024-08-09T21:17:04.729002492Z"}
```
