### PR TITLE
BCDA-8523-change-job-id-for-river-jobs

### DIFF
--- a/bcdaworker/queueing/river.go
+++ b/bcdaworker/queueing/river.go
@@ -138,9 +138,9 @@ func (w *JobWorker) Work(ctx context.Context, job *river.Job[models.JobEnqueueAr
 	}
 
 	// start a goroutine that will periodically check the status of the parent job
-	go checkIfCancelled(ctx, repo, cancel, jobID, 15)
+	go checkIfCancelled(ctx, repo, cancel, job.ID, 15)
 
-	if err := workerInstance.ProcessJob(ctx, jobID, *exportJob, job.Args); err != nil {
+	if err := workerInstance.ProcessJob(ctx, job.ID, *exportJob, job.Args); err != nil {
 		err := errors.Wrap(err, "failed to process job")
 		logger.Error(err)
 		return err


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8523

## 🛠 Changes

River processing of jobs was passing the wrong job_id (it was using job_id, not {river}_job_id) to the process that saved `jobkeys` table entries.

## ℹ️ Context

River processing of jobs was passing the wrong job_id (it was using job_id, not {river}_job_id) to the process that saved `jobkeys` table entries.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local testing and linting
