### PR TITLE
BCDA-8460-MBI-masking-alert-testing

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -93,4 +93,8 @@ func main() {
 		fmt.Printf("Error occurred while executing command %s\n", err)
 		log.API.Fatal(err)
 	}
+
+	// Log a made up MBI number for testing the Splunk alert
+	log.API.Info("Processing MBI number: 1EG4-TE5-MK73")
+	log.API.Info("Processing HICN number: 123-45-6789")
 }


### PR DESCRIPTION
## 🎫 Ticket

[BCDA-8460](https://jira.cms.gov/browse/BCDA-8460)

## 🛠 Changes

Two log statements logging made up MBI and HICN numbers

## ℹ️ Context

We mask MBI/HICN numbers in Splunk logs. An alert triggers if there is an unmasked identifier logged. Testing that alert as part of this ticket.
