### PR TITLE
BCDA-8635: Migrate Platinum AMI From Jenkins to Github Workflows

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
-          ref: 'main'
+          ref: 'lauren/BCDA-8635'
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: download packer configs
@@ -65,6 +65,6 @@ jobs:
           ls $GITHUB_WORKSPACE/packer-configs/
           ls ./packer-configs/
           pwd
-          packer init packer/platinum.json 2>&1
-          PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
+          packer init packer/platinum.json.pkr.hcl 2>&1
+          PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          clean: false
           repository: CMSgov/bcda-ops
           ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -64,7 +64,7 @@ jobs:
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #TMPDIR: /home/ec2-user/
+          TMPDIR: /home/ec2-user/
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -56,8 +56,10 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Install python
         uses: actions/setup-python@v4
+      - name: Install pipx #6.5.0
+        run: python3 -m pip install --user pipx
       - name: Install ansible #6.5.0
-        run: python3 -m pip3 install ansible==6.5.0
+        run: pipx install --include-deps ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -56,6 +56,6 @@ jobs:
           set -euo pipefail
           ls
           pwd
-          packer init ./packer-config/github-actions-runner/
+          packer init ${{ github.workspace }}/packer-config/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -43,13 +43,14 @@ jobs:
           TMPDIR: /home/ec2-user/
         run: |        
           packer init ./platformrepo/packer/github-actions-runner/
+          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
       - name: Checkout
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
           ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}
-      - name: packer init
+      - name: packer build
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -1,13 +1,9 @@
 name: Build AMI
 
-# on:
-#   schedule:
-#     - cron: "H 23 * * *"
-# below trigger will be modified after testing
 on:
   pull_request:
-    paths:
-      - .github/workflows/build-ami.yml
+    types:
+      - closed
 
 permissions:
   id-token: write
@@ -50,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
-          ref: 'lauren/BCDA-8635'
+          ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}
       - name: download packer configs
         uses: actions/download-artifact@v4
@@ -66,7 +62,6 @@ jobs:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TMPDIR: /home/ec2-user/
         run: |
-          # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
           packer init packer/platinum.json.pkr.hcl 2>&1
           packer build -color=false -var "source_ami=${GOLD_IMAGE}" -var "subnet_id=${SUBNET_ID}" packer/platinum.json.pkr.hcl 2>&1

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Install Ansible
         run: |
           sudo yum update -y
+          sudo apt install python3-pip
           python3 -m pip install ansible==6.5.0
       
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -47,8 +47,6 @@ jobs:
             GOLD_IMAGE=/bcda/workflows/gold_image_ami
       - name: download packer configs
         uses: actions/download-artifact@v4
-        with:
-          name: packer-configs
       - name: checkout bcda-ops
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          ls
+          ls ${{ github.workspace }}
           pwd
           packer init ${{ github.workspace }}/packer-config/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -63,6 +63,6 @@ jobs:
           ls ${{ github.workspace }}/
           #ls $GITHUB_WORKSPACE/
           pwd
-          packer init $GITHUB_WORKSPACE/packer/github-actions-runner/
+          packer init $GITHUB_WORKSPACE/packer-configs/packer/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
       - name: Install ansible #6.5.0
-        run: pip install ansible==6.5.0
+        run: python -m pip install ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -65,7 +65,6 @@ jobs:
           ls $GITHUB_WORKSPACE/packer-configs/
           ls ./packer-configs/
           pwd
-          packer init packer-configs/
-          packer plugins install github.com/hashicorp/ansible
-          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
+          #packer init packer/platinum.json
+          PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -55,7 +55,8 @@ jobs:
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
           ls ${{ github.workspace }}
+          ls $GITHUB_WORKSPACE
           pwd
-          packer init ${{ github.workspace }}/packer-config/github-actions-runner/
-          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
+          # packer init ${{ github.workspace }}/packer-config/github-actions-runner/
+          #USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -55,7 +55,7 @@ jobs:
       - name: download packer configs
         uses: actions/download-artifact@v4
       - name: Install python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
       - name: Install ansible #6.5.0
         run: pip3 install ansible==6.5.0
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -30,7 +30,7 @@ jobs:
           path: ./packer/github-actions-runner/
   build_ami:
     name: build the platinum ami
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: get_packer_configs
     steps:
       - uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -45,7 +45,7 @@ jobs:
           pwd
           ls 
           
