### PR TITLE
BCDA-8897: Make small updates to readme and build to address obstacles to local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ load-fixtures: reset-db
 
 	# Ensure components are started as expected
 	docker compose up -d api worker ssas
-	docker run --rm --network bcda-app-net willwill/wait-for-it api:3000 -t 100
-	docker run --rm --network bcda-app-net willwill/wait-for-it ssas:3003 -t 100
+	docker run --rm --network bcda-app-net willwill/wait-for-it api:3000 -t 300
+	docker run --rm --network bcda-app-net willwill/wait-for-it ssas:3003 -t 300
 
 	# Additional fixtures for postman+ssas
 	docker compose run db psql -v ON_ERROR_STOP=1 "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -f /var/db/postman_fixtures.sql

--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ Before we can run the application locally, we need to build the docker images an
 make docker-bootstrap
 ```
 
-\*Known Issue: If the swagger/documentation container fails to build or start, edit the makefile locally to remove `documentation` from the `docker-bootstrap` command line.
-
 After that has completed successfully, we can start the containers:
 
 ```sh


### PR DESCRIPTION
## 🎫 Ticket

Ticket to set up local environment:
https://jira.cms.gov/browse/BCDA-8897



## 🛠 Changes

- Removed an outdated reference in the readme
- Increased time to wait on the api booting up before throwing an error when loading fixtures

## ℹ️ Context

These changes are made in response to some small obstacles I faced while setting up the api locally.
The readme referenced a docker service that has been removed.
The api service time-to-wait had to be increased since `load-fixtures` would fail before completing.

## 🧪 Validation

I reset my local environment and ran through the setup steps again, including running `load-fixtures` and encountered no errors.
