### PR TITLE
Carl/bcda 8596 root cause fixes

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -120,11 +120,7 @@ func NewBlueButtonClient(config BlueButtonConfig) (*BlueButtonClient, error) {
 		// Ensure that we have compression enabled. This allows the transport to request for gzip content
 		// and handle the decompression transparently.
 		// See: https://golang.org/src/net/http/transport.go?s=3396:10950#L182 for more information
-		DisableCompression:  false,
-		MaxIdleConns:        100,              // default value
-		MaxIdleConnsPerHost: 100,              // Upped from 2 to 100 to match the default value of MaxIdleConns
-		IdleConnTimeout:     90 * time.Second, // default value
-		MaxConnsPerHost:     0,                // default value (0 means no limit)
+		DisableCompression: false,
 	}
 	var timeout int
 	if timeout, err = strconv.Atoi(conf.GetEnv("BB_TIMEOUT_MS")); err != nil {

--- a/bcda/models/models.go
+++ b/bcda/models/models.go
@@ -127,7 +127,7 @@ const (
 )
 
 type JobEnqueueArgs struct {
-	ID              int
+	ID              int // parent Job ID
 	ACOID           string
 	CMSID           string
 	BeneficiaryIDs  []string

--- a/bcdaworker/queueing/manager.go
+++ b/bcdaworker/queueing/manager.go
@@ -76,7 +76,7 @@ func validateJob(ctx context.Context, cfg ValidateJobConfig) (*models.Job, error
 		maxNotFoundRetries, err := safecast.ToInt(utils.GetEnvInt("BCDA_WORKER_MAX_JOB_NOT_FOUND_RETRIES", 3))
 		if err != nil {
 			cfg.Logger.Errorf("Failed to convert BCDA_WORKER_MAX_JOB_NOT_FOUND_RETRIES to int32. Defaulting to 3. Error: %s", err)
-			return nil, err, false
+			return nil, err, true
 		}
 
 		if cfg.ErrorCount >= maxNotFoundRetries {
@@ -93,7 +93,7 @@ func validateJob(ctx context.Context, cfg ValidateJobConfig) (*models.Job, error
 		u, err := safecast.ToUint(cfg.JobID)
 		if err != nil {
 			cfg.Logger.Errorf("Failed to convert Job ID to uint. Error: %s", err)
-			return nil, err, false
+			return nil, err, true
 		}
 
 		_, err = worker.CheckJobCompleteAndCleanup(ctx, cfg.Repository, u)

--- a/bcdaworker/queueing/manager_test.go
+++ b/bcdaworker/queueing/manager_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestProcessJobFailedValidation(t *testing.T) {
+func TestProcessJobFailedValidation_Integration(t *testing.T) {
 	tests := []struct {
 		name        string
 		validateErr error
@@ -87,7 +87,6 @@ func TestProcessJobFailedValidation(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestCheckIfCancelled(t *testing.T) {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8596

## 🛠 Changes

Revert worker client transport options that were causing large scale restarts.  Adjust a few odds and ends with the job reworks to make things clearer.

## ℹ️ Context

There was an incident related to jobs being stuck in an infinite loop of sending successful requests to BFD.  It seems like what was happening under the hood was that requests were happening, then at some point before finishing, the worker instance would restart.  I am 95% sure this is related to the transport config.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tested and linted locally, deployed branch to test env where the same issue was happening and is now resolved.
