### PR TITLE
BCDA-8453: Remove query params from POST requests to BFD

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -166,7 +166,7 @@ func (bbc *BlueButtonClient) GetPatientByMbi(jobData models.JobEnqueueArgs, mbi 
 	params := GetDefaultParams()
 	params.Set("identifier", fmt.Sprintf("http://hl7.org/fhir/sid/us-mbi|%s", mbi))
 
-	u, err := bbc.getURL("Patient/_search", params)
+	u, err := bbc.getURL("Patient/_search", url.Values{})
 	if err != nil {
 		return "", err
 	}
@@ -194,7 +194,7 @@ func (bbc *BlueButtonClient) GetClaim(jobData models.JobEnqueueArgs, mbi string,
 	updateParamWithServiceDate(&params, claimsWindow)
 	updateParamWithLastUpdated(&params, jobData.Since, jobData.TransactionTime)
 
-	u, err := bbc.getURL("Claim/_search", params)
+	u, err := bbc.getURL("Claim/_search", url.Values{})
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (bbc *BlueButtonClient) GetClaimResponse(jobData models.JobEnqueueArgs, mbi
 	updateParamWithServiceDate(&params, claimsWindow)
 	updateParamWithLastUpdated(&params, jobData.Since, jobData.TransactionTime)
 
-	u, err := bbc.getURL("ClaimResponse/_search", params)
+	u, err := bbc.getURL("ClaimResponse/_search", url.Values{})
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,6 @@ func addDefaultRequestHeaders(req *http.Request, reqID uuid.UUID, jobData models
 	req.Header.Add(constants.BBHeaderOriginQID, reqID.String())
 	req.Header.Add(constants.BBHeaderOriginQC, "1")
 	req.Header.Add(constants.BBHeaderOriginURL, req.URL.String())
-	req.Header.Add(constants.BBHeaderOriginQ, req.URL.RawQuery)
 	req.Header.Add("IncludeIdentifiers", "mbi")
 	req.Header.Add(jobIDHeader, strconv.Itoa(jobData.ID))
 	req.Header.Add(clientIDHeader, jobData.CMSID)

--- a/bcda/client/bluebutton_test.go
+++ b/bcda/client/bluebutton_test.go
@@ -594,14 +594,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				noServiceDateChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -615,14 +610,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				noSinceChecker,
-				nowChecker,
-				noServiceDateChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -636,15 +626,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				serviceDateLowerBoundChecker,
-				noServiceDateUpperBoundChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -658,15 +642,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				noServiceDateLowerBoundChecker,
-				serviceDateUpperBoundChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -680,15 +658,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				serviceDateLowerBoundChecker,
-				serviceDateUpperBoundChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -702,14 +674,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				noServiceDateChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -723,14 +690,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				noSinceChecker,
-				nowChecker,
-				noServiceDateChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -744,15 +706,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				serviceDateLowerBoundChecker,
-				noServiceDateUpperBoundChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -766,15 +722,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				noServiceDateLowerBoundChecker,
-				serviceDateUpperBoundChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 		{
@@ -788,15 +738,9 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 				assert.NotEmpty(t, result.Entries)
 			},
 			[]func(*testing.T, *http.Request){
-				sinceChecker,
-				nowChecker,
-				serviceDateLowerBoundChecker,
-				serviceDateUpperBoundChecker,
-				excludeSAMHSAChecker,
-				noIncludeAddressFieldsChecker,
 				hasDefaultRequestHeaders,
 				hasBulkRequestHeaders,
-				hasClaimRequiredURLEncodedParams,
+				hasClaimRequiredURLEncodedBody,
 			},
 		},
 	}
@@ -815,7 +759,6 @@ func (s *BBRequestTestSuite) TestValidateRequest() {
 
 				assert.True(t, strings.HasSuffix(req.Header.Get("BlueButton-OriginalUrl"), req.URL.String()),
 					"%s does not end with %s", req.Header.Get("BlueButton-OriginalUrl"), req.URL.String())
-				assert.Equal(t, req.URL.RawQuery, req.Header.Get("BlueButton-OriginalQuery"))
 
 				assert.Empty(t, req.Header.Get(oldJobIDHeader))
 				assert.Empty(t, req.Header.Get(oldClientIDHeader))
@@ -949,7 +892,6 @@ func hasDefaultRequestHeaders(t *testing.T, req *http.Request) {
 	assert.NotEmpty(t, req.Header.Get(constants.BBHeaderTS))
 	assert.NotEmpty(t, req.Header.Get(constants.BBHeaderOriginURL))
 	assert.NotEmpty(t, req.Header.Get(constants.BBHeaderOriginQID))
-	assert.NotEmpty(t, req.Header.Get(constants.BBHeaderOriginQ))
 	assert.NotEmpty(t, req.Header.Get(constants.BBHeaderOriginQC))
 }
 func hasContentTypeURLEncodedHeader(t *testing.T, req *http.Request) {
@@ -959,7 +901,7 @@ func hasURLEncodedBodyWithIdentifier(t *testing.T, req *http.Request) {
 	body := reqBodyToString(req)
 	assert.Contains(t, body, fmt.Sprintf("identifier=%s", url.QueryEscape("http://hl7.org/fhir/sid/us-mbi|")))
 }
-func hasClaimRequiredURLEncodedParams(t *testing.T, req *http.Request) {
+func hasClaimRequiredURLEncodedBody(t *testing.T, req *http.Request) {
 	body := reqBodyToString(req)
 	assert.Contains(t, body, "includeTaxNumbers=true")
 	assert.Contains(t, body, "mbi=beneID1")


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8453

## 🛠 Changes

- Removed query parameters from POST operations to BFD endpoints, since they are now sent in the body.
- Also removed a header that's no longer in use, per this page: https://github.com/CMSgov/beneficiary-fhir-data/wiki/Making-Requests-to-BFD

## ℹ️ Context

Changes were made so that we are no longer sending unnecessary parameters with our requests to BFD. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Unit tests pass and smoke tests pass. 