-          packer init ./packer/packer/github-actions-runner/
+          packer init ./platformrepo/packer/github-actions-runner/
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -65,6 +65,6 @@ jobs:
           ls $GITHUB_WORKSPACE/packer-configs/
           ls ./packer-configs/
           pwd
-          #packer init packer/platinum.json
+          packer init packer/platinum.json 2>&1
           PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -18,7 +18,6 @@ jobs:
   build_ami:
     name: build the platinum ami
     runs-on: self-hosted
-    needs: get_packer_configs
     steps:
       - uses: hashicorp/setup-packer@v2.0.1
       - uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -10,20 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  get_packer_configs:
-    name: get packer configs
-    runs-on: self-hosted
-    steps:
-      - name: checkout platform repo
-        uses: actions/checkout@v4
-        with: 
-          repository: cmsgov/ab2d-bcda-dpc-platform
-          ref: 'main'
-      - name: upload packer configs
-        uses: actions/upload-artifact@v4
-        with:
-          name: packer-configs
-          path: ./packer/github-actions-runner/
   build_ami:
     name: build the platinum ami
     runs-on: self-hosted
@@ -46,11 +32,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
-          ref: 'main'
+          ref: 'lauren/BCDA-8635'
           token: ${{ env.GITHUB_TOKEN }}
-      - name: download packer configs
-        uses: actions/download-artifact@v4
-
       - name: Install Ansible
         run: |
           sudo yum update -y

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -36,17 +36,6 @@ jobs:
         with: 
           repository: cmsgov/ab2d-bcda-dpc-platform
           ref: 'main'
-          path: ./platformrepo
-      - name: copy packer config
-        run: |   
-          #mkdir ${{ github.workspace }}/packer-config
-          cp -a ./platformrepo/packer/. ${{ github.workspace }}/packer-config
-      - name: Checkout ops
-        uses: actions/checkout@v4
-        with:
-          repository: CMSgov/bcda-ops
-          ref: 'main'
-          token: ${{ env.GITHUB_TOKEN }}
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,6 +46,6 @@ jobs:
           ls ${{ github.workspace }}/
           #ls $GITHUB_WORKSPACE/
           pwd
-          packer init ./packer-config/github-actions-runner/
-          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
+          packer init ./packer/github-actions-runner/
+          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -39,8 +39,8 @@ jobs:
           path: ./platformrepo
       - name: copy packer config
         run: |   
-          mkdir ./packer-config
-          cp -a ./platformrepo/packer/. ./packer-config
+          mkdir ${{ github.workspace }}/packer-config
+          cp -a ./platformrepo/packer/. ${{ github.workspace }}/packer-config
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -55,7 +55,7 @@ jobs:
       - name: download packer configs
         uses: actions/download-artifact@v4
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v3
       - name: Install ansible #6.5.0
         run: pip3 install ansible==6.5.0
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -62,8 +62,8 @@ jobs:
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
           ls ${{ github.workspace }}/
-          #ls $GITHUB_WORKSPACE/
+          ls $GITHUB_WORKSPACE/
           pwd
-          packer init $GITHUB_WORKSPACE/packer-configs/packer/github-actions-runner/
+          packer init ./packer-configs/packer/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -1,9 +1,14 @@
 name: Build AMI
 
+# on:
+#   pull_request:
+#     types:
+#       - closed
 on:
   pull_request:
-    types:
-      - closed
+    paths:
+      - .github/workflows/build-ami.yml
+
 
 permissions:
   id-token: write

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   get_packer_configs:
     name: get packer configs
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: checkout platform repo
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           path: ./packer/github-actions-runner/
   build_ami:
     name: build the platinum ami
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: get_packer_configs
     steps:
       - uses: hashicorp/setup-packer@v2.0.1

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -39,12 +39,11 @@ jobs:
           path: ./platformrepo
       - name: copy packer config
         run: |   
-          mkdir ${{ github.workspace }}/packer-config
+          #mkdir ${{ github.workspace }}/packer-config
           cp -a ./platformrepo/packer/. ${{ github.workspace }}/packer-config
-      - name: Checkout
+      - name: Checkout ops
         uses: actions/checkout@v4
         with:
-          clean: false
           repository: CMSgov/bcda-ops
           ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: get_packer_configs
     steps:
-      - uses: hashicorp/setup-packer@v2.0.1
       - uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ vars.AWS_REGION }}
@@ -55,6 +54,13 @@ jobs:
 
       - name: download packer configs
         uses: actions/download-artifact@v4
+      - name: Install python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+
+      - name: Install ansible
+        run: pip install ansible
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -51,15 +51,14 @@ jobs:
           repository: CMSgov/bcda-ops
           ref: 'lauren/BCDA-8635'
           token: ${{ env.GITHUB_TOKEN }}
-
       - name: download packer configs
         uses: actions/download-artifact@v4
-      - name: Install python
-        uses: actions/setup-python@v3
-      - name: Install pipx #6.5.0
-        run: python3 -m pip3 install --user pipx
-      - name: Install ansible #6.5.0
-        run: pipx install --include-deps ansible==6.5.0
+
+      - name: Install Ansible
+        run: |
+          sudo yum update -y
+          python3 -m pip install ansible==6.5.0
+      
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
       - name: Install ansible #6.5.0
-        run: pip3 install ansible==6.5.0
+        run: pip install ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
       - name: Install ansible #6.5.0
-        run: python3 -m pip install ansible==6.5.0
+        run: python3 -m pip3 install ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -59,8 +59,8 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install ansible
-        run: pip install ansible
+      - name: Install ansible #6.5.0
+        run: pip install ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -45,14 +45,15 @@ jobs:
             GITHUB_TOKEN=/ci/github/token
             SUBNET_ID=/bcda/workflows/packer_subnet_id
             GOLD_IMAGE=/bcda/workflows/gold_image_ami
-      - name: download packer configs
-        uses: actions/download-artifact@v4
       - name: checkout bcda-ops
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
           ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}
+
+      - name: download packer configs
+        uses: actions/download-artifact@v4
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -31,6 +31,7 @@ jobs:
   build_ami:
     name: build the platinum ami
     runs-on: self-hosted
+    needs: get_packer_configs
     steps:
       - uses: hashicorp/setup-packer@v2.0.1
       - uses: aws-actions/configure-aws-credentials@v3
@@ -65,5 +66,5 @@ jobs:
           ls ./packer-configs/
           pwd
           packer init packer-configs/
-          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
+          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -55,7 +55,7 @@ jobs:
       - name: download packer configs
         uses: actions/download-artifact@v4
       - name: Install python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
       - name: Install ansible #6.5.0
         run: pip install ansible==6.5.0
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Ansible
         run: |
           sudo yum update -y
-          sudo apt install python3-pip
+          sudo yum install python3-pip
           python3 -m pip install ansible==6.5.0
       
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -68,5 +68,5 @@ jobs:
           #packer plugins install github.com/hashicorp/ansible
 
           packer init packer/platinum.json.pkr.hcl 2>&1
-          PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
+          PACKER_LOG=1 packer build -color=false -var 'source_ami=${GOLD_IMAGE}' -var 'subnet_id=${SUBNET_ID}' packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -61,8 +61,7 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          ls ${{ github.workspace }}/
-          ls $GITHUB_WORKSPACE/
+          ls $GITHUB_WORKSPACE/packer-configs
           pwd
           packer init packer-configs/packer/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   get_packer_configs:
     name: get packer configs
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: checkout platform repo
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TMPDIR: /home/ec2-user/
+          #TMPDIR: /home/ec2-user/
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -68,5 +68,5 @@ jobs:
           #packer plugins install github.com/hashicorp/ansible
 
           packer init packer/platinum.json.pkr.hcl 2>&1
-          PACKER_LOG=1 packer build -color=false -var 'source_ami=${{GOLD_IMAGE}}' -var "subnet_id=$SUBNET_ID" packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
+          PACKER_LOG=1 packer build -color=false -var "source_ami=${GOLD_IMAGE}" -var "subnet_id=$SUBNET_ID" packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -54,6 +54,6 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          packer init ./platformrepo/packer/github-actions-runner/
+          packer init ./packer-config/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -62,11 +62,6 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          ls $GITHUB_WORKSPACE/packer-configs/
-          ls ./packer-configs/
-          pwd
-          #packer plugins install github.com/hashicorp/ansible
-
           packer init packer/platinum.json.pkr.hcl 2>&1
-          PACKER_LOG=1 packer build -color=false -var "source_ami=${GOLD_IMAGE}" -var "subnet_id=$SUBNET_ID" packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
+          packer build -color=false -var "source_ami=${GOLD_IMAGE}" -var "subnet_id=${SUBNET_ID}" packer/platinum.json.pkr.hcl 2>&1
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
       - name: Install ansible #6.5.0
