### PR TITLE
remove local mount points

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,8 +25,6 @@ services:
       # Remaining environment variables defined in ./shared_files/decrypted/local.env
     volumes:
       - ./test_results:/go/src/github.com/CMSgov/bcda-app/test_results
-      - ${HOME}/.cache/go-build:/root/.cache/go-build
-      - ${GOPATH}/pkg/mod:/go/pkg/mod
   db-unit-test:
     image: postgres:15
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
       - CI=${CI} # Used to determine if the API is running on a CI process
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
-      - ${HOME}/.cache/go-build:/root/.cache/go-build
-      - ${GOPATH}/pkg/mod:/go/pkg/mod
     ports:
       - "3000:3000"
       - "3001:3001"
@@ -55,8 +53,6 @@ services:
       - CI=${CI} # Used to determine if the API is running on a CI process
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
-      - ${HOME}/.cache/go-build:/root/.cache/go-build
-      - ${GOPATH}/pkg/mod:/go/pkg/mod
     depends_on:
       - db
       - queue
@@ -108,8 +104,6 @@ services:
       - SSAS_TOKEN_BLACKLIST_CACHE_REFRESH_MINUTES=5
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-app
-      - ${HOME}/.cache/go-build:/root/.cache/go-build
-      - ${GOPATH}/pkg/mod:/go/pkg/mod
     ports:
       - "3003:3003"
       - "3004:3004"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8327

## 🛠 Changes

Removed local mount points for Go dependencies for Docker.

## ℹ️ Context

Right now, you'll have to add these virtual mounts manually to go ahead and build the projects locally. However, this is not required as Docker installs all dependencies

## 🧪 Validation

Built and ran the service locally. Did multiple queries and triggered export jobs.