### PR TITLE
BCDA-8637: refresh attribution data GHA

### DIFF
--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -69,7 +69,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
       - name: Install psql
         run: |
-          sudo amazon-linux-extras install postgresql14
+          sudo dnf install postgresql15 -y
       - name: Get database credentials
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -69,7 +69,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
       - name: Install psql
         run: |
-          sudo dnf install postgresql15 -y
+          sudo dnf install postgresql16 -y
       - name: Get database credentials
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -53,14 +53,14 @@ jobs:
               HOST=$(aws rds describe-db-instances --query 'DBInstances[*].[Endpoint.Address]' --output text | grep bcda-$key 2>&1)
               if [ $? -ne 0 ]; then
                   echo "Error: failed to retrieve database host."
-                  exit
+                  exit 1
               fi
               CONNECTION_URL=$(echo $value 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
               ./scripts/refresh_test_attribution.sh -c "${CONNECTION_URL}" -f > /dev/null 2>&1
 
               if [ $? -ne 0 ]; then
                   echo "Error: Refresh failed; run script locally for more details."
-                  exit
+                  exit 1
               else 
                   echo "Success: refresh complete."
               fi

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -40,13 +40,41 @@ jobs:
       - name: Refresh all environments
         run: |
           set -euo pipefail
-          ENVS=($DEV_DB, $TEST_DB, $SBX_DB, $PROD_DB)
-          for conn in ${ENVS[@]}; do
-            ./scripts/refresh_test_attribution.sh -c "${conn}" -f > /dev/null 2>&1
+
+          declare -A environments
+
+          environments["dev"]=$DEV_DB
+          environments["test"]=$TEST_DB
+          # environments["opensbx"]=$TEST_DB
+          # environments["prod"]=$PROD_DB
+
+          for key in "${!environments[@]}"; do
+
+            value="${environments[$key]}"
+            echo "Key: $key, Value: $value"
+
+            HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-$key-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
+            CONNECTION_URL=$(echo $value 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
+
+            ./scripts/refresh_test_attribution.sh -c "${CONNECTION_URL}" -f > /dev/null 2>&1
+            
             if [ $? -ne 0 ]; then
               echo "Refresh failed. Run script locally for more details."
             else 
               echo "Refresh Successful."
             fi
           done
+
+
+
+
+          # ENVS=($DEV_DB, $TEST_DB, $TEST_DB, $PROD_DB)
+          # for conn in ${ENVS[@]}; do
+          #   ./scripts/refresh_test_attribution.sh -c "${conn}" -f > /dev/null 2>&1
+          #   if [ $? -ne 0 ]; then
+          #     echo "Refresh failed. Run script locally for more details."
+          #   else 
+          #     echo "Refresh Successful."
+          #   fi
+          # done
           

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -30,7 +30,7 @@ jobs:
             PROD_DB=/bcda/prod/api/DATABASE_URL
       - name: Install psql
         run: |
-          sudo dnf install postgresql15 -y
+          sudo dnf install postgresql16 -y
       - name: checkout bcda-ops
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -45,10 +45,10 @@ jobs:
           set -euo pipefail
           declare -A environments
 
-          # environments["dev"]=$DEV_DB
+          environments["dev"]=$DEV_DB
           environments["test"]=$TEST_DB
-          # environments["opensbx"]=$TEST_DB
-          # environments["prod"]=$PROD_DB
+          environments["opensbx"]=$SBX_DB
+          environments["prod"]=$PROD_DB
 
           for key in "${!environments[@]}"; do
               value="${environments[$key]}"

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -2,9 +2,6 @@
 name: Refresh Attribution For Test ACOs
 
 on:
-  pull_request: # temporary for testing
-    paths:
-      - .github/workflows/refresh_test_attribution.yml
   schedule:
     - cron: "0 12 * * 1" 
 

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -53,7 +53,7 @@ jobs:
           for key in "${!environments[@]}"; do
               value="${environments[$key]}"
 
-              HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-$key-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
+              HOST=$(aws rds describe-db-instances --query 'DBInstances[*].[DBName,DBInstanceIdentifier,Endpoint.Address]' --output text | grep bcda-$key 2>&1)
               if [ $? -ne 0 ]; then
                   echo "Error: failed to retrieve database host."
                   exit

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -2,6 +2,9 @@
 name: Refresh Attribution For Test ACOs
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/refresh_test_attribution.yml
   schedule:
     - cron: "0 12 * * 1" 
 

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -26,6 +26,7 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
+            GITHUB_TOKEN=/ci/github/token
             DEV_DB=/bcda/dev/api/DATABASE_URL
             TEST_DB=/bcda/test/api/DATABASE_URL
       - name: checkout bcda-ops

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -33,7 +33,7 @@ jobs:
             PROD_DB=/bcda/prod/api/DATABASE_URL
       - name: Install psql
         run: |
-          sudo amazon-linux-extras install postgresql14
+          sudo dnf install postgresql15 -y
       - name: checkout bcda-ops
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -46,9 +46,9 @@ jobs:
           declare -A environments
 
           environments["dev"]=$DEV_DB
-          environments["test"]=$TEST_DB
-          environments["opensbx"]=$TEST_DB
-          environments["prod"]=$PROD_DB
+          # environments["test"]=$TEST_DB
+          # environments["opensbx"]=$TEST_DB
+          # environments["prod"]=$PROD_DB
 
           for key in "${!environments[@]}"; do
               value="${environments[$key]}"

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - .github/workflows/refresh_test_attribution.yml
   schedule:
-    - cron: "15 4,5 * * *"   # <=== Change this value
+    - cron: "0 12 * * 1" 
 
 permissions:
   id-token: write
@@ -29,6 +29,8 @@ jobs:
             GITHUB_TOKEN=/ci/github/token
             DEV_DB=/bcda/dev/api/DATABASE_URL
             TEST_DB=/bcda/test/api/DATABASE_URL
+            SBX_DB=/bcda/opensbx/api/DATABASE_URL
+            PROD_DB=/bcda/prod/api/DATABASE_URL
       - name: checkout bcda-ops
         uses: actions/checkout@v4
         with:
@@ -38,7 +40,7 @@ jobs:
       - name: Refresh all environments
         run: |
           set -euo pipefail
-          ENVS=($DEV_DB)
+          ENVS=($DEV_DB, $TEST_DB, $SBX_DB, $PROD_DB)
           for conn in ${ENVS[@]}; do
             ./scripts/refresh_test_attribution.sh -c "${conn}" -f > /dev/null 2>&1
             if [ $? -ne 0 ]; then

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -47,7 +47,7 @@ jobs:
 
           environments["dev"]=$DEV_DB
           environments["test"]=$TEST_DB
-          environments["opensbx"]=$foo
+          environments["opensbx"]=$SBX_DB
           environments["prod"]=$PROD_DB
 
           for key in "${!environments[@]}"; do

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Refresh all environments
         run: |
           set -euo pipefail
-          ENVS=($DEV_DB, $TEST_DB)
-          for aco in ${ENVS[@]}; do
-            echo "FOO BAR"
+          ENVS=($DEV_DB)
+          for conn in ${ENVS[@]}; do
+            ./scripts/refresh_test_attribution.sh -c "${conn}" -f > /dev/null 2>&1
             if [ $? -ne 0 ]; then
               echo "Refresh failed. Run script locally for more details."
             else 

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -47,7 +47,7 @@ jobs:
 
           environments["dev"]=$DEV_DB
           environments["test"]=$TEST_DB
-          environments["opensbx"]=$SBX_DB
+          environments["opensbx"]=$foo
           environments["prod"]=$PROD_DB
 
           for key in "${!environments[@]}"; do
@@ -68,3 +68,17 @@ jobs:
                   echo "Success: refresh complete."
               fi
               done
+      - name: Failure Alert
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to bcda-alerts
+          payload: |
+            channel: "C034CFU945C"
+            attachments:
+              - color: danger
+                text: "FAILURE: Refresh Test Attribution (run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>)."
+                mrkdown_in:
+                  - text

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -2,9 +2,6 @@
 name: Refresh Attribution For Test ACOs
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/refresh_test_attribution.yml
   schedule:
     - cron: "0 12 * * 1" 
 

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Refresh all environments
         run: |
           set -euo pipefail
-
           declare -A environments
 
           environments["dev"]=$DEV_DB
@@ -49,21 +48,24 @@ jobs:
           # environments["prod"]=$PROD_DB
 
           for key in "${!environments[@]}"; do
+              value="${environments[$key]}"
 
-            value="${environments[$key]}"
-            echo "Key: $key, Value: $value"
+              HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-$key-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
+              if [ $? -ne 0 ]; then
+                  echo "Error: failed to retrieve database host."
+                  exit
+              fi
+              CONNECTION_URL=$(echo $value 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
+              ./scripts/refresh_test_attribution.sh -c "${CONNECTION_URL}" -f > /dev/null 2>&1
 
-            HOST=$(aws rds describe-db-instances --db-instance-identifier bcda-$key-rds 2>&1 | jq -r '.DBInstances[0].Endpoint.Address' 2>&1)
-            CONNECTION_URL=$(echo $value 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
+              if [ $? -ne 0 ]; then
+                  echo "Refresh failed. Run script locally for more details."
+                  exit
+              else 
+                  echo "Refresh Successful."
+              fi
+              done
 
-            ./scripts/refresh_test_attribution.sh -c "${CONNECTION_URL}" -f > /dev/null 2>&1
-            
-            if [ $? -ne 0 ]; then
-              echo "Refresh failed. Run script locally for more details."
-            else 
-              echo "Refresh Successful."
-            fi
-          done
 
 
 

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -31,6 +31,9 @@ jobs:
             TEST_DB=/bcda/test/api/DATABASE_URL
             SBX_DB=/bcda/opensbx/api/DATABASE_URL
             PROD_DB=/bcda/prod/api/DATABASE_URL
+      - name: Install psql
+        run: |
+          sudo amazon-linux-extras install postgresql14
       - name: checkout bcda-ops
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -1,0 +1,49 @@
+# Refreshes attribution for test acos in all envs.
+name: Refresh Attribution For Test ACOs
+
+on:
+  pull_request: # temporary for testing
+    paths:
+      - .github/workflows/refresh_test_attribution.yml
+  schedule:
+    - cron: "15 4,5 * * *"   # <=== Change this value
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  refresh_attribution:
+    name: Refresh Attribution
+    runs-on: self-hosted
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
+      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            DEV_DB=/bcda/dev/api/DATABASE_URL
+            TEST_DB=/bcda/test/api/DATABASE_URL
+      - name: checkout bcda-ops
+        uses: actions/checkout@v4
+        with:
+          repository: CMSgov/bcda-ops
+          ref: 'main'
+          token: ${{ env.GITHUB_TOKEN }}
+      - name: Refresh all environments
+        run: |
+          set -euo pipefail
+          ENVS=($DEV_DB, $TEST_DB)
+          for aco in ${ENVS[@]}; do
+            echo "FOO BAR"
+            if [ $? -ne 0 ]; then
+              echo "Refresh failed. Run script locally for more details."
+            else 
+              echo "Refresh Successful."
+            fi
+          done
+          

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -53,7 +53,7 @@ jobs:
           for key in "${!environments[@]}"; do
               value="${environments[$key]}"
 
-              HOST=$(aws rds describe-db-instances --query 'DBInstances[*].[DBName,DBInstanceIdentifier,Endpoint.Address]' --output text | grep bcda-$key 2>&1)
+              HOST=$(aws rds describe-db-instances --query 'DBInstances[*].[Endpoint.Address]' --output text | grep bcda-$key 2>&1)
               if [ $? -ne 0 ]; then
                   echo "Error: failed to retrieve database host."
                   exit

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -45,8 +45,8 @@ jobs:
           set -euo pipefail
           declare -A environments
 
-          environments["dev"]=$DEV_DB
-          # environments["test"]=$TEST_DB
+          # environments["dev"]=$DEV_DB
+          environments["test"]=$TEST_DB
           # environments["opensbx"]=$TEST_DB
           # environments["prod"]=$PROD_DB
 

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -47,8 +47,8 @@ jobs:
 
           environments["dev"]=$DEV_DB
           environments["test"]=$TEST_DB
-          # environments["opensbx"]=$TEST_DB
-          # environments["prod"]=$PROD_DB
+          environments["opensbx"]=$TEST_DB
+          environments["prod"]=$PROD_DB
 
           for key in "${!environments[@]}"; do
               value="${environments[$key]}"
@@ -62,24 +62,9 @@ jobs:
               ./scripts/refresh_test_attribution.sh -c "${CONNECTION_URL}" -f > /dev/null 2>&1
 
               if [ $? -ne 0 ]; then
-                  echo "Refresh failed. Run script locally for more details."
+                  echo "Error: Refresh failed; run script locally for more details."
                   exit
               else 
-                  echo "Refresh Successful."
+                  echo "Success: refresh complete."
               fi
               done
-
-
-
-
-
-          # ENVS=($DEV_DB, $TEST_DB, $TEST_DB, $PROD_DB)
-          # for conn in ${ENVS[@]}; do
-          #   ./scripts/refresh_test_attribution.sh -c "${conn}" -f > /dev/null 2>&1
-          #   if [ $? -ne 0 ]; then
-          #     echo "Refresh failed. Run script locally for more details."
-          #   else 
-          #     echo "Refresh Successful."
-          #   fi
-          # done
-          

--- a/bcda/lambda/optout/main.go
+++ b/bcda/lambda/optout/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/CMSgov/bcda-app/conf"
 )
 
+// integration test
+
 func main() {
 	// Localstack is a local-development server that mimics AWS. The endpoint variable
 	// should only be set in local development to avoid making external calls to a real AWS account.

--- a/bcda/lambda/optout/main.go
+++ b/bcda/lambda/optout/main.go
@@ -21,8 +21,6 @@ import (
 	"github.com/CMSgov/bcda-app/conf"
 )
 
-// integration test
-
 func main() {
 	// Localstack is a local-development server that mimics AWS. The endpoint variable
 	// should only be set in local development to avoid making external calls to a real AWS account.


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8637

## 🛠 Changes

creating github action to refresh attribution data weekly.

## ℹ️ Context

Pulled the refresh out of smoke tests to reduce number of times it runs and so we can expand upon this for PY transitions or run it ad-hoc without smoke tests.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Works in all envs, verified in database and multiple successful test runs: https://github.com/CMSgov/bcda-app/actions/runs/13996655667/job/39193385477?pr=1070
