### PR TITLE
BCDA-8975: Fix worker docker container and enable debugging

### DIFF
--- a/Dockerfiles/Dockerfile.bcda_prod
+++ b/Dockerfiles/Dockerfile.bcda_prod
@@ -1,5 +1,6 @@
 FROM golang:1.23.1-alpine3.20 AS builder
 
+ARG GO_FLAGS
 RUN apk update upgrade
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
@@ -17,13 +18,14 @@ COPY . .
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcda
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go install
+    go install "$GO_FLAGS"
 
 # ------------------------------------------------------------------------
 FROM golang:1.23.1-alpine3.20
+
 ARG ENVIRONMENT
 # only add dev packages if the environment argument was set to development
-RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash
+RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash && go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcda
 
 # This directory is needed on the api container to import synthetic data
@@ -31,5 +33,6 @@ COPY --from=builder /go/src/github.com/CMSgov/bcda-app/shared_files/ /go/src/git
 
 COPY --from=builder /go/src/github.com/CMSgov/bcda-app/bcda/ /go/src/github.com/CMSgov/bcda-app/bcda/
 COPY --from=builder /go/bin/ /go/bin/
+
 ENTRYPOINT ["bcda"]
 CMD ["start-api"]

--- a/Dockerfiles/Dockerfile.bcdaworker_prod
+++ b/Dockerfiles/Dockerfile.bcdaworker_prod
@@ -26,6 +26,7 @@ ARG ENVIRONMENT
 RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcdaworker
 
+COPY --from=builder /go/src/github.com/CMSgov/bcda-app/shared_files/ /go/src/github.com/CMSgov/bcda-app/shared_files/
 # This file is needed on the worker container by hcc.go -- similar requirement in build_and_package.sh
 COPY --from=builder /go/src/github.com/CMSgov/bcda-app/bcda/models/fhir/alr/utils/hcc_crosswalk.tsv /etc/sv/worker/hcc_crosswalk.tsv
 

--- a/Dockerfiles/Dockerfile.bcdaworker_prod
+++ b/Dockerfiles/Dockerfile.bcdaworker_prod
@@ -1,5 +1,6 @@
 FROM golang:1.23.1-alpine3.20 AS builder
 
+ARG GO_FLAGS
 RUN apk update upgrade
 
 WORKDIR /go/src/github.com/CMSgov/bcda-app
@@ -17,13 +18,14 @@ COPY . .
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcdaworker
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go install
+    go install "$GO_FLAGS"
 
 # ------------------------------------------------------------------------
 FROM golang:1.23.1-alpine3.20
+
 ARG ENVIRONMENT
 # only add dev packages if the environment argument was set to development
-RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash
+RUN [ "$ENVIRONMENT" != "development" ] || apk add git openssl entr bash && go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /go/src/github.com/CMSgov/bcda-app/bcdaworker
 
 COPY --from=builder /go/src/github.com/CMSgov/bcda-app/shared_files/ /go/src/github.com/CMSgov/bcda-app/shared_files/
@@ -32,4 +34,5 @@ COPY --from=builder /go/src/github.com/CMSgov/bcda-app/bcda/models/fhir/alr/util
 
 COPY --from=builder /go/src/github.com/CMSgov/bcda-app/bcdaworker/ /go/src/github.com/CMSgov/bcda-app/bcdaworker/
 COPY --from=builder /go/bin/ /go/bin/
+
 ENTRYPOINT ["bcdaworker"]

--- a/Makefile
+++ b/Makefile
@@ -175,16 +175,12 @@ worker-shell:
 	docker compose exec -T worker bash
 
 debug-api:
-	docker compose start db queue worker
-	@echo "Starting debugger. This may take a while..."
-	@-bash -c "trap 'docker compose stop' EXIT; \
-		docker compose -f docker-compose.yml -f docker-compose.debug.yml run --no-deps -T --rm -p 3000:3000 -v $(shell pwd):/go/src/github.com/CMSgov/bcda-app api dlv debug -- start-api"
+	docker compose up --watch worker & \
+	docker compose -f docker-compose.yml -f docker-compose.debug.yml up --watch api
 
 debug-worker:
