### PR TITLE
BCDA-8839: Add needed smoke test vars to deploy workflow

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -2,6 +2,8 @@
 name: Deploy All
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       release_version:
@@ -54,12 +56,13 @@ permissions:
   contents: read
 
 env:
+  RELEASE_VERSION: ${{ inputs.release_version || 'main' }}
+  OPS_RELEASE_VERSION: ${{ inputs.ops_release_version || 'main' }}
+  SSAS_RELEASE_VERSION: ${{ inputs.ssas_release_version || 'main' }}
   RELEASE_ENV: ${{ inputs.env || 'dev' }}
   CONFIRM_RELEASE_ENV: ${{ inputs.confirm_env || 'dev' }}
-  RELEASE_VERSION: ${{ inputs.release_version || 'main' }}
-  SSAS_RELEASE_VERSION: ${{ inputs.ssas_release_version || 'main' }}
-  OPS_RELEASE_VERSION: ${{ inputs.ops_release_version || 'main' }}
   ENV_MODIFIER: ${{ inputs.env == 'opensbx' && 'sbx' || inputs.env }}
+  TEST_ACO: ${{ inputs.test_aco || 'dev' }}
 
 jobs:
   migrate_db:
@@ -185,10 +188,10 @@ jobs:
     needs: [migrate_db, deploy]
     uses: ./.github/workflows/smoke-tests.yml
     with:
-      release_version: ${{ inputs.release_version }}
-      ssas_release_version: ${{ inputs.ssas_release_version }}
-      env: ${{ inputs.env }}
-      test_aco: ${{ inputs.test_aco }}
+      release_version: ${{ inputs.release_version || 'main' }}
+      ssas_release_version: ${{ inputs.ssas_release_version || 'main' }}
+      env: ${{ inputs.env || 'dev' }}
+      test_aco: ${{ inputs.test_aco || 'dev' }}
       smoke_tests: true
       postman_tests: true
     secrets: inherit

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -36,6 +36,18 @@ on:
           - test
           - opensbx
           - prod
+      test_aco:
+        description: Run the smoke tests using the selected ACO
+        required: true
+        type: choice
+        options:
+          - 'dev'
+          - 'small'
+          - 'medium'
+          - 'large'
+          - 'extra-large'
+          - 'paca'
+        default: 'dev'
 
 permissions:
   id-token: write
@@ -176,6 +188,9 @@ jobs:
       release_version: ${{ inputs.release_version }}
       ssas_release_version: ${{ inputs.ssas_release_version }}
       env: ${{ inputs.env }}
+      test_aco: ${{ inputs.test_aco }}
+      smoke_tests: true
+      postman_tests: true
     secrets: inherit
 
   post_deploy:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8839

## 🛠 Changes

Add needed smoke test vars to deploy workflow and autodeploy to dev env.

## ℹ️ Context

Deploy workflow was failing due to missing vars

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing
