### PR TITLE
BCDA-8523: Adjust query that counts total number of unprocessed jobs

### DIFF
--- a/bcdaworker/queueing/river.go
+++ b/bcdaworker/queueing/river.go
@@ -169,7 +169,7 @@ func updateJobQueueCountCloudwatchMetric(db *sql.DB, log logrus.FieldLogger) {
 }
 
 func getQueueJobCount(db *sql.DB, log logrus.FieldLogger) float64 {
-	row := db.QueryRow(`select count(*) from river_job;`)
+	row := db.QueryRow(`SELECT COUNT(*) FROM river_job WHERE state NOT IN ('completed', 'cancelled', 'discarded');`)
 
 	var count int
 	if err := row.Scan(&count); err != nil {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8523

## 🛠 Changes

Adjust query that counts total unprocessed jobs.

## ℹ️ Context

This query is what determines the cloudwatch alarms for total number of unprocessed jobs.  Previously que-go would just delete finished jobs, while river does not.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local testing and linting.