-	docker compose start db queue api
-	@echo "Starting debugger. This may take a while..."
-	@-bash -c "trap 'docker compose stop' EXIT; \
-		docker compose -f docker-compose.yml -f docker-compose.debug.yml run --no-deps -T --rm -v $(shell pwd):/go/src/github.com/CMSgov/bcda-app worker dlv debug"
+	docker compose up --watch api & \
+	docker compose -f docker-compose.yml -f docker-compose.debug.yml up --watch worker
 
 bdt:
 	# Set up valid client credentials

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ make performance-test
 ### **Update Database Seed Data**
 
 After the user has finished updating the Postgres database used for unit testing with the new data, the user can update
-the seed data by running the following comamnd:
+the seed data by running the following command:
 
 ```sh
 make unit-test-db-snapshot
@@ -309,3 +309,31 @@ docker exec -it bcda-app-api-1 sh -c 'bcda -h'
 
 Follow installing go + vscode [setup guide](https://marketplace.visualstudio.com/items?itemName=golang.go#getting-started).
 Additional settings found under `.vscode/settings.json` allow tests to be run within vscode.
+
+## Debugging
+
+To attach to either the api or worker process within its respective docker container and debug, stop at breakpoints, and view local variables during execution, run the appropriate debug command.
+
+`make debug-api`
+
+or
+
+`make debug-worker`
+
+Once the containers are up, the program to debug will wait to be connected to dlv. Use dlv directly, or use a remote-attach debugging configuration in vscode.
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Connect to server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 4040,
+            "host": "127.0.0.1"
+        }
+    ]
+}
+```
+

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -3,11 +3,25 @@ version: '3'
 
 services:
   api:
+    build:
+      args:
+        GO_FLAGS: -gcflags=all=-N -l
+    entrypoint: dlv
+    command: exec --headless --listen=:4040 --accept-multiclient /go/bin/bcda -- start-api
     security_opt:
       - seccomp:unconfined
+    ports:
+      - "4040:4040"
   worker:
+    build:
+      args:
+        GO_FLAGS: -gcflags=all=-N -l
+    entrypoint: dlv
+    command: exec --headless --listen=:4040 --accept-multiclient /go/bin/bcdaworker
     security_opt:
       - seccomp:unconfined
+    ports:
+      - "4040:4040"
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     command: ["bcda", "start-api"]
     env_file:
       - ./shared_files/decrypted/local.env
+    volumes:
+      - fhir_payload_dir:/go/src/github.com/CMSgov/bcda-app/bcdaworker/data
     ports:
       - "3000:3000"
       - "3001:3001"
@@ -52,6 +54,8 @@ services:
     command: ["bcdaworker"]
     env_file:
       - ./shared_files/decrypted/local.env
+    volumes:
+      - fhir_payload_dir:/go/src/github.com/CMSgov/bcda-app/bcdaworker/data
     depends_on:
       - db
       - queue
@@ -104,6 +108,9 @@ services:
       - "3005:3005"
     depends_on:
       - db
+
+volumes:
+  fhir_payload_dir:
 
 networks:
   default:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8975

## 🛠 Changes

- fixed a problem with the worker docker container by including the `shared_files` directory in its file system
- added a docker volume to share files in the FHIR_ PAYLOAD_DIR between the api and worker containers
- adjusted the debug docker compose file to enable debugging with our new docker setup, and updated docs to make it user-friendly

## ℹ️ Context

The changes from the first BCDA-8975 PR more clearly defined the file system of the docker containers, and the bind mount to the host file system was removed. I missed that the `share_files` directory was required by the worker container, which caused it to fail when it picked up jobs. Adding the directory explicitly into the container should address this problem. **On a related note, we should keep an eye out for any other directories or files that may have been missed.** This should give us the opportunity to better organize our code and the requirements of the program in general.

Another issue we were seeing in smoke tests is that the api and worker containers expect to share a `FHIR_PAYLOAD_DIR` directory, which was previously being provided by default when the entire repo directory was a bind mount. Now the single directory is shared explicitly via a docker volume. Ideally we would like to define the directory path within the containers via configuration, but since the filepath is specified in many tests, it will be more work to untangle it.

I also (re?)enabled docker container bcda app debugging. Follow the readme "Debug" instructions to test it out! Try debugging the api, attaching to it with vscode, and making a request to an endpoint like `_metadata` to view the local variables at execution. Let me know if the instructions are unclear, or if you think the `make debug-<>` commands should work differently. On the make commands, I assumed that if you're debugging, you probably want to enable watch as well.

## 🧪 Validation

- I tested new jobs on my local environment and verified that the worker completed them as expected.
