### PR TITLE
BCDA-9020: reorder ci check steps and update file name

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -94,11 +94,6 @@ jobs:
     needs: lint_and_test
     runs-on: self-hosted
     steps:
-      - name: Download code coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report
-          path: testcoverage.out
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
@@ -112,13 +107,17 @@ jobs:
         with:
           repository: CMSgov/bcda-app
           fetch-depth: 0
+      - name: Download code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
             -Dsonar.projectKey=bcda-aco-api
             -Dsonar.sources=.
-            -Dsonar.go.coverage.reportPaths=./testcoverage.out
+            -Dsonar.go.coverage.reportPaths=testcoverage.out
             -Dsonar.coverage.exclusions=**/*test.go,**/test/**/*,**/testUtils/*,**/scripts/*,**/ops/*,**/mock*.go,**/mock/**/*
             -Dsonar.branch.name=${{ env.RELEASE_VERSION }}
             -Dsonar.projectVersion=${{ github.sha }}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9020

## 🛠 Changes

- reordered the workflow steps to pull the coverage report after cloning the repo
 - updated the coverage report path

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Look in this PR's checks for the "CI Checks / Lint and Test (pull_request)" workflow. Navigate to the "Sonarqube Quality Gate" job and in the "Run quality gate scan" step, follow the link provided at the end of the step to the sonarqube scan. Ensure that the overal code coverate is not 0% (~85%).
