### PR TITLE
BCDA-8528-Update-MaxIdleConnsPerHost

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -120,7 +120,11 @@ func NewBlueButtonClient(config BlueButtonConfig) (*BlueButtonClient, error) {
 		// Ensure that we have compression enabled. This allows the transport to request for gzip content
 		// and handle the decompression transparently.
 		// See: https://golang.org/src/net/http/transport.go?s=3396:10950#L182 for more information
-		DisableCompression: false,
+		DisableCompression:  false,
+		MaxIdleConns:        100,              // default value
+		MaxIdleConnsPerHost: 100,              // Upped from 2 to 100 to match the default value of MaxIdleConns
+		IdleConnTimeout:     90 * time.Second, // default value
+		MaxConnsPerHost:     0,                // default value (0 means no limit)
 	}
 	var timeout int
 	if timeout, err = strconv.Atoi(conf.GetEnv("BB_TIMEOUT_MS")); err != nil {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8528

## 🛠 Changes

Improve worker performance by cleaning up idle connections 
`bluebutton.go` -> `NewBlueButtonClient`, in the transport, set `MaxIdleConnsPerHost`

## ℹ️ Context
The default setting of 2 for `MaxIdleConnsPerHost` leads to a lot of sockets left in our kernel in the `TIME_WAIT` state. Setting it to match `MaxIdleConns` mean that we get a lot more reuse per socket.

References: [Medium](https://medium.com/@loginradius/how-to-use-the-http-client-in-go-to-enhance-performance-3a91b51bf693) and [GitHub](https://github.com/OJ/gobuster/issues/127)