### PR TITLE
BCDA-9102: Make sure config is available for worker instance

### DIFF
--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -1788,7 +1788,7 @@ func TestGetBenesByFileID_Fail_NoACOConfig(t *testing.T) {
 	serviceInstance := NewService(repository, cfg, "").(*service)
 	benes, err := serviceInstance.getBenesByFileID(ctx, uint(1), args)
 	assert.Nil(t, benes)
-	assert.ErrorContains(t, err, "failed to access ACO Config, possibly failing to ignore suppressed MBIs")
+	assert.ErrorContains(t, err, "failed to load or match ACO config (or potentially no ACO Configs set), CMS ID:")
 }
 
 func TestGetBenesByFileID_Fail_ACOConfigMismatch(t *testing.T) {
@@ -1812,7 +1812,7 @@ func TestGetBenesByFileID_Fail_ACOConfigMismatch(t *testing.T) {
 	serviceInstance := NewService(repository, cfg, "").(*service)
 	benes, err := serviceInstance.getBenesByFileID(ctx, uint(1), args)
 	assert.Nil(t, benes)
-	assert.ErrorContains(t, err, "failed to access ACO Config, possibly failing to ignore suppressed MBIs")
+	assert.ErrorContains(t, err, "failed to load or match ACO config (or potentially no ACO Configs set), CMS ID:")
 }
 
 func TestCreateQueueJobs_Fail_NoACOConfig(t *testing.T) {
@@ -1834,7 +1834,7 @@ func TestCreateQueueJobs_Fail_NoACOConfig(t *testing.T) {
 	serviceInstance := NewService(repository, cfg, "").(*service)
 	jobArgs, err := serviceInstance.createQueueJobs(ctx, args, time.Now(), nil)
 	assert.Nil(t, jobArgs)
-	assert.ErrorContains(t, err, "failed to access ACO Config, possibly failing to ignore suppressed MBIs")
+	assert.ErrorContains(t, err, "failed to load or match ACO config (or potentially no ACO Configs set), CMS ID:")
 }
 
 func TestCreateQueueJobs_Fail_ACOConfigMismatch(t *testing.T) {
@@ -1858,7 +1858,7 @@ func TestCreateQueueJobs_Fail_ACOConfigMismatch(t *testing.T) {
 	serviceInstance := NewService(repository, cfg, "").(*service)
 	jobArgs, err := serviceInstance.createQueueJobs(ctx, args, time.Now(), nil)
 	assert.Nil(t, jobArgs)
-	assert.ErrorContains(t, err, "failed to access ACO Config, possibly failing to ignore suppressed MBIs")
+	assert.ErrorContains(t, err, "failed to load or match ACO config (or potentially no ACO Configs set), CMS ID:")
 }
 
 func getCCLFFile(id uint, isRunout bool, forceIncorrect bool) *models.CCLFFile {

--- a/bcdaworker/queueing/worker_prepare.go
+++ b/bcdaworker/queueing/worker_prepare.go
@@ -45,6 +45,9 @@ func NewPrepareJobWorker() (*PrepareJobWorker, error) {
 	if err != nil {
 		logger.Fatalf("failed to load service config. Err: %v", err)
 	}
+	if len(cfg.ACOConfigs) == 0 {
+		logger.Fatalf("no ACO configs found, these are required for downstream processing")
+	}
 
 	repository := postgres.NewRepository(database.Connection)
 	svc := service.NewService(repository, cfg, "")

--- a/bcdaworker/queueing/worker_prepare_test.go
+++ b/bcdaworker/queueing/worker_prepare_test.go
@@ -105,7 +105,6 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareExportJobsDatabase_Integr
 				CCLFFileNewID:          uint(1),
 				CCLFFileOldID:          uint(2),
 				ResourceTypes:          []string{"Coverage"},
-				ACOConfigDataTypes:     []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 			}
 
 			if tt.bfdErr {
@@ -162,7 +161,6 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareExportJobs_Integration() 
 		CCLFFileNewID:          uint(1),
 		CCLFFileOldID:          uint(2),
 		ResourceTypes:          []string{"Coverage"},
-		ACOConfigDataTypes:     []string{constants.Adjudicated},
 	}
 
 	worker := &PrepareJobWorker{svc: svc, v1Client: c, v2Client: c, r: s.r}
@@ -216,7 +214,6 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareWorkerWork() {
 			CCLFFileNewID:          uint(1),
 			CCLFFileOldID:          uint(2),
 			ResourceTypes:          []string{"Claim"},
-			ACOConfigDataTypes:     []string{constants.PartiallyAdjudicated},
 		},
 	}
 
@@ -276,7 +273,6 @@ func (s *PrepareWorkerIntegrationTestSuite) TestPrepareWorkerWork_Integration() 
 			CCLFFileNewID:          uint(1),
 			CCLFFileOldID:          uint(2),
 			ResourceTypes:          []string{"Coverage"},
-			ACOConfigDataTypes:     []string{constants.Adjudicated, constants.PartiallyAdjudicated},
 		},
 	}
 

--- a/bcdaworker/queueing/worker_types/prepare_types.go
+++ b/bcdaworker/queueing/worker_types/prepare_types.go
@@ -25,7 +25,6 @@ type PrepareJobArgs struct {
 	ClaimsDate             time.Time
 	OptOutDate             time.Time
 	TransactionID          string
-	ACOConfigDataTypes     []string
 }
 
 func (args PrepareJobArgs) Kind() string {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9102

## 🛠 Changes

Not represented in this PR:
- Added param store values for BCDA_WORKER_CONFIG_PATH to point at (cloned) worker config.yml files (also in param store).  This doubles the config.yml files we have to keep in sync but was the easiest path forward.  (The alternative is messing around with an archaic script in bcda-ops, something that we have spent a lot of time trying to refactor as part of our AL2023 work).

In this PR:
- Add error checks for when we fail to load ACO Config appropriately.
- Add tests for the above and update existing.
- Some cleanup of now unused functions.

## ℹ️ Context

Previously if we failed to load ACO Configs we would just silently ignore the related logic blocks.  This included important logic checks.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
