### PR TITLE
BCDA-9064: Add aco config to prepare job data

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -474,9 +474,11 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType co
 		return
 	}
 
-	if acoCfg, ok := h.Svc.GetACOConfigForID(ad.CMSID); ok {
+	acoCfg, ok := h.Svc.GetACOConfigForID(ad.CMSID)
+	if ok {
 		ctx = service.NewACOCfgCtx(ctx, acoCfg)
 	}
+
 	rp, ok := middleware.GetRequestParamsFromCtx(ctx)
 	if !ok {
 		panic("Request parameters must be set prior to calling this handler.")
@@ -584,6 +586,7 @@ func (h *Handler) bulkRequest(w http.ResponseWriter, r *http.Request, reqType co
 		ClaimsDate:             timeConstraints.ClaimsDate,
 		OptOutDate:             timeConstraints.OptOutDate,
 		TransactionID:          r.Context().Value(m.CtxTransactionKey).(string),
+		ACOConfigDataTypes:     acoCfg.Data,
 	}
 
 	logger.Infof("Adding jobs using %T", h.Enq)

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -839,7 +839,7 @@ func (s *ServiceTestSuite) TestGetQueJobs_Integration() {
 				ComplexDataRequestType: tt.ComplexRequestType,
 				BFDPath:                basePath,
 				ClaimsDate:             tt.expClaimsWindow.UpperBound,
-				ACOConfigDataTypes:     []string{"adjudicated", "partially-adjudicated"},
+				ACOConfigDataTypes:     []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 			}
 
 			repository := &models.MockRepository{}
@@ -950,7 +950,7 @@ func (s *ServiceTestSuite) TestGetQueJobsErrorHandling_Integration() {
 			CMSID:              defaultACOID,
 			ACOID:              uuid.NewUUID(),
 			RequestType:        22,
-			ACOConfigDataTypes: []string{"adjudicated", "partially-adjudicated"},
+			ACOConfigDataTypes: []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 		}
 		repository := &models.MockRepository{}
 		repository.On("GetACOByCMSID", testUtils.CtxMatcher, args.CMSID).Return(&models.ACO{UUID: args.ACOID, TerminationDetails: nil}, nil)
@@ -966,7 +966,7 @@ func (s *ServiceTestSuite) TestGetQueJobsErrorHandling_Integration() {
 			CMSID:              defaultACOID,
 			ACOID:              uuid.NewUUID(),
 			RequestType:        constants.DefaultRequest,
-			ACOConfigDataTypes: []string{"adjudicated", "partially-adjudicated"},
+			ACOConfigDataTypes: []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 		}
 		repository := &models.MockRepository{}
 		repository.On("GetACOByCMSID", testUtils.CtxMatcher, args.CMSID).Return(&models.ACO{UUID: args.ACOID, TerminationDetails: nil}, nil)
@@ -983,7 +983,7 @@ func (s *ServiceTestSuite) TestGetQueJobsErrorHandling_Integration() {
 			CMSID:              defaultACOID,
 			ACOID:              uuid.NewUUID(),
 			RequestType:        constants.RetrieveNewBeneHistData,
-			ACOConfigDataTypes: []string{"adjudicated", "partially-adjudicated"},
+			ACOConfigDataTypes: []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 		}
 		repository := &models.MockRepository{}
 		repository.On("GetACOByCMSID", testUtils.CtxMatcher, args.CMSID).Return(&models.ACO{UUID: args.ACOID, TerminationDetails: nil}, nil)
@@ -1000,7 +1000,7 @@ func (s *ServiceTestSuite) TestGetQueJobsErrorHandling_Integration() {
 			CMSID:              defaultACOID,
 			ACOID:              uuid.NewUUID(),
 			RequestType:        constants.RetrieveNewBeneHistData,
-			ACOConfigDataTypes: []string{"adjudicated", "partially-adjudicated"},
+			ACOConfigDataTypes: []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 		}
 		repository := &models.MockRepository{}
 		repository.On("GetACOByCMSID", testUtils.CtxMatcher, args.CMSID).Return(&models.ACO{UUID: args.ACOID, TerminationDetails: nil}, nil)
@@ -1065,8 +1065,8 @@ func (s *ServiceTestSuite) TestGetQueJobsByDataType_Integration() {
 		terminationDetails *models.Termination
 		dataTypes          []string
 	}{
-		{"Adjudicated", defaultACOID, constants.DefaultRequest, constants.GetExistingBenes, time.Time{}, claimsWindow{}, benes1, timeB, []string{"Patient"}, nil, []string{"adjudicated"}},
-		{"PartiallyAdjudicated", defaultACOID, constants.DefaultRequest, constants.GetExistingBenes, time.Time{}, claimsWindow{}, benes1, timeA, []string{"Claim"}, nil, []string{"partially-adjudicated"}},
+		{constants.Adjudicated, defaultACOID, constants.DefaultRequest, constants.GetExistingBenes, time.Time{}, claimsWindow{}, benes1, timeB, []string{"Patient"}, nil, []string{constants.Adjudicated}},
+		{"PartiallyAdjudicated", defaultACOID, constants.DefaultRequest, constants.GetExistingBenes, time.Time{}, claimsWindow{}, benes1, timeA, []string{"Claim"}, nil, []string{constants.PartiallyAdjudicated}},
 	}
 
 	for _, tt := range tests {
@@ -1643,7 +1643,7 @@ func (s *ServiceTestSuiteWithDatabase) TestGetBenesByID_Integration() {
 			newCtx := NewACOCfgCtx(context.Background(), acoConfig)
 			rc := worker_types.PrepareJobArgs{
 				CMSID:              test.cmsID,
-				ACOConfigDataTypes: []string{"adjudicated", "partially-adjudicated"},
+				ACOConfigDataTypes: []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 			}
 			actualBeneCount, err := service.getBenesByFileID(newCtx, 1, rc)
 			if err != nil {

--- a/bcdaworker/queueing/worker_prepare_test.go
+++ b/bcdaworker/queueing/worker_prepare_test.go
@@ -105,7 +105,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareExportJobsDatabase_Integr
 				CCLFFileNewID:          uint(1),
 				CCLFFileOldID:          uint(2),
 				ResourceTypes:          []string{"Coverage"},
-				ACOConfigDataTypes:     []string{"adjudicated", "partially-adjudicated"},
+				ACOConfigDataTypes:     []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 			}
 
 			if tt.bfdErr {
@@ -162,7 +162,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareExportJobs_Integration() 
 		CCLFFileNewID:          uint(1),
 		CCLFFileOldID:          uint(2),
 		ResourceTypes:          []string{"Coverage"},
-		ACOConfigDataTypes:     []string{"adjudicated"},
+		ACOConfigDataTypes:     []string{constants.Adjudicated},
 	}
 
 	worker := &PrepareJobWorker{svc: svc, v1Client: c, v2Client: c, r: s.r}
@@ -216,7 +216,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareWorkerWork() {
 			CCLFFileNewID:          uint(1),
 			CCLFFileOldID:          uint(2),
 			ResourceTypes:          []string{"Claim"},
-			ACOConfigDataTypes:     []string{"partially-adjudicated"},
+			ACOConfigDataTypes:     []string{constants.PartiallyAdjudicated},
 		},
 	}
 
@@ -276,7 +276,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareWorkerWork_Integration() 
 			CCLFFileNewID:          uint(1),
 			CCLFFileOldID:          uint(2),
 			ResourceTypes:          []string{"Coverage"},
-			ACOConfigDataTypes:     []string{"adjudicated", "partially-adjudicated"},
+			ACOConfigDataTypes:     []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 		},
 	}
 

--- a/bcdaworker/queueing/worker_prepare_test.go
+++ b/bcdaworker/queueing/worker_prepare_test.go
@@ -105,6 +105,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareExportJobsDatabase_Integr
 				CCLFFileNewID:          uint(1),
 				CCLFFileOldID:          uint(2),
 				ResourceTypes:          []string{"Coverage"},
+				ACOConfigDataTypes:     []string{"adjudicated", "partially-adjudicated"},
 			}
 
 			if tt.bfdErr {
@@ -161,6 +162,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareExportJobs_Integration() 
 		CCLFFileNewID:          uint(1),
 		CCLFFileOldID:          uint(2),
 		ResourceTypes:          []string{"Coverage"},
+		ACOConfigDataTypes:     []string{"adjudicated"},
 	}
 
 	worker := &PrepareJobWorker{svc: svc, v1Client: c, v2Client: c, r: s.r}
