### PR TITLE
BCDA-8888: Adjust deploy workflow deps, adjust slack alerts

### DIFF
--- a/.github/workflows/build-and-package-all.yml
+++ b/.github/workflows/build-and-package-all.yml
@@ -3,6 +3,8 @@
 name: Build and Package All
 
 on:
+  push:
+    branches: [main] # autodeploy to dev
   workflow_call:
     inputs:
       release_version:
@@ -40,13 +42,13 @@ jobs:
   build_and_package_bcda:
     uses: ./.github/workflows/build-and-package-bcda.yml
     with:
-      release_version: ${{ inputs.release_version }}
+      release_version: ${{ inputs.release_version || 'main' }}
     secrets: inherit
 
   build_and_package_ssas:
     uses: CMSgov/bcda-ssas-app/.github/workflows/build-and-package.yml@main
     with:
-      ssas_release_version: ${{ inputs.ssas_release_version }}
+      ssas_release_version: ${{ inputs.ssas_release_version || 'main' }}
     secrets: inherit
   
   create_amis:
@@ -66,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/bcda-ops
-          ref: ${{ inputs.ops_release_version }}
+          ref: ${{ inputs.ops_release_version || 'main' }}
           token: ${{ env.GITHUB_TOKEN }}
       - name: Get platinum AMI ID
         run: |
@@ -95,7 +97,7 @@ jobs:
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
           packer init packer/api.json.pkr.hcl 2>&1
-          packer build -color=false -var "source_ami=${{ env.BCDA_PLATINUM_AMI }}" -var "subnet_id=${{ env.SUBNET_ID }}" -var "version=${{ inputs.release_version}}" -var "release_type=${{ env.RELEASE_TYPE }}" packer/api.json.pkr.hcl 2>&1
+          packer build -color=false -var "source_ami=${{ env.BCDA_PLATINUM_AMI }}" -var "subnet_id=${{ env.SUBNET_ID }}" -var "version=${{ inputs.release_version || 'main' }}" -var "release_type=${{ env.RELEASE_TYPE }}" packer/api.json.pkr.hcl 2>&1
       - name: Create Worker AMI
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -104,9 +106,9 @@ jobs:
           # set -euo pipefail to ensure internal packer/ansible failures get passed to the jenkins pipeline and fails that jobstep
           set -euo pipefail
           packer init packer/worker.json.pkr.hcl 2>&1
-          packer build -color=false -var "source_ami=${{ env.BCDA_PLATINUM_AMI }}" -var "subnet_id=${{ env.SUBNET_ID }}" -var "version=${{ inputs.release_version}}" -var "release_type=${{ env.RELEASE_TYPE }}" packer/worker.json.pkr.hcl 2>&1
+          packer build -color=false -var "source_ami=${{ env.BCDA_PLATINUM_AMI }}" -var "subnet_id=${{ env.SUBNET_ID }}" -var "version=${{ inputs.release_version || 'main' }}" -var "release_type=${{ env.RELEASE_TYPE }}" packer/worker.json.pkr.hcl 2>&1
       - name: Success Alert
-        if: ${{ success() }}
+        if: ${{ success() && needs.build_and_package_bcda.result == 'success' && needs.build_and_package_ssas.result == 'success' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -116,11 +118,11 @@ jobs:
             channel: "C03S23MJFJS"
             attachments:
               - color: good
-                text: "SUCCESS: Build AMIs (run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>)."
+                text: "SUCCESS: Build and Package BCDA/SSAS (run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>)."
                 mrkdown_in:
                   - text
       - name: Failure Alert
-        if: ${{ failure() }}
+        if: ${{ failure() || needs.build_and_package_bcda.result != 'success' || needs.build_and_package_ssas.result != 'success' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -130,6 +132,6 @@ jobs:
             channel: "C034CFU945C"
             attachments:
               - color: danger
-                text: "FAILURE: Build AMIs (run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>)."
+                text: "FAILURE: Build and Package BCDA/SSAS (run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>)."
                 mrkdown_in:
                   - text

--- a/.github/workflows/build-and-package-bcda.yml
+++ b/.github/workflows/build-and-package-bcda.yml
@@ -22,13 +22,13 @@ jobs:
   ci_checks:
     uses: ./.github/workflows/ci-checks.yml
     with:
-      release_version: ${{ inputs.release_version }}
+      release_version: ${{ inputs.release_version || 'main' }}
     secrets: inherit
 
   build_and_package:
     uses: ./.github/workflows/package-rpms.yml
     with:
-      release_version: ${{ inputs.release_version }}
+      release_version: ${{ inputs.release_version || 'main' }}
     secrets: inherit
   
   post_build:
@@ -37,20 +37,6 @@ jobs:
     needs: [ci_checks, build_and_package]
     runs-on: self-hosted
     steps:
-      - name: Success Alert
-        if: ${{ success() && needs.ci_checks.result == 'success' && needs.build_and_package.result == 'success' }}
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          # Sends to bcda-deploy
-          payload: |
-            channel: "C03S23MJFJS"
-            attachments:
-              - color: good
-                text: "SUCCESS: Build and Package BCDA/Worker (run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>)."
-                mrkdown_in:
-                  - text
       - name: Failure Alert
         if: ${{ failure() || needs.ci_checks.result != 'success' || needs.build_and_package.result != 'success' }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -2,8 +2,8 @@
 name: Deploy All
 
 on:
-  push:
-    branches: [main] # autodeploy to dev
+  schedule:
+    - cron: 0 8 * * 1-5 # every workday at 8am
   workflow_dispatch:
     inputs:
       release_version:
@@ -197,7 +197,7 @@ jobs:
     secrets: inherit
 
   notify_newrelic:
-    needs: [smoketests]
+    needs: [deploy]
     runs-on: self-hosted
     steps:
       - name: Set env vars from AWS params
@@ -232,10 +232,10 @@ jobs:
   slack_alerts:
     if: ${{ always() }}
     runs-on: self-hosted
-    needs: [migrate_db, deploy, smoketests, notify_newrelic]
+    needs: [migrate_db, deploy, notify_newrelic]
     steps:
       - name: Publish Build Info
-        if: ${{ success() && needs.migrate_db.result == 'success' && needs.deploy.result == 'success' && needs.smoketests.result == 'success' && needs.notify_newrelic.result == 'success' }}
+        if: ${{ success() && needs.migrate_db.result == 'success' && needs.deploy.result == 'success' && needs.notify_newrelic.result == 'success' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -261,7 +261,7 @@ jobs:
                   - pretext
                   - footer
       - name: Failure Alert
-        if: ${{ failure() || needs.migrate_db.result != 'success' || needs.deploy.result != 'success' || needs.smoketests.result != 'success' || needs.notify_newrelic.result != 'success' }}
+        if: ${{ failure() || needs.migrate_db.result != 'success' || needs.deploy.result != 'success' || needs.notify_newrelic.result != 'success' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,41 +1,9 @@
-name: 'BCDA Smoke Tests'
+name: 'Smoke Tests'
 
 on:
   pull_request:
     paths:
       - .github/workflows/smoke_tests.yml
-  workflow_call:
-    inputs:
-      release_version:
-        description: The branch of the bcda-app to use for the test execution.
-        required: true
-        type: 'string'
-        default: 'main'
-      ssas_release_version:
-        description: The branch of the ssas-app to use for the test execution.
-        required: true
-        type: 'string'
-        default: 'main'
-      env:
-        description: The environment in which to run smoke tests
-        required: true
-        type: string
-        default: 'dev'
-      test_aco:
-        description: Run the tests using the selected ACO
-        required: true
-        type: 'string'
-        default: 'dev'
-      smoke_tests:
-        description: Flag which indicates if smoke integration tests should be run
-        required: true
-        type: boolean
-        default: true
-      postman_tests:
-        description: Flag which indicates if postman integration tests should be run
-        required: true
-        type: boolean
-        default: true
   workflow_dispatch:
     inputs:
       release_version:
@@ -80,6 +48,38 @@ on:
         required: true
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      release_version:
+        description: The branch of the bcda-app to use for the test execution.
+        required: true
+        type: 'string'
+        default: 'main'
+      ssas_release_version:
+        description: The branch of the ssas-app to use for the test execution.
+        required: true
+        type: 'string'
+        default: 'main'
+      env:
+        description: The environment in which to run smoke tests
+        required: true
+        type: string
+        default: 'dev'
+      test_aco:
+        description: Run the tests using the selected ACO
+        required: true
+        type: 'string'
+        default: 'dev'
+      smoke_tests:
+        description: Flag which indicates if smoke integration tests should be run
+        required: true
+        type: boolean
+        default: true
+      postman_tests:
+        description: Flag which indicates if postman integration tests should be run
+        required: true
+        type: boolean
+        default: true
 
 
 permissions:
@@ -90,9 +90,8 @@ env:
   COMPOSE_INTERACTIVE_NO_CLI: 1
   VAULT_PW: ${{ secrets.VAULT_PW }}
 
-jobs: 
-
-  smoke_tests: 
+jobs:
+  smoke_tests:
     name: run smoke tests
     runs-on: self-hosted
     env:
@@ -161,19 +160,51 @@ jobs:
            --global-var v2Disabled=false \
            --global-var blacklistedClientId=${DENYLIST_CLIENT_ID} --global-var blacklistedClientSecret=${DENYLIST_CLIENT_SECRET} \
            --global-var maintenanceMode=""
-  
       - name: Run Smoke Tests
         if: ${{inputs.smoke_tests}} == 'true'
         run: |
           CLIENT_ID=$(echo $CLIENT_CREDENTIALS_PARAMS | jq -r .client_id)
           CLIENT_SECRET=$(echo $CLIENT_CREDENTIALS_PARAMS | jq -r .client_secret)
-          docker compose -f docker-compose.test.yml run --rm postman_test test/postman_test/BCDA_Postman_Smoke_Tests.postman_collection.json -e test/postman_test/${{ inputs.env }}.postman_environment.json --global-var clientId=$CLIENT_ID --global-var clientSecret=$CLIENT_SECRET --global-var maintenanceMode=""
-
+          docker compose -f docker-compose.test.yml run --rm postman_test test/postman_test/BCDA_Postman_Smoke_Tests.postman_collection.json \
+            -e test/postman_test/${{ inputs.env }}.postman_environment.json \
+            --global-var clientId=$CLIENT_ID \
+            --global-var clientSecret=$CLIENT_SECRET \
+            --global-var maintenanceMode=""
       - name: Run PACA Tests
         run: |
           CLIENT_ID=$(echo $PACA_CLIENT_CREDENTIALS_PARAMS | jq -r .client_id)
           CLIENT_SECRET=$(echo $PACA_CLIENT_CREDENTIALS_PARAMS | jq -r .client_secret)
-          docker compose -f docker-compose.test.yml run --rm postman_test test/postman_test/BCDA_PAC_Postman_Smoke_Tests.postman_collection.json -e test/postman_test/${{ inputs.env }}.postman_environment.json \
-          --global-var clientId=$CLIENT_ID \
-          --global-var clientSecret=$CLIENT_SECRET \
+          docker compose -f docker-compose.test.yml run --rm postman_test test/postman_test/BCDA_PAC_Postman_Smoke_Tests.postman_collection.json \
+            -e test/postman_test/${{ inputs.env }}.postman_environment.json \
+            --global-var clientId=$CLIENT_ID \
+            --global-var clientSecret=$CLIENT_SECRET \
+            --global-var maintenanceMode=""
+      - name: Success Alert
+        if: ${{ success() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to bcda-deploy
+          payload: |
+            channel: "C03S23MJFJS"
+            attachments:
+              - color: good
+                text: "SUCCESS: Smoketests in ${{ inputs.env }} for ${{ inputs.release_version }}.  Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                mrkdown_in:
+                  - text
+      - name: Failure Alert
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Sends to bcda-alerts
+          payload: |
+            channel: "C034CFU945C"
+            attachments:
+              - color: danger
+                text: "FAILURE: Smoketests in ${{ inputs.env }} for ${{ inputs.release_version }}. .  Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                mrkdown_in:
+                  - text
   

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -107,7 +107,7 @@ jobs:
             channel: "C034CFU945C"
             attachments:
               - color: danger
-                text: "FAILED: Tag and Release BCDA (${{ env.RELEASE_VERSION }}) and OPS (${{ env.OPS_RELEASE_VERSION }}).  Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                text: "FAILURE: Tag and Release BCDA (${{ env.RELEASE_VERSION }}) and OPS (${{ env.OPS_RELEASE_VERSION }}).  Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
                 mrkdown_in:
                   - text
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8888

## 🛠 Changes

Decouple smoke tests from full deploy alert.  Reduce number of slack alerts (noisy).  Add build and package on push to main.  Add cron autodeploy daily.

## ℹ️ Context

Small adjustments to the deploy process we think would be useful as we kick the tires.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Test the workflows in dev.
