### PR TITLE
BCDA-8911: fix golangci lint issues

### DIFF
--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -69,6 +69,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
       - name: Install psql
         run: |
+          sudo dnf update
           sudo dnf install postgresql16 -y
       - name: Get database credentials
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -69,7 +69,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-test-github-actions
       - name: Install psql
         run: |
-          sudo dnf update
+          sudo dnf -y update
           sudo dnf install postgresql16 -y
       - name: Get database credentials
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+        - errcheck
+        text: "conf.UnsetEnv|conf.SetEnv" # these are used and unchecked in over 280 test files
 formatters:
   enable:
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ setup-tests:
 LINT_TIMEOUT ?= 3m
 lint: setup-tests
 	docker compose -f docker-compose.test.yml run \
-	--rm tests golangci-lint run -D=errcheck,staticcheck,govet --timeout=$(LINT_TIMEOUT) --verbose
+	--rm tests golangci-lint run --timeout=$(LINT_TIMEOUT) --verbose
 	# TODO: Remove the exclusion of G301 as part of BCDA-8414
 	docker compose -f docker-compose.test.yml run --rm tests gosec -exclude=G301 ./... ./optout
 

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -103,11 +103,14 @@ func (s *RequestsTestSuite) SetupTest() {
 }
 
 func (s *RequestsTestSuite) TearDownTest() {
-	conf.SetEnv(s.T(), "BCDA_ENABLE_RUNOUT", s.runoutEnabledEnvVar)
+	err := conf.SetEnv(s.T(), "BCDA_ENABLE_RUNOUT", s.runoutEnabledEnvVar)
+	assert.Empty(s.T(), err)
 }
 
 func (s *RequestsTestSuite) TestRunoutEnabled() {
-	conf.SetEnv(s.T(), "BCDA_ENABLE_RUNOUT", "true")
+	err := conf.SetEnv(s.T(), "BCDA_ENABLE_RUNOUT", "true")
+	assert.Empty(s.T(), err)
+
 	qj := []*models.JobEnqueueArgs{}
 	tests := []struct {
 		name string
@@ -486,7 +489,9 @@ func (s *RequestsTestSuite) TestAttributionStatus() {
 }
 
 func (s *RequestsTestSuite) TestRunoutDisabled() {
-	conf.SetEnv(s.T(), "BCDA_ENABLE_RUNOUT", "false")
+	err := conf.SetEnv(s.T(), "BCDA_ENABLE_RUNOUT", "false")
+	assert.Empty(s.T(), err)
+
 	req := s.genGroupRequest("runout", middleware.RequestParameters{})
 	w := httptest.NewRecorder()
 	h := &Handler{}

--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -363,7 +363,7 @@ func isGzipEncoded(filePath string) (encoded bool, err error) {
 
 	//We can't compare to a magic number if there's less than 2 bytes returned. Also can't be ndjson
 	if bytesRead < 2 {
-		return false, errors.New("Invalid file with length 1 byte.")
+		return false, errors.New("invalid file with length 1 byte")
 	}
 
 	comparison := []byte{0x1f, 0x8b}

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -139,12 +139,13 @@ func (s *APITestSuite) TestJobStatusNotComplete() {
 
 			JobStatus(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
-			if rr.Code == http.StatusAccepted {
+			switch rr.Code {
+			case http.StatusAccepted:
 				assert.Contains(t, rr.Header().Get("X-Progress"), tt.status)
 				assert.Equal(t, "", rr.Header().Get("Expires"))
-			} else if rr.Code == http.StatusInternalServerError {
+			case http.StatusInternalServerError:
 				assert.Contains(t, rr.Body.String(), "Service encountered numerous errors")
-			} else if rr.Code == http.StatusGone {
+			case http.StatusGone:
 				assertExpiryEquals(t, j.CreatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
 			}
 		})

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -348,7 +348,7 @@ func (s *APITestSuite) TestDeleteJob() {
 			DeleteJob(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
 			if rr.Code == http.StatusGone {
-				assert.Contains(t, rr.Body.String(), "Job was not cancelled because it is not Pending or In Progress")
+				assert.Contains(t, rr.Body.String(), "job was not cancelled because it is not Pending or In Progress")
 			}
 		})
 	}

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -455,7 +455,7 @@ func (s *APITestSuite) TestDeleteJob() {
 			DeleteJob(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
 			if rr.Code == http.StatusGone {
-				assert.Contains(t, rr.Body.String(), "Job was not cancelled because it is not Pending or In Progress")
+				assert.Contains(t, rr.Body.String(), "job was not cancelled because it is not Pending or In Progress")
 			}
 		})
 	}

--- a/bcda/api/v2/api_test.go
+++ b/bcda/api/v2/api_test.go
@@ -146,12 +146,13 @@ func (s *APITestSuite) TestJobStatusNotComplete() {
 
 			JobStatus(rr, req)
 			assert.Equal(t, tt.expStatusCode, rr.Code)
-			if rr.Code == http.StatusAccepted {
+			switch rr.Code {
+			case http.StatusAccepted:
 				assert.Contains(t, rr.Header().Get("X-Progress"), tt.status)
 				assert.Equal(t, "", rr.Header().Get("Expires"))
-			} else if rr.Code == http.StatusInternalServerError {
+			case http.StatusInternalServerError:
 				assert.Contains(t, rr.Body.String(), "Service encountered numerous errors")
-			} else if rr.Code == http.StatusGone {
+			case http.StatusGone:
 				assertExpiryEquals(t, j.CreatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
 			}
 		})

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -42,33 +42,26 @@ type EnvVars struct {
 }
 
 func (s *SSASClientTestSuite) setEnvVars(r EnvVars) {
-	var err error
 	if r.SSAS_URL != "" {
 		if r.SSAS_URL == "-1" {
-			err = conf.SetEnv(s.T(), "SSAS_URL", "")
-			s.Empty(s.T(), err)
+			conf.SetEnv(s.T(), "SSAS_URL", "")
 		} else {
-			err = conf.SetEnv(s.T(), "SSAS_URL", r.SSAS_URL)
-			s.Empty(s.T(), err)
+			conf.SetEnv(s.T(), "SSAS_URL", r.SSAS_URL)
 		}
 	}
 	if r.SSAS_PUBLIC_URL != "" {
 		if r.SSAS_PUBLIC_URL == "-1" {
-			err = conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", "")
-			s.Empty(s.T(), err)
+			conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", "")
 		} else {
-			err = conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", r.SSAS_PUBLIC_URL)
-			s.Empty(s.T(), err)
+			conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", r.SSAS_PUBLIC_URL)
 		}
 	}
 
 	if r.BCDA_SSAS_CLIENT_ID != "" {
 		if r.BCDA_SSAS_CLIENT_ID == "-1" {
-			err = conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", "")
-			s.Empty(s.T(), err)
+			conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", "")
 		} else {
-			err = conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", r.BCDA_SSAS_CLIENT_ID)
-			s.Empty(s.T(), err)
+			conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", r.BCDA_SSAS_CLIENT_ID)
 		}
 	}
 }

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -42,27 +42,33 @@ type EnvVars struct {
 }
 
 func (s *SSASClientTestSuite) setEnvVars(r EnvVars) {
-
+	var err error
 	if r.SSAS_URL != "" {
 		if r.SSAS_URL == "-1" {
-			conf.SetEnv(s.T(), "SSAS_URL", "")
+			err = conf.SetEnv(s.T(), "SSAS_URL", "")
+			s.Empty(s.T(), err)
 		} else {
-			conf.SetEnv(s.T(), "SSAS_URL", r.SSAS_URL)
+			err = conf.SetEnv(s.T(), "SSAS_URL", r.SSAS_URL)
+			s.Empty(s.T(), err)
 		}
 	}
 	if r.SSAS_PUBLIC_URL != "" {
 		if r.SSAS_PUBLIC_URL == "-1" {
-			conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", "")
+			err = conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", "")
+			s.Empty(s.T(), err)
 		} else {
-			conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", r.SSAS_PUBLIC_URL)
+			err = conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", r.SSAS_PUBLIC_URL)
+			s.Empty(s.T(), err)
 		}
 	}
 
 	if r.BCDA_SSAS_CLIENT_ID != "" {
 		if r.BCDA_SSAS_CLIENT_ID == "-1" {
-			conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", "")
+			err = conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", "")
+			s.Empty(s.T(), err)
 		} else {
-			conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", r.BCDA_SSAS_CLIENT_ID)
+			err = conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", r.BCDA_SSAS_CLIENT_ID)
+			s.Empty(s.T(), err)
 		}
 	}
 }

--- a/bcda/aws/parameters.go
+++ b/bcda/aws/parameters.go
@@ -22,13 +22,13 @@ func GetParameter(s *session.Session, keyname string) (string, error) {
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("Error retrieving parameter %s from parameter store: %w", keyname, err)
+		return "", fmt.Errorf("error retrieving parameter %s from parameter store: %w", keyname, err)
 	}
 
 	val := *result.Parameter.Value
 
 	if val == "" {
-		return "", fmt.Errorf("No parameter store value found for %s", keyname)
+		return "", fmt.Errorf("no parameter store value found for %s", keyname)
 	}
 
 	return val, nil
@@ -58,7 +58,7 @@ func GetParameters(s *session.Session, keynames []*string) (map[string]string, e
 	}
 
 	// Build the parameter map that we're going to return
-	var paramMap map[string]string = make(map[string]string)
+	paramMap := make(map[string]string)
 
 	for _, item := range params.Parameters {
 		paramMap[*item.Name] = *item.Value

--- a/bcda/aws/parameters_test.go
+++ b/bcda/aws/parameters_test.go
@@ -40,7 +40,7 @@ func TestGetParameter(t *testing.T) {
 			// GetParameter fails
 			keyname:       key1,
 			expectedValue: "",
-			expectedErr:   errors.New("Error retrieving parameter key1 from parameter store: error"),
+			expectedErr:   errors.New("error retrieving parameter key1 from parameter store: error"),
 			ssmNew:        func(p client.ConfigProvider, cfgs ...*aws.Config) *ssm.SSM { return nil },
 			ssmsvcGetParameter: func(c *ssm.SSM, input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 				return nil, errors.New("error")
@@ -50,7 +50,7 @@ func TestGetParameter(t *testing.T) {
 			// Empty parameter
 			keyname:       key1,
 			expectedValue: "",
-			expectedErr:   fmt.Errorf("No parameter store value found for %s", key1),
+			expectedErr:   fmt.Errorf("no parameter store value found for %s", key1),
 			ssmNew:        func(p client.ConfigProvider, cfgs ...*aws.Config) *ssm.SSM { return nil },
 			ssmsvcGetParameter: func(c *ssm.SSM, input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 				val := ""

--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -344,9 +344,8 @@ func setUpApp() *cli.App {
 				}
 				if failure > 0 || skipped > 0 {
 					log.API.Errorf("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped, err)
-					err = errors.New("Files skipped or failed import. See logs for more details.")
+					err = errors.New("files skipped or failed import. See logs for more details")
 					return err
-
 				}
 				log.API.Infof("Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)
 				fmt.Fprintf(app.Writer, "Completed CCLF import.  Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)

--- a/bcda/cclf/cclf.go
+++ b/bcda/cclf/cclf.go
@@ -207,7 +207,7 @@ func (importer CclfImporter) importCCLF8(ctx context.Context, zipMetadata *cclfZ
 	}
 
 	if recordCount > validator.totalRecordCount {
-		err := fmt.Errorf("Unexpected number of records imported for file %s (expected: %d, actual: %d)", fileMetadata.name, validator.totalRecordCount, recordCount)
+		err := fmt.Errorf("unexpected number of records imported for file %s (expected: %d, actual: %d)", fileMetadata.name, validator.totalRecordCount, recordCount)
 		importer.Logger.Error(err)
 		return err
 	}

--- a/bcda/cclf/cclf_test.go
+++ b/bcda/cclf/cclf_test.go
@@ -74,7 +74,7 @@ func (s *CCLFTestSuite) SetupSuite() {
 		s.FailNow(err.Error())
 	}
 	s.pendingDeletionDir = dir
-	testUtils.SetPendingDeletionDir(s.Suite, dir)
+	testUtils.SetPendingDeletionDir(&s.Suite, dir)
 
 	s.db = database.Connection
 }
@@ -199,7 +199,7 @@ func (s *CCLFTestSuite) TestImportCCLF8() {
 	validator.totalRecordCount = 2
 
 	err = s.importer.importCCLF8(context.Background(), metadata, validator)
-	s.ErrorContains(err, "Unexpected number of records imported for file T.BCD.A0001.ZC8Y18.D181120.T1000009 (expected: 2, actual: 7)")
+	s.ErrorContains(err, "unexpected number of records imported for file T.BCD.A0001.ZC8Y18.D181120.T1000009 (expected: 2, actual: 7)")
 
 	// successful
 	validator.maxRecordLength = 549

--- a/bcda/cclf/csv.go
+++ b/bcda/cclf/csv.go
@@ -165,7 +165,7 @@ func (importer CSVImporter) ProcessCSV(csv csvFile) error {
 		return fmt.Errorf("unexpected number of records imported (expected: %d, actual: %d)", count, records)
 	}
 	if err != nil {
-		return errors.New("failed to write attribution beneficiaries to database using CopyFrom.")
+		return errors.New("failed to write attribution beneficiaries to database using CopyFrom")
 	}
 
 	err = rtx.UpdateCCLFFileImportStatus(ctx, csv.metadata.fileID, constants.ImportComplete)

--- a/bcda/cclf/csv_test.go
+++ b/bcda/cclf/csv_test.go
@@ -51,7 +51,7 @@ func (s *CSVTestSuite) SetupTest() {
 		s.FailNow(err.Error())
 	}
 	s.pendingDeletionDir = dir
-	testUtils.SetPendingDeletionDir(s.Suite, dir)
+	testUtils.SetPendingDeletionDir(&s.Suite, dir)
 	db, _ := databasetest.CreateDatabase(s.T(), "../../db/migrations/bcda/", true)
 	tf, err := testfixtures.New(
 		testfixtures.Database(db),

--- a/bcda/cclf/local_fileprocessor_test.go
+++ b/bcda/cclf/local_fileprocessor_test.go
@@ -77,7 +77,7 @@ func setupSuiteHelper(s *LocalFileProcessorTestSuite) {
 			FileArchiveThresholdHr: hours,
 		},
 	}
-	testUtils.SetPendingDeletionDir(s.Suite, dir)
+	testUtils.SetPendingDeletionDir(&s.Suite, dir)
 }
 
 func (s *LocalFileProcessorTestSuite) TearDownTest() {

--- a/bcda/cclf/parser.go
+++ b/bcda/cclf/parser.go
@@ -97,17 +97,18 @@ func validateCSVMetadata(subMatches []string) (csvFileMetadata, error) {
 	var err error
 
 	var mapper csvMetadataFileNameMap
-	if subMatches[2] == "PCPB" { // MDTCoC CSV File
+	switch subMatches[2] {
+	case "PCPB":
 		mapper = csvMetadataFileNameMap{
 			PerformanceYear: 4,
 			DateTime:        6,
 		}
-	} else if subMatches[2] == "BCD" { // CDAC CSV File
+	case "BCD":
 		mapper = csvMetadataFileNameMap{
 			PerformanceYear: 6,
 			DateTime:        7,
 		}
-	} else {
+	default:
 		err = errors.Wrapf(err, "failed to parse Model of csv file")
 		log.API.Error(err)
 		return csvFileMetadata{}, err

--- a/bcda/cclf/s3_fileprocessor.go
+++ b/bcda/cclf/s3_fileprocessor.go
@@ -77,20 +77,20 @@ func (processor *S3FileProcessor) LoadCclfFiles(path string) (cclfMap map[string
 
 			if metadata.cclfNum == 0 {
 				if cclf0Metadata != nil {
-					readError = fmt.Errorf("Multiple CCLF0 files found in zip (%s/%s)", bucket, *obj.Key)
+					readError = fmt.Errorf("multiple CCLF0 files found in zip (%s/%s)", bucket, *obj.Key)
 					break
 				}
 				cclf0Metadata = &metadata
 				cclf0File = f
 			} else if metadata.cclfNum == 8 {
 				if cclf8Metadata != nil {
-					readError = fmt.Errorf("Multiple CCLF8 files found in zip (%s/%s)", bucket, *obj.Key)
+					readError = fmt.Errorf("multiple CCLF8 files found in zip (%s/%s)", bucket, *obj.Key)
 					break
 				}
 				cclf8Metadata = &metadata
 				cclf8File = f
 			} else {
-				readError = fmt.Errorf("Unexpected CCLF num %d processed (%s/%s)", metadata.cclfNum, bucket, *obj.Key)
+				readError = fmt.Errorf("unexpected CCLF num %d processed (%s/%s)", metadata.cclfNum, bucket, *obj.Key)
 				break
 			}
 		}

--- a/bcda/client/mock_bluebutton.go
+++ b/bcda/client/mock_bluebutton.go
@@ -62,10 +62,10 @@ func (bbc *MockBlueButtonClient) GetData(endpoint, patientID string) (string, er
 			return "", err
 		}
 	}
-	cleanData := strings.Replace(string(fData), "20000000000001", patientID, -1)
+	cleanData := strings.ReplaceAll(string(fData), "20000000000001", patientID)
 	if bbc.MBI != nil {
 		// no longer hashed, but this is only a test file with synthetic test data
-		cleanData = strings.Replace(cleanData, "-1Q03Z002871", *bbc.MBI, -1)
+		cleanData = strings.ReplaceAll(cleanData, "-1Q03Z002871", *bbc.MBI)
 	}
 	return cleanData, err
 }

--- a/bcda/lambda/cclf/main.go
+++ b/bcda/lambda/cclf/main.go
@@ -156,7 +156,7 @@ func handleCclfImport(s3AssumeRoleArn, s3ImportPath string) (string, error) {
 		result := fmt.Sprintf("Successfully imported %v files.  Failed to import %v files.  Skipped %v files.  See logs for more details.", success, failure, skipped)
 		logger.Error(result)
 
-		err = errors.New("Files skipped or failed import. See logs for more details.")
+		err = errors.New("files skipped or failed import. See logs for more details")
 		return result, err
 
 	}

--- a/bcda/lambda/cclf/main_test.go
+++ b/bcda/lambda/cclf/main_test.go
@@ -49,7 +49,7 @@ func (s *AttributionImportMainSuite) TestImportCCLFDirectory() {
 
 	tests := []test{
 		{path: "../../../shared_files/cclf/archives/valid/", filename: "cclf/archives/valid/T.BCD.A0001.ZCY18.D181120.T1000000", expectedLogs: []string{"Successfully imported 2 files.", "Failed to import 0 files.", "Skipped 0 files."}},
-		{path: "../../../shared_files/cclf/archives/invalid_bcd/", filename: "cclf/archives/invalid_bcd/P.BCD.A0009.ZCY18.D181120.T0001000", err: errors.New("Files skipped or failed import. See logs for more details."), expectedLogs: []string{}},
+		{path: "../../../shared_files/cclf/archives/invalid_bcd/", filename: "cclf/archives/invalid_bcd/P.BCD.A0009.ZCY18.D181120.T0001000", err: errors.New("files skipped or failed import. See logs for more details"), expectedLogs: []string{}},
 		{path: "../../../shared_files/cclf/archives/skip/", filename: "cclf/archives/skip/T.BCD.ACOB.ZC0Y18.D181120.T0001000", expectedLogs: []string{"Successfully imported 0 files.", "Failed to import 0 files.", "Skipped 0 files."}},
 	}
 
@@ -78,5 +78,5 @@ func (s *AttributionImportMainSuite) TestImportCCLFDirectory() {
 func (s *AttributionImportMainSuite) TestHandlerMissingS3AssumeRoleArn() {
 	assert := assert.New(s.T())
 	_, err := attributionImportHandler(context.Background(), testUtils.GetSQSEvent(s.T(), "doesn't-matter", "fake_filename"))
-	assert.Contains(err.Error(), "Error retrieving parameter /cclf-import/bcda/local/bfd-bucket-role-arn from parameter store: ParameterNotFound: Parameter /cclf-import/bcda/local/bfd-bucket-role-arn not found.")
+	assert.Contains(err.Error(), "error retrieving parameter /cclf-import/bcda/local/bfd-bucket-role-arn from parameter store: ParameterNotFound: Parameter /cclf-import/bcda/local/bfd-bucket-role-arn not found.")
 }

--- a/bcda/lambda/optout/main_test.go
+++ b/bcda/lambda/optout/main_test.go
@@ -107,5 +107,5 @@ func (s *OptOutImportMainSuite) TestImportSuppressionDirectory_Failed() {
 func (s *OptOutImportMainSuite) TestHandlerMissingS3AssumeRoleArn() {
 	assert := assert.New(s.T())
 	_, err := optOutImportHandler(context.Background(), testUtils.GetSQSEvent(s.T(), "doesn't-matter", "fake_filename"))
-	assert.Contains(err.Error(), "Error retrieving parameter /opt-out-import/bcda/local/bfd-bucket-role-arn from parameter store: ParameterNotFound: Parameter /opt-out-import/bcda/local/bfd-bucket-role-arn not found.")
+	assert.Contains(err.Error(), "error retrieving parameter /opt-out-import/bcda/local/bfd-bucket-role-arn from parameter store: ParameterNotFound: Parameter /opt-out-import/bcda/local/bfd-bucket-role-arn not found.")
 }

--- a/bcda/models/postgres/repository.go
+++ b/bcda/models/postgres/repository.go
@@ -608,7 +608,7 @@ func (r *Repository) GetAlrMBIs(ctx context.Context, cmsID string) (*models.AlrM
 	err := row.Scan(&id, &aco, &timestamp)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("No ALR meta data found for %s", cmsID)
+			return nil, fmt.Errorf("no ALR meta data found for %s", cmsID)
 		}
 		return nil, err
 	}
@@ -622,7 +622,7 @@ func (r *Repository) GetAlrMBIs(ctx context.Context, cmsID string) (*models.AlrM
 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("No ALR MBIs found for %s with id %d", cmsID, id)
+			return nil, fmt.Errorf("no ALR MBIs found for %s with id %d", cmsID, id)
 		}
 		return nil, err
 	}

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -981,7 +981,7 @@ func (r *RepositoryTestSuite) TestGetAlrMBIs() {
 	r.NotEmpty(alrMBI.Metakey)
 
 	alrMBI, err = r.repository.GetAlrMBIs(context.Background(), "A9996")
-	r.Contains(err.Error(), "No ALR meta data found for A9996")
+	r.Contains(err.Error(), "no ALR meta data found for A9996")
 	r.Nil(alrMBI)
 }
 

--- a/bcda/responseutils/v2/writer_test.go
+++ b/bcda/responseutils/v2/writer_test.go
@@ -108,7 +108,7 @@ func (s *ResponseUtilsWriterTestSuite) TestWriteError() {
 func (s *ResponseUtilsWriterTestSuite) TestCreateCapabilityStatement() {
 	relversion := "r1"
 	baseurl := "bcda.cms.gov"
-	var cs *fhirmodelCS.CapabilityStatement = CreateCapabilityStatement(time.Now(), relversion, baseurl)
+	cs := CreateCapabilityStatement(time.Now(), relversion, baseurl)
 	assert.Equal(s.T(), relversion, cs.Software.Version.Value)
 	assert.Equal(s.T(), "Beneficiary Claims Data API", cs.Software.Name.Value)
 	assert.Equal(s.T(), baseurl, cs.Implementation.Url.Value)
@@ -178,7 +178,7 @@ func (s *ResponseUtilsWriterTestSuite) TestWriteJobsBundle() {
 }
 
 func (s *ResponseUtilsWriterTestSuite) TestCreateJobsBundle() {
-	var jb *fhirmodelCR.Bundle = CreateJobsBundle(nil, constants.TestAPIUrl)
+	jb := CreateJobsBundle(nil, constants.TestAPIUrl)
 
 	assert.Equal(s.T(), uint32(0), jb.Total.Value)
 	assert.Equal(s.T(), fhircodes.BundleTypeCode_SEARCHSET, jb.Type.Value)

--- a/bcda/responseutils/writer.go
+++ b/bcda/responseutils/writer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/conf"
 	"github.com/CMSgov/bcda-app/log"
-	logAPI "github.com/CMSgov/bcda-app/log"
 	"github.com/ccoveille/go-safecast"
 
 	"github.com/google/fhir/go/fhirversion"
@@ -311,7 +310,7 @@ func WriteBundleResponse(bundle *fhirmodels.Bundle, w http.ResponseWriter) {
 	}
 	resourceJSON, err := marshaller.Marshal(resource)
 	if err != nil {
-		logAPI.API.Error(err)
+		log.API.Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -320,7 +319,7 @@ func WriteBundleResponse(bundle *fhirmodels.Bundle, w http.ResponseWriter) {
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(resourceJSON)
 	if err != nil {
-		logAPI.API.Error(err)
+		log.API.Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/bcda/responseutils/writer_test.go
+++ b/bcda/responseutils/writer_test.go
@@ -107,7 +107,7 @@ func (s *ResponseUtilsWriterTestSuite) TestWriteError() {
 func (s *ResponseUtilsWriterTestSuite) TestCreateCapabilityStatement() {
 	relversion := "r1"
 	baseurl := "bcda.cms.gov"
-	var cs *fhirmodels.CapabilityStatement = CreateCapabilityStatement(time.Now(), relversion, baseurl)
+	cs := CreateCapabilityStatement(time.Now(), relversion, baseurl)
 	assert.Equal(s.T(), relversion, cs.Software.Version.Value)
 	assert.Equal(s.T(), "Beneficiary Claims Data API", cs.Software.Name.Value)
 	assert.Equal(s.T(), baseurl, cs.Implementation.Url.Value)
@@ -176,7 +176,7 @@ func (s *ResponseUtilsWriterTestSuite) TestWriteJobsBundle() {
 }
 
 func (s *ResponseUtilsWriterTestSuite) TestCreateJobsBundle() {
-	var jb *fhirmodels.Bundle = CreateJobsBundle(nil, constants.TestAPIUrl)
+	jb := CreateJobsBundle(nil, constants.TestAPIUrl)
 
 	assert.Equal(s.T(), uint32(0), jb.Total.Value)
 	assert.Equal(s.T(), fhircodes.BundleTypeCode_SEARCHSET, jb.Type.Value)

--- a/bcda/service/config.go
+++ b/bcda/service/config.go
@@ -121,7 +121,7 @@ func (cfg *Config) ComputeFields() (err error) {
 	}
 
 	if cfg.AlrJobSize == 0 {
-		return errors.New("invalid ALR job size supplied. Must be greater than zero.")
+		return errors.New("invalid ALR job size supplied. Must be greater than zero")
 	}
 
 	return nil

--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -170,7 +170,7 @@ func (s *service) GetQueJobs(ctx context.Context, conditions RequestConditions) 
 		}
 		queJobs = append(queJobs, jobs...)
 	} else {
-		return nil, fmt.Errorf("Unsupported RequestType %d", conditions.ReqType)
+		return nil, fmt.Errorf("unsupported RequestType %d", conditions.ReqType)
 	}
 
 	// add existiing beneficiaries to the job queue
@@ -369,7 +369,7 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 		}
 
 		if len(benes) == 0 {
-			return nil, nil, fmt.Errorf("Found 0 new or existing beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
+			return nil, nil, fmt.Errorf("found 0 new or existing beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
 				conditions.CMSID, cclfFileNew.ID)
 		}
 
@@ -407,7 +407,7 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 			return nil, nil, err
 		}
 		if len(newBeneficiaries) == 0 {
-			return nil, nil, fmt.Errorf("Found 0 new beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
+			return nil, nil, fmt.Errorf("found 0 new beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
 				conditions.CMSID, cclfFileNew.ID)
 		}
 		return newBeneficiaries, nil, nil
@@ -425,7 +425,7 @@ func (s *service) getNewAndExistingBeneficiaries(ctx context.Context, conditions
 		return nil, nil, err
 	}
 	if len(benes) == 0 {
-		return nil, nil, fmt.Errorf("Found 0 new or existing beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
+		return nil, nil, fmt.Errorf("found 0 new or existing beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
 			conditions.CMSID, cclfFileNew.ID)
 	}
 
@@ -476,7 +476,7 @@ func (s *service) getBeneficiaries(ctx context.Context, conditions RequestCondit
 		return nil, err
 	}
 	if len(benes) == 0 {
-		return nil, fmt.Errorf("Found 0 beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
+		return nil, fmt.Errorf("found 0 beneficiaries from CCLF8 file for cmsID %s cclfFiledID %d",
 			conditions.CMSID, cclfFile.ID)
 	}
 
@@ -674,8 +674,8 @@ func (e CCLFNotFoundError) Error() string {
 }
 
 var (
-	ErrJobNotCancelled   = goerrors.New("Job was not cancelled due to internal server error.")
-	ErrJobNotCancellable = goerrors.New("Job was not cancelled because it is not Pending or In Progress")
+	ErrJobNotCancelled   = goerrors.New("job was not cancelled due to internal server error")
+	ErrJobNotCancellable = goerrors.New("job was not cancelled because it is not Pending or In Progress")
 )
 
 type CtxACOCfgType string

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -280,14 +280,14 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries_Integration() {
 			getCCLFFile(4, false, false),
 			nil,
 			nil,
-			fmt.Errorf("Found 0 new beneficiaries from CCLF8 file for cmsID"),
+			fmt.Errorf("found 0 new beneficiaries from CCLF8 file for cmsID"),
 		},
 		{
 			"NoBenesFoundNewAndOld",
 			getCCLFFile(5, false, false),
 			getCCLFFile(6, false, false),
 			nil,
-			fmt.Errorf("Found 0 new or existing beneficiaries from CCLF8 file for cmsID"),
+			fmt.Errorf("found 0 new or existing beneficiaries from CCLF8 file for cmsID"),
 		},
 		{
 			"NoMBIsForOldCCLF",
@@ -494,7 +494,7 @@ func (s *ServiceTestSuite) TestGetNewAndExistingBeneficiaries_RecentSinceParamet
 
 			// Assert
 			if !tt.populateBenes {
-				assert.ErrorContains(err, "Found 0 new or existing beneficiaries from CCLF8 file for cmsID A0005")
+				assert.ErrorContains(err, "found 0 new or existing beneficiaries from CCLF8 file for cmsID A0005")
 			} else {
 				assert.NoError(err)
 				assert.Len(oldBenes, len(tt.expectedOldMBIIndexes))
@@ -544,7 +544,7 @@ func (s *ServiceTestSuite) TestGetBeneficiaries_Integration() {
 			"NoBenesFound",
 			models.FileTypeDefault,
 			getCCLFFile(2, false, false),
-			fmt.Errorf("Found 0 beneficiaries from CCLF8 file for cmsID"),
+			fmt.Errorf("found 0 beneficiaries from CCLF8 file for cmsID"),
 		},
 		{
 			"BenesReturnedRunout",
@@ -1462,7 +1462,7 @@ func (s *ServiceTestSuiteWithDatabase) TestGetNewAndExistingBeneficiaries_Recent
 
 			// Assert
 			if !tt.populateBenes {
-				assert.ErrorContains(err, "Found 0 new or existing beneficiaries from CCLF8 file for cmsID A0005")
+				assert.ErrorContains(err, "found 0 new or existing beneficiaries from CCLF8 file for cmsID A0005")
 			} else {
 				assert.NoError(err)
 				assert.Len(oldBenes, len(tt.expectedOldMBIIndexes))

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -39,7 +39,7 @@ func (s *SuppressionTestSuite) SetupSuite() {
 		log.Fatal(err)
 	}
 	s.pendingDeletionDir = dir
-	testUtils.SetPendingDeletionDir(s.Suite, dir)
+	testUtils.SetPendingDeletionDir(&s.Suite, dir)
 
 }
 

--- a/bcda/suppression/suppression_test.go
+++ b/bcda/suppression/suppression_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 
@@ -76,7 +75,7 @@ func TestSuppressionTestSuite(t *testing.T) {
 func (s *SuppressionTestSuite) TestImportSuppression() {
 	assert := assert.New(s.T())
 
-	hook := test.NewLocal(logrus.StandardLogger())
+	hook := test.NewLocal(log.StandardLogger())
 	// 181120 file
 	fileTime, _ := time.Parse(time.RFC3339, "2018-11-20T10:00:00Z")
 	metadata := &optout.OptOutFilenameMetadata{

--- a/bcda/testUtils/utils.go
+++ b/bcda/testUtils/utils.go
@@ -99,7 +99,7 @@ func SetAndRestoreEnvKey(key, value string) func() {
 	}
 }
 
-func MakeDirToDelete(s suite.Suite, filePath string) {
+func MakeDirToDelete(s *suite.Suite, filePath string) {
 	assert := assert.New(s.T())
 	_, err := os.Create(filepath.Clean(filepath.Join(filePath, "deleteMe1.txt")))
 	assert.Nil(err)
@@ -113,7 +113,7 @@ func MakeDirToDelete(s suite.Suite, filePath string) {
 
 // SetPendingDeletionDir sets the PENDING_DELETION_DIR to the supplied "path" and ensures
 // that the directory is created
-func SetPendingDeletionDir(s suite.Suite, path string) {
+func SetPendingDeletionDir(s *suite.Suite, path string) {
 	err := conf.SetEnv(s.T(), "PENDING_DELETION_DIR", path)
 	if err != nil {
 		s.FailNow("failed to set the PENDING_DELETION_DIR env variable,", err)

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -133,7 +133,7 @@ func FileServer(r chi.Router, path string, root http.FileSystem) {
 	fs := http.StripPrefix(path, http.FileServer(root))
 
 	if path != "/" && path[len(path)-1] != '/' {
-		r.Get(path, http.RedirectHandler(path+"/", 301).ServeHTTP)
+		r.Get(path, http.RedirectHandler(path+"/", http.StatusMovedPermanently).ServeHTTP)
 		path += "/"
 	}
 	path += "*"

--- a/bcdaworker/cleanup/cleanup_test.go
+++ b/bcdaworker/cleanup/cleanup_test.go
@@ -94,8 +94,10 @@ func (s *CleanupTestSuite) TestArchiveExpiring() {
 	}
 	postgrestest.CreateJobs(s.T(), s.db, &j)
 
-	conf.SetEnv(s.T(), "FHIR_PAYLOAD_DIR", "../bcdaworker/data/test")
-	conf.SetEnv(s.T(), "FHIR_ARCHIVE_DIR", constants.TestArchivePath)
+	err := conf.SetEnv(s.T(), "FHIR_PAYLOAD_DIR", "../bcdaworker/data/test")
+	assert.Empty(s.T(), err)
+	err = conf.SetEnv(s.T(), "FHIR_ARCHIVE_DIR", constants.TestArchivePath)
+	assert.Empty(s.T(), err)
 
 	path := fmt.Sprintf("%s/%d/", conf.GetEnv("FHIR_PAYLOAD_DIR"), j.ID)
 	newpath := conf.GetEnv("FHIR_ARCHIVE_DIR")

--- a/bcdaworker/cleanup/cleanup_test.go
+++ b/bcdaworker/cleanup/cleanup_test.go
@@ -37,7 +37,7 @@ func (s *CleanupTestSuite) SetupSuite() {
 		log.Fatal(err)
 	}
 	s.pendingDeletionDir = dir
-	testUtils.SetPendingDeletionDir(s.Suite, dir)
+	testUtils.SetPendingDeletionDir(&s.Suite, dir)
 
 	s.db = database.Connection
 
@@ -94,10 +94,8 @@ func (s *CleanupTestSuite) TestArchiveExpiring() {
 	}
 	postgrestest.CreateJobs(s.T(), s.db, &j)
 
-	err := conf.SetEnv(s.T(), "FHIR_PAYLOAD_DIR", "../bcdaworker/data/test")
-	assert.Empty(s.T(), err)
-	err = conf.SetEnv(s.T(), "FHIR_ARCHIVE_DIR", constants.TestArchivePath)
-	assert.Empty(s.T(), err)
+	conf.SetEnv(s.T(), "FHIR_PAYLOAD_DIR", "../bcdaworker/data/test")
+	conf.SetEnv(s.T(), "FHIR_ARCHIVE_DIR", constants.TestArchivePath)
 
 	path := fmt.Sprintf("%s/%d/", conf.GetEnv("FHIR_PAYLOAD_DIR"), j.ID)
 	newpath := conf.GetEnv("FHIR_ARCHIVE_DIR")

--- a/bcdaworker/queueing/alr.go
+++ b/bcdaworker/queueing/alr.go
@@ -98,7 +98,7 @@ func (q *MasterQueue) startAlrJob(queJob *que.Job) error {
 		return nil
 	}
 	if !errors.Is(err, repository.ErrJobKeyNotFound) {
-		return fmt.Errorf("Failed to search for job keys in database: %w", err)
+		return fmt.Errorf("failed to search for job keys in database: %w", err)
 	}
 	// End of validation
 

--- a/bcdaworker/worker/alr.go
+++ b/bcdaworker/worker/alr.go
@@ -112,7 +112,7 @@ func goWriterV1(ctx context.Context, a *AlrWorker, c chan *alr.AlrFhirBulk, file
 		jobKeys = append(jobKeys, jk)
 	}
 
-	if err := a.Repository.CreateJobKeys(ctx, jobKeys); err != nil {
+	if err := a.CreateJobKeys(ctx, jobKeys); err != nil {
 		result <- fmt.Errorf(constants.JobKeyCreateErr, err)
 		return
 	}
@@ -174,7 +174,7 @@ func goWriterV2(ctx context.Context, a *AlrWorker, c chan *alr.AlrFhirBulk, file
 		jobKeys = append(jobKeys, jk)
 	}
 
-	if err := a.Repository.CreateJobKeys(ctx, jobKeys); err != nil {
+	if err := a.CreateJobKeys(ctx, jobKeys); err != nil {
 		result <- fmt.Errorf(constants.JobKeyCreateErr, err)
 		return
 	}
@@ -211,7 +211,7 @@ func (a *AlrWorker) ProcessAlrJob(
 	// there is no data associated with this job.
 	if len(alrModels) == 0 {
 		jk := models.JobKey{JobID: id, QueJobID: &queJobID, FileName: models.BlankFileName, ResourceType: "ALR"}
-		if err := a.Repository.CreateJobKey(ctx, jk); err != nil {
+		if err := a.CreateJobKey(ctx, jk); err != nil {
 			return fmt.Errorf(constants.JobKeyCreateErr, err)
 		}
 	}

--- a/conf/config.go
+++ b/conf/config.go
@@ -282,7 +282,7 @@ func Checkout(v interface{}) error {
 		}
 	}
 
-	return errors.New("The data type provided to Checkout func is not supported.")
+	return errors.New("the data type provided to Checkout func is not supported")
 
 }
 

--- a/test/datagenerator/1800medicare.go
+++ b/test/datagenerator/1800medicare.go
@@ -42,7 +42,8 @@ func main() {
 		panic(err)
 	}
 
-	_, err = outf.WriteString(fmt.Sprintf("HDR_BENEDATASHR%s\n", now.Format("20060102")))
+	str := fmt.Sprintf("HDR_BENEDATASHR%s\n", now.Format("20060102"))
+	_, err = outf.WriteString(str)
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +69,8 @@ func main() {
 			recs := records(p)
 			for _, r := range recs {
 				for _, f := range []field{r.hicn, r.blk, r.firstName, r.middleName, r.lastName, r.dob, r.addr1, r.addr2, r.addr3, r.city, r.state, r.zip5, r.zip4, r.gender, r.encDate, r.effDate, r.srcCode, r.mechCode, r.prefInd, r.saEffDate, r.saSrcCode, r.saMechCode, r.saPrefInd, r.acoID, r.acoName} {
-					_, err = outf.WriteString(fmt.Sprintf("%-"+fmt.Sprint(f.l)+"s", f.v))
+					str = fmt.Sprintf("%-"+fmt.Sprint(f.l)+"s", f.v)
+					_, err = outf.WriteString(str)
 					if err != nil {
 						panic(err)
 					}
@@ -81,7 +83,8 @@ func main() {
 			recCount += len(recs)
 		}
 
-		_, err = outf.WriteString(fmt.Sprintf("TRL_BENEDATASHR%s%-10d", now.Format("20060102"), recCount))
+		str = fmt.Sprintf("TRL_BENEDATASHR%s%-10d", now.Format("20060102"), recCount)
+		_, err = outf.WriteString(str)
 		if err != nil {
 			panic(err)
 		}

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -200,11 +200,11 @@ func validateMetrics(metrics vegeta.Metrics) error {
 	}
 
 	if len(metrics.Errors) > 0 {
-		return fmt.Errorf("Encountered %v errors", metrics.Errors)
+		return fmt.Errorf("encountered %v errors", metrics.Errors)
 	}
 
 	if metrics.Success < 1.0 {
-		return fmt.Errorf("Expected success rate of 1.0, received %f",
+		return fmt.Errorf("expected success rate of 1.0, received %f",
 			metrics.Success)
 	}
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8911

## 🛠 Changes

Golangci-lint fixes, adjustments

## ℹ️ Context

Our runners recently update golangci-lint to v2.  We temporarily disabled a few linters.  This PR fixes all of those.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.