### PR TITLE
BCDA-8509: InProgress JobStatus response always shows 0%

### DIFF
--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -190,10 +190,6 @@ func (s *service) GetJobAndKeys(ctx context.Context, jobID uint) (*models.Job, [
 		return nil, nil, err
 	}
 
-	// No need to look up job keys if the job is complete
-	if j.Status != models.JobStatusCompleted {
-		return j, nil, nil
-	}
 	keys, err := s.repository.GetJobKeys(ctx, jobID)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8509

## 🛠 Changes

- the method `GetJobAndKeys` in `bcda/service/service.go` now fetches job keys even when the job does not have the "Completed" status
- tests are added to validate the behavior of `GetJobAndKeys`
- tests are added to validate the behavior of the "X-Progress" header

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

The method `GetJobAndKeys` in `bcda/service/service.go` only fetched and returned job keys if the job had the "Completed" status. This contradicted the comment just above the status check, which implied that the keys should only be fetched if the job _didn't_ have the "Completed" status. Since the keys seemed to be required for jobs with the Completed status and otherwise, I simply removed the check.

## 🧪 Validation

- I created tests that check the conditions of this ticket, as well as other conditions
- I created a new job request with 3 sub jobs on my local environment, paused the bcda worker after it completed one sub job, and validated that the job status displayed "33%" progress