-        run: python -m pip install ansible==6.5.0
+        run: python3 -m pip install ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: self-hosted
     needs: get_packer_configs
     steps:
+      - uses: hashicorp/setup-packer@v2.0.1
       - uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -58,6 +58,6 @@ jobs:
           ls ${{ github.workspace }}/
           #ls $GITHUB_WORKSPACE/
           pwd
-          # packer init ${{ github.workspace }}/packer-config/github-actions-runner/
-          #USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
+          packer init ./packer-config/github-actions-runner/
+          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
       - name: Install ansible #6.5.0
-        run: pip install ansible==6.5.0
+        run: pip3 install ansible==6.5.0
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -36,14 +36,11 @@ jobs:
         with: 
           repository: cmsgov/ab2d-bcda-dpc-platform
           ref: 'main'
-          path: platformrepo
-      - name: packer init
-        env:
-          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TMPDIR: /home/ec2-user/
-        run: |        
-          packer init ./platformrepo/packer/github-actions-runner/
-          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
+          path: ./platformrepo
+      - name: copy packer config
+        run: |   
+          mkdir ./packer-config
+          cp -a ./platformrepo/packer/. ./packer-config
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -51,8 +48,12 @@ jobs:
           ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}
       - name: packer build
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TMPDIR: /home/ec2-user/
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
+          packer init ./platformrepo/packer/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -55,9 +55,9 @@ jobs:
       - name: download packer configs
         uses: actions/download-artifact@v4
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v3
       - name: Install pipx #6.5.0
-        run: python3 -m pip install --user pipx
+        run: python3 -m pip3 install --user pipx
       - name: Install ansible #6.5.0
         run: pipx install --include-deps ansible==6.5.0
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -1,14 +1,9 @@
 name: Build AMI
 
-# on:
-#   pull_request:
-#     types:
-#       - closed
 on:
   pull_request:
-    paths:
-      - .github/workflows/build-ami.yml
-
+    types:
+      - closed
 
 permissions:
   id-token: write
@@ -36,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
-          ref: 'lauren/BCDA-8635'
+          ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}
       - name: Install Ansible
         run: |

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -66,5 +66,6 @@ jobs:
           ls ./packer-configs/
           pwd
           packer init packer-configs/
+          packer plugins install github.com/hashicorp/ansible
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -65,6 +65,8 @@ jobs:
           ls $GITHUB_WORKSPACE/packer-configs/
           ls ./packer-configs/
           pwd
+          #packer plugins install github.com/hashicorp/ansible
+
           packer init packer/platinum.json.pkr.hcl 2>&1
           PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -68,5 +68,5 @@ jobs:
           #packer plugins install github.com/hashicorp/ansible
 
           packer init packer/platinum.json.pkr.hcl 2>&1
-          PACKER_LOG=1 packer build -color=false -var 'source_ami=${GOLD_IMAGE}' -var 'subnet_id=${SUBNET_ID}' packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
+          PACKER_LOG=1 packer build -color=false -var 'source_ami=${{GOLD_IMAGE}}' -var "subnet_id=$SUBNET_ID" packer/platinum.json.pkr.hcl 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -54,6 +54,8 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
+          ls
+          pwd
           packer init ./packer-config/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -1,4 +1,6 @@
 name: Build AMI
+# Build AMI will create a 'platinum ami' using packer and ansible that is based of the CMS monthly Gold Image.
+
 
 on:
   pull_request:

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -14,8 +14,22 @@ permissions:
   contents: read
 
 jobs:
-  build_ami:
+  get_packer_configs:
     name: build ami
+    runs-on: self-hosted
+    steps:
+      - name: checkout platform repo
+        uses: actions/checkout@v4
+        with: 
+          repository: cmsgov/ab2d-bcda-dpc-platform
+          ref: 'main'
+      - name: upload packer configs
+        uses: actions/upload-artifact@v4
+        with:
+          name: packer-configs
+          path: ./packer/github-actions-runner/
+  build_ami:
+    name: build the platinum ami
     runs-on: self-hosted
     steps:
       - uses: hashicorp/setup-packer@v2.0.1
@@ -31,11 +45,16 @@ jobs:
             GITHUB_TOKEN=/ci/github/token
             SUBNET_ID=/bcda/workflows/packer_subnet_id
             GOLD_IMAGE=/bcda/workflows/gold_image_ami
