### PR TITLE
PLT-726 Update BCDA test containers

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./test_results:/go/src/github.com/CMSgov/bcda-app/test_results
   db-unit-test:
-    image: postgres:15
+    image: postgres:16
     environment:
       - POSTGRES_PASSWORD=toor
       - POSTGRES_DB=bcda_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 ---
 services:
   queue:
-    image: postgres:15
+    image: postgres:16
     environment:
       - POSTGRES_DB=bcda_queue
       - POSTGRES_PASSWORD=toor
     ports:
       - "5433:5432"
   db:
-    image: postgres:15
+    image: postgres:16
     environment:
       - POSTGRES_DB=bcda
       - POSTGRES_PASSWORD=toor


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-726

## 🛠 Changes

Update test containers to use postgres:16

## ℹ️ Context

We updated all the postgres db to version 16 and need the test to reflect this.

## 🧪 Validation

Unit and integration test will be run to verify.
