### PR TITLE
BCDA-8460 - Log MBI/HICN number to test Splunk alerting

### DIFF
--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -387,6 +387,10 @@ Responses:
 	200: MetadataResponse
 */
 func Metadata(w http.ResponseWriter, r *http.Request) {
+	// Log a made up MBI number for testing the Splunk alert
+	log.API.Info("Processing MBI number: 1EG4-TE5-MK73")
+	log.API.Info("Processing HICN number: 123-45-6789")
+
 	dt := time.Now()
 
 	scheme := "http"


### PR DESCRIPTION
## 🎫 Ticket

[BCDA-8460](https://jira.cms.gov/browse/BCDA-8460)

## 🛠 Changes

Two log statements logging made up MBI and HICN numbers

## ℹ️ Context

We mask MBI/HICN numbers in Splunk logs. An alert triggers if there is an unmasked identifier logged. Testing that alert as part of this ticket.