-      - name: Checkout
+      - name: download packer configs
+        uses: actions/download-artifact@v4
+        with:
+          name: packer-configs
+      - name: checkout bcda-ops
         uses: actions/checkout@v4
-        with: 
-          repository: cmsgov/ab2d-bcda-dpc-platform
+        with:
+          repository: CMSgov/bcda-ops
           ref: 'main'
+          token: ${{ env.GITHUB_TOKEN }}
       - name: packer build
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -64,6 +64,6 @@ jobs:
           ls ${{ github.workspace }}/
           ls $GITHUB_WORKSPACE/
           pwd
-          packer init ./packer-configs/packer/github-actions-runner/
+          packer init packer-configs/packer/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -37,14 +37,11 @@ jobs:
           repository: cmsgov/ab2d-bcda-dpc-platform
           ref: 'main'
           path: platformrepo
-      - name: packer build
+      - name: packer init
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TMPDIR: /home/ec2-user/
-        run: |
-          pwd
-          ls 
-          
+        run: |        
           packer init ./platformrepo/packer/github-actions-runner/
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,4 +49,9 @@ jobs:
           repository: CMSgov/bcda-ops
           ref: 'main'
           token: ${{ env.GITHUB_TOKEN }}
+      - name: packer init
+        run: |
+          # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
+          set -euo pipefail
+          USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          ls ${{ github.workspace }}/opt/actions-runner/_work/bcda-app/bcda-app
-          #ls $GITHUB_WORKSPACE/opt/actions-runner/_work/bcda-app/bcda-app
+          ls ${{ github.workspace }}/
+          #ls $GITHUB_WORKSPACE/
           pwd
           # packer init ${{ github.workspace }}/packer-config/github-actions-runner/
           #USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Ansible
         run: |
           sudo yum update -y
-          sudo yum install python3-pip
+          sudo yum install python3-pip -y
           python3 -m pip install ansible==6.5.0
       
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -61,8 +61,9 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          ls $GITHUB_WORKSPACE/packer-configs
+          ls $GITHUB_WORKSPACE/packer-configs/
+          ls ./packer-configs/
           pwd
-          packer init packer-configs/packer/github-actions-runner/
+          packer init packer-configs/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -3,6 +3,8 @@ name: Build AMI
 
 
 on:
+  workflow_call:
+  workflow_dispatch:
   pull_request:
     types:
       - closed

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -56,9 +56,6 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Install python
         uses: actions/setup-python@v3
-        with:
-          python-version: '3.8'
-
       - name: Install ansible #6.5.0
         run: pip install ansible==6.5.0
       - name: packer build

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   get_packer_configs:
-    name: build ami
+    name: get packer configs
     runs-on: self-hosted
     steps:
       - name: checkout platform repo
@@ -65,6 +65,6 @@ jobs:
           ls ${{ github.workspace }}/
           #ls $GITHUB_WORKSPACE/
           pwd
-          packer init ./packer/github-actions-runner/
+          packer init $GITHUB_WORKSPACE/packer/github-actions-runner/
           USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' ./platinum.json 2>&1 | tee platinum_packer_output.txt
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
-          ls ${{ github.workspace }}
-          ls $GITHUB_WORKSPACE
+          ls ${{ github.workspace }}/opt/actions-runner/_work/bcda-app/bcda-app
+          #ls $GITHUB_WORKSPACE/opt/actions-runner/_work/bcda-app/bcda-app
           pwd
           # packer init ${{ github.workspace }}/packer-config/github-actions-runner/
           #USER=`whoami` PACKER_LOG=1 packer build -color=false -var 'source_ami=$GOLD_IMAGE' -var 'subnet_id=$SUBNET_ID' packer/platinum.json 2>&1 | tee platinum_packer_output.txt


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8635

## 🛠 Changes

Migration of platinum image creation from Jenkins -> Github Workflows.

## ℹ️ Context

Made as part of the larger effort to deprecate Jenkins. This requires another PR in the ops repo that must also be merged: https://github.com/CMSgov/bcda-ops/pull/1146 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Workflow passes and confirmed AMI is available in EC2. (latest run will fail until ops repo is merged, but successful run can be found here: https://github.com/CMSgov/bcda-app/actions/runs/13039689810/job/36378517357?pr=1031)
