### PR TITLE
Carl/bcda 8967 adjust deploy verifications

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -172,7 +172,11 @@ jobs:
             if [[ $BCDA_API_VERSION != ${{ env.RELEASE_VERSION }} ]]; then
               echo "BCDA API expected release version: ${{ env.RELEASE_VERSION }} did not match curled version: ${BCDA_API_VERSION}."
               TRY=$(($TRY + 1))
-              sleep $VERIFICATION_SLEEP
+              if [ $TRY -gt $VERIFICATION_RETRIES ]; then
+                exit 1
+              else
+                sleep $SLEEP_TIME
+              fi
             else
               break
             fi
@@ -193,7 +197,11 @@ jobs:
             if [[ $BCDA_SSAS_VERSION != ${{ env.SSAS_RELEASE_VERSION }} ]]; then
               echo "BCDA SSAS expected release version: ${{ env.SSAS_RELEASE_VERSION }} did not match curled version: ${BCDA_API_VERSION}."
               TRY=$(($TRY + 1))
-              sleep $VERIFICATION_SLEEP
+              if [ $TRY -gt $VERIFICATION_RETRIES ]; then
+                exit 1
+              else
+                sleep $SLEEP_TIME
+              fi
             else
               break
             fi
@@ -219,7 +227,11 @@ jobs:
             if [[ $BCDA_WORKER_VERSION != ${{ env.RELEASE_VERSION }} ]]; then
               echo "BCDA Worker expected release version: ${{ env.RELEASE_VERSION }} did not match curled version: ${BCDA_WORKER_VERSION}."
               TRY=$(($TRY + 1))
-              sleep $VERIFICATION_SLEEP
+              if [ $TRY -gt $VERIFICATION_RETRIES ]; then
+                exit 1
+              else
+                sleep $SLEEP_TIME
+              fi
             else
               break
             fi

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -2,8 +2,6 @@
 name: Deploy All
 
 on:
-  push:
-    branches: [carl/BCDA-8967-adjust-deploy-verifications]
   schedule:
     - cron: 0 12 * * 1-5 # every workday at 8am EST
   workflow_dispatch:

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -2,8 +2,10 @@
 name: Deploy All
 
 on:
+  push:
+    branches: [carl/BCDA-8967-adjust-deploy-verifications]
   schedule:
-    - cron: 0 8 * * 1-5 # every workday at 8am
+    - cron: 0 12 * * 1-5 # every workday at 8am EST
   workflow_dispatch:
     inputs:
       release_version:
@@ -63,6 +65,8 @@ env:
   CONFIRM_RELEASE_ENV: ${{ inputs.confirm_env || 'dev' }}
   ENV_MODIFIER: ${{ (inputs.env == 'opensbx' && 'sbx') || inputs.env || 'dev' }}
   TEST_ACO: ${{ inputs.test_aco || 'dev' }}
+  VERIFICATION_RETRIES: 90 # 90 retries with 10s sleep = max 900s or 15m.  Verification jobs run in parallel.
+  VERIFICATION_SLEEP: 10
 
 jobs:
   migrate_db:
@@ -151,41 +155,82 @@ jobs:
           aws autoscaling start-instance-refresh --region ${{ vars.AWS_REGION }} --auto-scaling-group-name ${ASG}
           export WORKER_ASG=`aws autoscaling describe-auto-scaling-groups --region ${{ vars.AWS_REGION }} --filters "Name=tag:Name,Values=bcda-${{ env.RELEASE_ENV }}-worker" --query 'AutoScalingGroups[0].AutoScalingGroupName' --output text`
           aws autoscaling start-instance-refresh --region ${{ vars.AWS_REGION }} --auto-scaling-group-name ${WORKER_ASG}
-      - run: sleep 300 # Give plenty of time for api and worker instances to refresh
-      - name: Verify API version
-        run: |
-          export BCDA_API_VERSION=`curl https://${{ vars.API_BASE_URL }}/_version | jq -r .version`
-          if [[ $BCDA_API_VERSION != ${{ env.RELEASE_VERSION }} ]]; then
-            echo "BCDA API expected release version: ${{ env.RELEASE_VERSION }} did not match curled version: ${BCDA_API_VERSION}."
-            exit 1
-          fi
-      - name: Verify SSAS version
-        run: |
-          export BCDA_SSAS_VERSION=`curl https://${{ vars.API_BASE_URL }}/_auth | jq -r .version`
-          if [[ $BCDA_SSAS_VERSION != ${{ env.SSAS_RELEASE_VERSION }} ]]; then
-            echo "BCDA SSAS expected release version: ${{ env.SSAS_RELEASE_VERSION }} did not match curled version: ${BCDA_SSAS_VERSION}."
-            exit 1
-          fi
-      - name: Verify Worker version
-        run: |
-          export IMAGE_ID=`aws ec2 describe-instances --region ${{ vars.AWS_REGION }} --filters 'Name=tag:Name,Values=bcda-${{ env.RELEASE_ENV }}-worker' 'Name=instance-state-name,Values=running' --query 'Reservations[0].Instances[*][LaunchTime,ImageId] | reverse(sort_by(@,&[0])) | [0][1]' --output text`
-          # Was unable to escape the backticks (`), creating this function seems to get around that
-          get_image_version () {
-              aws ec2 describe-images --region us-east-1 --image-ids ${IMAGE_ID} --query 'Images[0].Tags[?Key==`version`].Value' --output text
-          }
-          export BCDA_WORKER_VERSION=`get_image_version`
-          if [[ $BCDA_WORKER_VERSION != ${{ env.RELEASE_VERSION }} ]]; then
-            echo "BCDA Worker expected release version: ${{ env.RELEASE_VERSION }} did not match curled version: ${BCDA_WORKER_VERSION}."
-            exit 1
-          fi
       - name: Upload notify script
         uses: actions/upload-artifact@v4
         with:
           name: notify-script
           path: ./scripts/mark_deployment.py
+  
+  verify_api_version:
+    needs: [deploy]
+    runs-on: self-hosted
+    steps:
+      - run: |
+          TRY=1
+
+          until [ $TRY -gt $VERIFICATION_RETRIES ]; do
+            BCDA_API_VERSION=`curl https://${{ vars.API_BASE_URL }}/_version | jq -r .version`
+
+            if [[ $BCDA_API_VERSION != ${{ env.RELEASE_VERSION }} ]]; then
+              echo "BCDA API expected release version: ${{ env.RELEASE_VERSION }} did not match curled version: ${BCDA_API_VERSION}."
+              TRY=$(($TRY + 1))
+              sleep $VERIFICATION_SLEEP
+            else
+              break
+            fi
+
+            exit 1
+          done
+
+  verify_ssas_version:
+    needs: [deploy]
+    runs-on: self-hosted
+    steps:
+      - run: |
+          TRY=1
+
+          until [ $TRY -gt $VERIFICATION_RETRIES ]; do
+            BCDA_SSAS_VERSION=`curl https://${{ vars.API_BASE_URL }}/_version | jq -r .version`
+
+            if [[ $BCDA_SSAS_VERSION != ${{ env.SSAS_RELEASE_VERSION }} ]]; then
+              echo "BCDA SSAS expected release version: ${{ env.SSAS_RELEASE_VERSION }} did not match curled version: ${BCDA_API_VERSION}."
+              TRY=$(($TRY + 1))
+              sleep $VERIFICATION_SLEEP
+            else
+              break
+            fi
+
+            exit 1
+          done
+
+  verify_worker_version:
+    needs: [deploy]
+    runs-on: self-hosted
+    steps:
+      - run: |
+          TRY=1
+
+          until [ $TRY -gt $VERIFICATION_RETRIES ]; do
+            export IMAGE_ID=`aws ec2 describe-instances --region ${{ vars.AWS_REGION }} --filters 'Name=tag:Name,Values=bcda-${{ env.RELEASE_ENV }}-worker' 'Name=instance-state-name,Values=running' --query 'Reservations[0].Instances[*][LaunchTime,ImageId] | reverse(sort_by(@,&[0])) | [0][1]' --output text`
+            # Was unable to escape the backticks (`), creating this function seems to get around that
+            get_image_version () {
+                aws ec2 describe-images --region us-east-1 --image-ids ${IMAGE_ID} --query 'Images[0].Tags[?Key==`version`].Value' --output text
+            }
+            export BCDA_WORKER_VERSION=`get_image_version`
+
+            if [[ $BCDA_WORKER_VERSION != ${{ env.RELEASE_VERSION }} ]]; then
+              echo "BCDA Worker expected release version: ${{ env.RELEASE_VERSION }} did not match curled version: ${BCDA_WORKER_VERSION}."
+              TRY=$(($TRY + 1))
+              sleep $VERIFICATION_SLEEP
+            else
+              break
+            fi
+
+            exit 1
+          done
 
   smoketests:
-    needs: [migrate_db, deploy]
+    needs: [migrate_db, deploy, verify_api_version, verify_ssas_version, verify_worker_version]
     uses: ./.github/workflows/smoke-tests.yml
     with:
       release_version: ${{ inputs.release_version || 'main' }}
@@ -197,7 +242,7 @@ jobs:
     secrets: inherit
 
   notify_newrelic:
-    needs: [deploy]
+    needs: [migrate_db, deploy, verify_api_version, verify_ssas_version, verify_worker_version]
     runs-on: self-hosted
     steps:
       - name: Set env vars from AWS params

--- a/ops/release.sh
+++ b/ops/release.sh
@@ -78,27 +78,37 @@ if [ -n "$MANUAL_TAGS" ]; then
   NEWTAG="$2"
   PREVRELEASENUM=${PREVTAG//^r/}
   NEWRELEASENUM=${NEWTAG//^r/}
+  echo "Manual tags set: PREVRELEASENUM:${PREVRELEASENUM}, NEWRELEASENUM:${NEWRELEASENUM}, PREVTAG:${PREVTAG}, NEWTAG:${NEWTAG}"
 else
   PREVRELEASENUM=$(git tag | grep '^r[0-9]' | sed 's/^r//' | sort -n | tail -1)
   NEWRELEASENUM=$(($PREVRELEASENUM + 1))
   PREVTAG="r$PREVRELEASENUM"
   NEWTAG="r$NEWRELEASENUM"
+  echo "No manual tags: PREVRELEASENUM:${PREVRELEASENUM}, NEWRELEASENUM:${NEWRELEASENUM}, PREVTAG:${PREVTAG}, NEWTAG:${NEWTAG}"
 fi
 
 TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
 
 if [ -n $PREVTAG ]
 then
+  echo "Get all commits between ${PREVTAG} and HEAD"
   commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
 else
+  echo "Get latest commit"
   commits=$(git log --pretty=format:"- %s" HEAD)
 fi
+
+echo "Commits found:"
+echo $commits
 
 echo "$NEWTAG - $(date +%Y-%m-%d)" > $TMPFILE
 echo "================" >> $TMPFILE
 echo "" >> $TMPFILE
 echo "$commits" >> $TMPFILE
 echo "" >> $TMPFILE
+
+echo "Release notes created:"
+cat $TMPFILE
 
 #git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8967

## 🛠 Changes

Convert deploy workflow version verifications to run in parallel with a long retry interval to account for lengthy instance refreshes.

## ℹ️ Context

Currently we are just sleeping for 240s then checking versions.  This is failing deploys a bit more than 50% of the time.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Test deploy run on PR branch push.