@@ -213,7 +215,8 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareWorkerWork() {
 			ComplexDataRequestType: constants.GetNewAndExistingBenes,
 			CCLFFileNewID:          uint(1),
 			CCLFFileOldID:          uint(2),
-			ResourceTypes:          []string{"Coverage"},
+			ResourceTypes:          []string{"Claim"},
+			ACOConfigDataTypes:     []string{"partially-adjudicated"},
 		},
 	}
 
@@ -273,6 +276,7 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareWorkerWork_Integration() 
 			CCLFFileNewID:          uint(1),
 			CCLFFileOldID:          uint(2),
 			ResourceTypes:          []string{"Coverage"},
+			ACOConfigDataTypes:     []string{"adjudicated", "partially-adjudicated"},
 		},
 	}
 

--- a/bcdaworker/queueing/worker_types/prepare_types.go
+++ b/bcdaworker/queueing/worker_types/prepare_types.go
@@ -25,6 +25,7 @@ type PrepareJobArgs struct {
 	ClaimsDate             time.Time
 	OptOutDate             time.Time
 	TransactionID          string
+	ACOConfigDataTypes     []string
 }
 
 func (args PrepareJobArgs) Kind() string {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9064

## 🛠 Changes

Add ACO config values (data types) to prepare job args

## ℹ️ Context

Currently prepare jobs are failing on not being able to find ACO configs.  I believe this is due to worker instance not having aco config.yml available.  This would also explain how it got past unit testing, docker composet smoke tests, but failed on actual public url smoke tests.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
