### PR TITLE
Draft: CCLF lambda changes

### DIFF
--- a/bcda/cclf/parser.go
+++ b/bcda/cclf/parser.go
@@ -27,12 +27,11 @@ func getCMSID(name string) (string, error) {
 }
 
 func CheckIfAttributionCSVFile(filePath string) bool {
-	pattern := `P\.PCPB\.M\d{4}\.D\d{6}\.T\d{7}`
+	pattern := `(P|T)\.PCPB\.M\d{4}\.D\d{6}\.T\d{7}`
 	filenameRegexp := regexp.MustCompile(pattern)
 	found := filenameRegexp.Match([]byte(filePath))
 	return found
 }
-
 
 func getCCLFFileMetadata(cmsID, fileName string) (cclfFileMetadata, error) {
 	var metadata cclfFileMetadata

--- a/bcda/cclf/parser.go
+++ b/bcda/cclf/parser.go
@@ -26,6 +26,14 @@ func getCMSID(name string) (string, error) {
 	return parts[1], nil
 }
 
+func CheckIfAttributionCSVFile(filePath string) bool {
+	pattern := `P\.PCPB\.M\d{4}\.D\d{6}\.T\d{7}`
+	filenameRegexp := regexp.MustCompile(pattern)
+	found := filenameRegexp.Match([]byte(filePath))
+	return found
+}
+
+
 func getCCLFFileMetadata(cmsID, fileName string) (cclfFileMetadata, error) {
 	var metadata cclfFileMetadata
 	const (

--- a/bcda/cclf/parser_test.go
+++ b/bcda/cclf/parser_test.go
@@ -323,6 +323,7 @@ func TestCheckIfAttributionCSVFile(t *testing.T) {
 		{name: "Is not an Attribution CSV File path (incorrect fourth)", path: "P.PCPB.M2014.D003022.T2420001", testIsCSV: false},
 		{name: "Is not an Attribution CSV File path (incorrect fifth)", path: "P.PCPB.M2014.D00302.T24200011", testIsCSV: false},
 		{name: "Is not an Attribution CSV File path (CCLF file)", path: "T.BCD.A0001.ZCY18.D181121.T1000000", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (opt-out file)", path: "T#EFT.ON.ACO.NGD1800.DPRF.D181120.T1000009", testIsCSV: false},
 	}
 
 	for _, test := range tests {

--- a/bcda/cclf/parser_test.go
+++ b/bcda/cclf/parser_test.go
@@ -91,7 +91,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 		{"Invalid date (no 13th month)", sspID, "T.BCD.A0001.ZC0Y18.D181320.T0001000", "failed to parse date", cclfFileMetadata{}},
 		{"CCLF file too old", sspID, gen(sspProd, startUTC.Add(-365*24*time.Hour)), "out of range", cclfFileMetadata{}},
 		{"CCLF file too new", sspID, gen(sspProd, startUTC.Add(365*24*time.Hour)), "out of range", cclfFileMetadata{}},
-		{"Production SSP file", sspID, sspProdFile, "",
+		{
+			"Production SSP file", sspID, sspProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      sspProdFile,
@@ -102,7 +103,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test SSP file", sspID, sspTestFile, "",
+		{
+			"Test SSP file", sspID, sspTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      sspTestFile,
@@ -125,7 +127,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeRunout,
 			},
 		},
-		{"Production CEC file", cecID, cecProdFile, "",
+		{
+			"Production CEC file", cecID, cecProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      cecProdFile,
@@ -136,7 +139,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test CEC file", cecID, cecTestFile, "",
+		{
+			"Test CEC file", cecID, cecTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      cecTestFile,
@@ -147,7 +151,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Production NGACO file", ngacoID, ngacoProdFile, "",
+		{
+			"Production NGACO file", ngacoID, ngacoProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      ngacoProdFile,
@@ -158,7 +163,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test NGACO file", ngacoID, ngacoTestFile, "",
+		{
+			"Test NGACO file", ngacoID, ngacoTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      ngacoTestFile,
@@ -169,7 +175,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Production CKCC file", ckccID, ckccProdFile, "",
+		{
+			"Production CKCC file", ckccID, ckccProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      ckccProdFile,
@@ -180,7 +187,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test CKCC file", ckccID, ckccTestFile, "",
+		{
+			"Test CKCC file", ckccID, ckccTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      ckccTestFile,
@@ -191,7 +199,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Production KCF file", kcfID, kcfProdFile, "",
+		{
+			"Production KCF file", kcfID, kcfProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      kcfProdFile,
@@ -202,7 +211,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test KCF file", kcfID, kcfTestFile, "",
+		{
+			"Test KCF file", kcfID, kcfTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      kcfTestFile,
@@ -213,7 +223,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Production DC file", dcID, dcProdFile, "",
+		{
+			"Production DC file", dcID, dcProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      dcProdFile,
@@ -224,7 +235,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test DC file", dcID, dcTestFile, "",
+		{
+			"Test DC file", dcID, dcTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      dcTestFile,
@@ -235,7 +247,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Production TEST file", testID, testProdFile, "",
+		{
+			"Production TEST file", testID, testProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      testProdFile,
@@ -246,7 +259,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test TEST file", testID, testTestFile, "",
+		{
+			"Test TEST file", testID, testTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      testTestFile,
@@ -257,7 +271,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Production SBX file", sbxID, sbxProdFile, "",
+		{
+			"Production SBX file", sbxID, sbxProdFile, "",
 			cclfFileMetadata{
 				env:       "production",
 				name:      sbxProdFile,
@@ -268,7 +283,8 @@ func TestGetCCLFMetadata(t *testing.T) {
 				fileType:  models.FileTypeDefault,
 			},
 		},
-		{"Test SBX file", sbxID, sbxTestFile, "",
+		{
+			"Test SBX file", sbxID, sbxTestFile, "",
 			cclfFileMetadata{
 				env:       "test",
 				name:      sbxTestFile,
@@ -301,7 +317,7 @@ func TestCheckIfAttributionCSVFile(t *testing.T) {
 		testIsCSV bool
 	}{
 		{name: "Is an Attribution CSV File path", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: true},
-		{name: "Is not an Attribution CSV File path (incorrect first)", path: "T.PCPB.M2014.D00302.T2420001", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (incorrect first)", path: "M.PCPB.M2014.D00302.T2420001", testIsCSV: false},
 		{name: "Is not an Attribution CSV File path (incorrect second)", path: "P.BFD.N2014.D00302.T2420001", testIsCSV: false},
 		{name: "Is not an Attribution CSV File path (incorrect third)", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: false},
 		{name: "Is not an Attribution CSV File path (incorrect fourth)", path: "P.PCPB.M2014.D003022.T2420001", testIsCSV: false},

--- a/bcda/cclf/parser_test.go
+++ b/bcda/cclf/parser_test.go
@@ -293,3 +293,26 @@ func TestGetCCLFMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckIfAttributionCSVFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		testIsCSV bool
+	}{
+		{name: "Is an Attribution CSV File path", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: true},
+		{name: "Is not an Attribution CSV File path", path: "T.PCPB.M2014.D00302.T2420001", testIsCSV: false},
+		{name: "Is an Attribution CCLF File path", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(sub *testing.T) {
+			isCSV := CheckIfAttributionCSVFile(test.path)
+			if test.testIsCSV {
+				assert.True(sub, isCSV)
+			} else {
+				assert.False(sub, isCSV)
+			}
+		})
+	}
+}

--- a/bcda/cclf/parser_test.go
+++ b/bcda/cclf/parser_test.go
@@ -88,6 +88,7 @@ func TestGetCCLFMetadata(t *testing.T) {
 	}{
 		{"Non CCLF0 or CCLF8 file", sspID, "P.A0001.ACO.ZC9Y18.D190108.T2355000", "invalid filename", cclfFileMetadata{}},
 		{"Unsupported CCLF file type", "Z9999", "P.Z0001.ACO.ZC8Y18.D190108.T2355000", "invalid filename", cclfFileMetadata{}},
+		{"Unsupported CSV file type", sspID, "P.PCPB.M2014.D00302.T2420001", "invalid filename", cclfFileMetadata{}},
 		{"Invalid date (no 13th month)", sspID, "T.BCD.A0001.ZC0Y18.D181320.T0001000", "failed to parse date", cclfFileMetadata{}},
 		{"CCLF file too old", sspID, gen(sspProd, startUTC.Add(-365*24*time.Hour)), "out of range", cclfFileMetadata{}},
 		{"CCLF file too new", sspID, gen(sspProd, startUTC.Add(365*24*time.Hour)), "out of range", cclfFileMetadata{}},

--- a/bcda/cclf/parser_test.go
+++ b/bcda/cclf/parser_test.go
@@ -301,8 +301,12 @@ func TestCheckIfAttributionCSVFile(t *testing.T) {
 		testIsCSV bool
 	}{
 		{name: "Is an Attribution CSV File path", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: true},
-		{name: "Is not an Attribution CSV File path", path: "T.PCPB.M2014.D00302.T2420001", testIsCSV: false},
-		{name: "Is an Attribution CCLF File path", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (incorrect first)", path: "T.PCPB.M2014.D00302.T2420001", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (incorrect second)", path: "P.BFD.N2014.D00302.T2420001", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (incorrect third)", path: "P.PCPB.M2014.D00302.T2420001", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (incorrect fourth)", path: "P.PCPB.M2014.D003022.T2420001", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (incorrect fifth)", path: "P.PCPB.M2014.D00302.T24200011", testIsCSV: false},
+		{name: "Is not an Attribution CSV File path (CCLF file)", path: "T.BCD.A0001.ZCY18.D181121.T1000000", testIsCSV: false},
 	}
 
 	for _, test := range tests {

--- a/bcda/lambda/cclf/main.go
+++ b/bcda/lambda/cclf/main.go
@@ -64,9 +64,9 @@ func cclfImportHandler(ctx context.Context, sqsEvent events.SQSEvent) (string, e
 			if parser.CheckIfAttributionCSVFile(e.S3.Object.Key) {
 				return handleCSVImport(s3AssumeRoleArn, filepath)
 			} else {
-			return handleCclfImport(s3AssumeRoleArn, filepath)
+				return handleCclfImport(s3AssumeRoleArn, filepath)
+			}
 		}
-	}
 	}
 
 	logger.Info("No ObjectCreated events found, skipping safely.")

--- a/bcda/lambda/cclf/main.go
+++ b/bcda/lambda/cclf/main.go
@@ -60,8 +60,7 @@ func cclfImportHandler(ctx context.Context, sqsEvent events.SQSEvent) (string, e
 			// importing the one file that was sent in the trigger.
 			filepath := fmt.Sprintf("%s/%s", e.S3.Bucket.Name, e.S3.Object.Key)
 			logger.Infof("Reading %s event for file %s", e.EventName, filepath)
-			parser := cclf.CSVParser{Filepath: e.S3.Object.Key}
-			if parser.CheckIfAttributionCSVFile(e.S3.Object.Key) {
+			if cclf.CheckIfAttributionCSVFile(e.S3.Object.Key) {
 				return handleCSVImport(s3AssumeRoleArn, filepath)
 			} else {
 				return handleCclfImport(s3AssumeRoleArn, filepath)

--- a/bcda/lambda/cclf/main.go
+++ b/bcda/lambda/cclf/main.go
@@ -30,11 +30,11 @@ func main() {
 			fmt.Println(res)
 		}
 	} else {
-		lambda.Start(cclfImportHandler)
+		lambda.Start(attributionImportHandler)
 	}
 }
 
-func cclfImportHandler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
+func attributionImportHandler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
 	env := conf.GetEnv("ENV")
 	appName := conf.GetEnv("APP_NAME")
 	logger := configureLogger(env, appName)

--- a/bcda/lambda/cclf/main_test.go
+++ b/bcda/lambda/cclf/main_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type CclfImportMainSuite struct {
+type AttributionImportMainSuite struct {
 	suite.Suite
 }
 
-func TestCclfImportMainSuite(t *testing.T) {
-	suite.Run(t, new(CclfImportMainSuite))
+func TestAttributionImportMainSuite(t *testing.T) {
+	suite.Run(t, new(AttributionImportMainSuite))
 }
 
-func (s *CclfImportMainSuite) TestImportCCLFDirectory() {
+func (s *AttributionImportMainSuite) TestImportCCLFDirectory() {
 	targetACO := "A0001"
 	assert := assert.New(s.T())
 
@@ -60,7 +60,7 @@ func (s *CclfImportMainSuite) TestImportCCLFDirectory() {
 		path, cleanup := testUtils.CopyToS3(s.T(), tc.path)
 		defer cleanup()
 
-		res, err := cclfImportHandler(context.Background(), testUtils.GetSQSEvent(s.T(), path, tc.filename))
+		res, err := attributionImportHandler(context.Background(), testUtils.GetSQSEvent(s.T(), path, tc.filename))
 
 		if tc.err == nil {
 			assert.Nil(err)
@@ -75,8 +75,8 @@ func (s *CclfImportMainSuite) TestImportCCLFDirectory() {
 	}
 }
 
-func (s *CclfImportMainSuite) TestHandlerMissingS3AssumeRoleArn() {
+func (s *AttributionImportMainSuite) TestHandlerMissingS3AssumeRoleArn() {
 	assert := assert.New(s.T())
-	_, err := cclfImportHandler(context.Background(), testUtils.GetSQSEvent(s.T(), "doesn't-matter", "fake_filename"))
+	_, err := attributionImportHandler(context.Background(), testUtils.GetSQSEvent(s.T(), "doesn't-matter", "fake_filename"))
 	assert.Contains(err.Error(), "Error retrieving parameter /cclf-import/bcda/local/bfd-bucket-role-arn from parameter store: ParameterNotFound: Parameter /cclf-import/bcda/local/bfd-bucket-role-arn not found.")
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8405

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Added the main entry to the CCLF lambda.
Added the logic flow for checking if the SQS event contains a CSV file path, or CCLF.
Renamed CCLF lambda functions to attribution agnostic.
Added parser functions for checking CSV file.
Added testing for CSV parser functions.

## ℹ️ Context

These changes will be the entry for the lambda changes in order to make the CCLF lambda more agonistic to an attribution lambda.

## 🧪 Validation

This PR is a part of a larger group of PR's that will come later. Some of these entries don't function properly, such as the CSVImporter. Therefore this PR is more-or less a check for making sure the functionality is up to standards for the team.
