### PR TITLE
BCDA-8747-support-mdtcoc-aco-regex

### DIFF
--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -638,7 +638,7 @@ func IsSupportedACO(cmsID string) bool {
 		ckcc    = `^C\d{4}$`
 		kcf     = `^K\d{4}$`
 		dc      = `^D\d{4}$`
-		mdtcoc  = `^CT\d{4}$`
+		mdtcoc  = `^CT\d{4,6}$`
 		test    = `^TEST\d{3}$`
 		sandbox = `^SBX[A-Z]{2}\d{3}$`
 		pattern = `(` + ssp + `)|(` + ngaco + `)|(` + cec + `)|(` + ckcc + `)|(` + kcf + `)|(` + dc + `)|(` + mdtcoc + `)|(` + test + `)|(` + sandbox + `)`

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -73,9 +73,9 @@ func TestSupportedACOs(t *testing.T) {
 		{"valid DC", "D9999", true},
 
 		{"MDTCOC too short", "CT999", false},
-		{"MDTCOC too long", "CT99999", false},
+		{"MDTCOC too long", "CT9999999", false},
 		{"MDTCOC invalid characters", "CT999V", false},
-		{"valid MDTCOC", "CT9999", true},
+		{"valid MDTCOC", "CT99999", true},
 
 		{"SBX too short", "SBXB1", false},
 		{"SBX too long", "SBXPA0123", false},


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8747

## 🛠 Changes

Added regex ^CT\d{4}$ for MDTCoC CMS ID

## ℹ️ Context

We validate the CMS ID format when creating an ACO. Currently, our jobs cannot create a new ACO starting with CT*

## 🧪 Validation

- Unit tests
- ACO Creation
