### PR TITLE
BCDA-8529: Fix logic for getResponse method

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -463,7 +463,7 @@ func (h *httpLogger) logRequest(req *http.Request) {
 
 func (h *httpLogger) logResponse(req *http.Request, resp *http.Response) {
 	h.l.WithFields(logrus.Fields{
-		"resp_code":      resp.StatusCode,
+		"resp_status":    resp.StatusCode,
 		"bb_query_id":    req.Header.Get(constants.BBHeaderOriginQID),
 		"bb_query_ts":    req.Header.Get(constants.BBHeaderTS),
 		"bb_uri":         req.URL.String(),

--- a/bcda/client/fhir/client.go
+++ b/bcda/client/fhir/client.go
@@ -141,7 +141,7 @@ func getResponse(c *http.Client, req *http.Request) (body []byte, err error) {
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("received incorrect status code %d, failed to parse body %+v", resp.StatusCode, err)
+			return nil, fmt.Errorf("failed to parse response body %+v", err)
 		}
 		return nil, fmt.Errorf("received incorrect status code %d body %s",
 			resp.StatusCode, string(body))

--- a/bcda/client/fhir/client.go
+++ b/bcda/client/fhir/client.go
@@ -129,7 +129,9 @@ func getResponse(c *http.Client, req *http.Request) (body []byte, err error) {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		resp.Body.Close()
+		if err := resp.Body.Close(); err != nil {
+			return nil, err
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8529

## 🛠 Changes

Updated logic within getResponse. Removed a unnecessary nil check. Reevaluated some error checking with request responses.

## ℹ️ Context

Needed to try and see if getResponse logic was responsible for potential memory leaks. 

## 🧪 Validation

Unit-test suite runs. 
