### PR TITLE
Update Github Actions Upload and Download Artifact from V2 to V3

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: ./test_results/latest/testcoverage.out
@@ -70,7 +70,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Download code coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
       - name: Set env vars from AWS params

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
           path: ./test_results/latest/testcoverage.out
@@ -70,7 +70,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Download code coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: code-coverage-report
       - name: Set env vars from AWS params


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

Bumped actions for artifact upload and down from v2 -> v3.

## ℹ️ Context

Github actions/<upload|download>-artifact@v1/2 are deprecated and will result in our CI failing. [Release announcement](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). Originally bumped to v4, but node20 is required. Can bump the version when PLT-338 is completed. V3 will be deprecated on November 30, 2024, so the upgrade to v3 is temporary to keep PRs unblocked.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Ran CI successfully.
