### PR TITLE
Fix release_type env var, cleanup

### DIFF
--- a/.github/workflows/build-and-package-all.yml
+++ b/.github/workflows/build-and-package-all.yml
@@ -6,29 +6,29 @@ on:
   workflow_call:
     inputs:
       release_version:
-        description: 'Release version (or branch name)'
+        description: 'Release version/tag (or branch name)'
+        required: true
+        type: string
+      ops_release_version:
+        description: 'Release version/tag bcda-ops (or branch name)'
         required: true
         type: string
       ssas_release_version:
-          description: 'Release version for bcda-ssas (or branch name)'
+          description: 'Release version/tag for bcda-ssas (or branch name)'
           required: true
           type: string
-      ops_release_version:
-        description: 'Release version bcda-ops (or branch name)'
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release version (or branch name)'
-        required: true
-        type: string
-      ssas_release_version:
-        description: 'Release version for bcda-ssas (or branch name)'
+        description: 'Release version/tag (or branch name)'
         required: true
         type: string
       ops_release_version:
-        description: 'Release version for bcda-ops (or branch name)'
+        description: 'Release version/tag for bcda-ops (or branch name)'
+        required: true
+        type: string
+      ssas_release_version:
+        description: 'Release version/tag for bcda-ssas (or branch name)'
         required: true
         type: string
 
@@ -72,14 +72,12 @@ jobs:
         run: |
           export BCDA_PLATINUM_AMI=`aws --region us-east-1 ec2 describe-images --filters Name=name,Values='bcda-platinum-??????????????' --query 'sort_by(Images,&CreationDate)[-1]' --output json | jq -r .ImageId`
           echo "BCDA_PLATINUM_AMI=$BCDA_PLATINUM_AMI" >> $GITHUB_ENV
-      - name: Get release type
-        run: |
-          if [[ $(git tag -l main | wc -c | xargs) -eq "0" ]]; then
-            export RELEASE_TYPE=dev
-          else
-            export RELEASE_TYPE=release
-          fi
-          echo "RELEASE_TYPE=$RELEASE_TYPE" >> $GITHUB_ENV
+      - name: Set release type (dev)
+        if: ${{ inputs.release_version == 'main' || inputs.release_version == '' }}
+        run: echo "RELEASE_TYPE=dev" >> $GITHUB_ENV
+      - name: Set release type (release)
+        if: ${{ inputs.release_version != 'main' && inputs.release_version != '' }}
+        run: echo "RELEASE_TYPE=release" >> $GITHUB_ENV
       - name: Install Ansible
         run: |
           sudo yum update -y
@@ -107,7 +105,6 @@ jobs:
           set -euo pipefail
           packer init packer/worker.json.pkr.hcl 2>&1
           packer build -color=false -var "source_ami=${{ env.BCDA_PLATINUM_AMI }}" -var "subnet_id=${{ env.SUBNET_ID }}" -var "version=${{ inputs.release_version}}" -var "release_type=${{ env.RELEASE_TYPE }}" packer/worker.json.pkr.hcl 2>&1
-          post_build:
       - name: Success Alert
         if: ${{ success() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -5,15 +5,15 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release version (or branch name)'
-        required: true
-        type: string
-      ssas_release_version:
-        description: 'Release version for bcda-ssas (or branch name)'
+        description: 'Release version/tag (or branch name)'
         required: true
         type: string
       ops_release_version:
-        description: 'Release version for bcda-ops (or branch name)'
+        description: 'Release version/tag for bcda-ops (or branch name)'
+        required: true
+        type: string
+      ssas_release_version:
+        description: 'Release version/tag for bcda-ssas (or branch name)'
         required: true
         type: string
       env:
@@ -175,6 +175,7 @@ jobs:
   #   secrets: inherit
 
   post_deploy:
+    if: ${{ always() }}
     # needs: [smoketests]
     needs: [deploy]
     runs-on: self-hosted
@@ -208,7 +209,8 @@ jobs:
             --api_key ${{ env.NEWRELIC_API_KEY }} \
             --version ${BCDA_AMI}
       - name: Publish Build Info
-        if: ${{ success() }}
+        if: ${{ success() && needs.migrate_db.result == 'success' && needs.deploy.result == 'success' }}
+        # if: ${{ success() && needs.migrate_db.result == 'success' && needs.smoketests.result == 'success' && needs.deploy.result == 'success' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -234,7 +236,8 @@ jobs:
                   - pretext
                   - footer
       - name: Failure Alert
-        if: ${{ failure() }}
+        if: ${{ failure() || needs.migrate_db.result != 'success' || needs.deploy.result != 'success' }}
+        # if: ${{ failure() || needs.migrate_db.result != 'success' || needs.smoketests.result != 'success' || needs.deploy.result != 'success' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage

--- a/.github/workflows/package-rpms.yml
+++ b/.github/workflows/package-rpms.yml
@@ -4,13 +4,13 @@ on:
   workflow_call:
     inputs:
       release_version:
-        description: 'Release version (or branch name)'
+        description: 'Release version/tag (or branch name)'
         required: true
         type: string
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release version (or branch name)'
+        description: 'Release version/tag (or branch name)'
         required: true
         type: string
 

--- a/bcda/constants/constants.go
+++ b/bcda/constants/constants.go
@@ -9,7 +9,7 @@ const ImportInprog = "In-Progress"
 const ImportComplete = "Completed"
 const ImportFail = "Failed"
 
-// This is set during compilation.  See build_and_package.sh in the ops repo
+// This is set during compilation.  See build_and_package.sh in the /ops dir
 var Version = "latest"
 
 const Adjudicated = "adjudicated"

--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -32,13 +32,13 @@ fi
 
 cd ../bcda
 go clean
-echo "Building bcda binary..." 
+echo "Building bcda binary Version=$VERSION..."
 go build -ldflags "-X github.com/CMSgov/bcda-app/bcda/constants.Version=$VERSION"
 echo "Packaging bcda binary into RPM..."
 fpm -v $VERSION -s dir -t rpm -n bcda bcda=/usr/local/bin/bcda models/fhir/alr/utils/hcc_crosswalk.tsv=/etc/sv/api/hcc_crosswalk.tsv ../conf/configs/=/go/src/github.com/CMSgov/bcda-app/conf/configs
 cd ../bcdaworker
 go clean
-echo "Building bcdaworker..."
+echo "Building bcdaworker Version=$VERSION..."
 go build -ldflags "-X github.com/CMSgov/bcda-app/bcda/constants.Version=$VERSION"
 echo "Packaging bcdaworker binary into RPM..."
 fpm -v $VERSION -s dir -t rpm -n bcdaworker bcdaworker=/usr/local/bin/bcdaworker ../bcda/models/fhir/alr/utils/hcc_crosswalk.tsv=/etc/sv/worker/hcc_crosswalk.tsv ../conf/configs/=/go/src/github.com/CMSgov/bcda-app/conf/configs/


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8739

## 🛠 Changes

Fix release type env var, cleanup of descriptions

## ℹ️ Context

Slight snag on the script that sets release type, which ended up deploying a dev build as opposed to the tag build.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing
