### PR TITLE
BCDA-9092: Adjust order of request mw to make sure AD info is available

### DIFF
--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -21,13 +21,13 @@ func IsDatabaseOK() (result string, ok bool) {
 func IsBlueButtonOK() bool {
 	bbc, err := client.NewBlueButtonClient(client.NewConfig("/v1/fhir"))
 	if err != nil {
-		log.API.Error("Health check: Blue Button client error: ", err.Error())
+		log.Worker.Error("Health check: Blue Button client error: ", err.Error())
 		return false
 	}
 
 	_, err = bbc.GetMetadata()
 	if err != nil {
-		log.API.Error("Health check: Blue Button connection error: ", err.Error())
+		log.Worker.Error("Health check: Blue Button connection error: ", err.Error())
 		return false
 	}
 

--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -18,6 +18,16 @@ func IsDatabaseOK() (result string, ok bool) {
 	return "ok", true
 }
 
+func IsWorkerDatabaseOK() (result string, ok bool) {
+	db := database.Connection
+	if err := db.Ping(); err != nil {
+		log.Worker.Error("Health check: database ping error: ", err.Error())
+		return "database ping error", false
+	}
+
+	return "ok", true
+}
+
 func IsBlueButtonOK() bool {
 	bbc, err := client.NewBlueButtonClient(client.NewConfig("/v1/fhir"))
 	if err != nil {

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -30,7 +30,7 @@ var commonAuth = []func(http.Handler) http.Handler{
 func NewAPIRouter() http.Handler {
 	r := chi.NewRouter()
 	m := monitoring.GetMonitor()
-	r.Use(gcmw.RequestID, appMiddleware.NewTransactionID, logging.NewStructuredLogger(), auth.ParseToken, middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
+	r.Use(gcmw.RequestID, appMiddleware.NewTransactionID, auth.ParseToken, logging.NewStructuredLogger(), middleware.SecurityHeader, middleware.ConnectionClose, logging.NewCtxLogger)
 
 	// Serve up the swagger ui folder
 	FileServer(r, "/api/v1/swagger", http.Dir("./swaggerui/v1"))

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -130,7 +130,7 @@ func logHealth() {
 	logFields["type"] = "health"
 	logFields["id"] = uuid.NewRandom()
 
-	if _, ok := health.IsDatabaseOK(); ok {
+	if _, ok := health.IsWorkerDatabaseOK(); ok {
 		logFields["db"] = "ok"
 	} else {
 		logFields["db"] = "error"

--- a/bcdaworker/queueing/river.go
+++ b/bcdaworker/queueing/river.go
@@ -74,22 +74,26 @@ func StartRiver(numWorkers int) *queue {
 		),
 	}
 
+	logger := getSlogLogger()
+
 	riverClient, err := river.NewClient(riverpgxv5.New(database.Pgxv5Pool), &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: numWorkers},
 		},
 		// TODO: whats an appropriate timeout?
 		JobTimeout:   -1, // default for river is 1m, que-go had no timeout, mimicking que-go for now
-		Logger:       getSlogLogger(),
+		Logger:       logger,
 		Workers:      workers,
 		PeriodicJobs: periodicJobs,
 	})
 
 	if err != nil {
+		logger.Error("failed to init river client", "error", err)
 		panic(err)
 	}
 
 	if err := riverClient.Start(context.Background()); err != nil {
+		logger.Error("failed to start river client", "error", err)
 		panic(err)
 	}
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9092

## 🛠 Changes

Re-ordered middleware to make sure that both:
- transaction id is available when parsing jwt tokens
- auth data is available when setting up the structured logger

## ℹ️ Context

The recent changes to logging (making sure transaction_id is present when making requests from bcda api -> ssas) broke the logging of ACO ID on various splunk alerts.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting, testing.
