### PR TITLE
BCDA-9018: demo endpoints (v3) initial stubbing out

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -103,6 +103,8 @@ func newHandler(dataTypes map[string]service.DataType, basePath string, apiVersi
 		h.RespWriter = responseutils.NewResponseWriter()
 	case "v2":
 		h.RespWriter = responseutilsv2.NewResponseWriter()
+	case "v3":
+		h.RespWriter = responseutilsv2.NewResponseWriter() // TODO: V3
 	default:
 		log.API.Fatalf("unexpected API version: %s", h.apiVersion)
 	}
@@ -611,7 +613,7 @@ func (h *Handler) getResourceTypes(parameters middleware.RequestParameters, cmsI
 				resourceTypes = append(resourceTypes, "Patient", "ExplanationOfBenefit", "Coverage")
 			}
 
-			if utils.ContainsString(acoConfig.Data, constants.PartiallyAdjudicated) && h.apiVersion != "v1" {
+			if utils.ContainsString(acoConfig.Data, constants.PartiallyAdjudicated) && h.apiVersion == "v2" {
 				resourceTypes = append(resourceTypes, "Claim", "ClaimResponse")
 			}
 		}

--- a/bcda/api/v3/api.go
+++ b/bcda/api/v3/api.go
@@ -1,0 +1,395 @@
+package v3
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/CMSgov/bcda-app/bcda/api"
+	"github.com/CMSgov/bcda-app/bcda/constants"
+	"github.com/CMSgov/bcda-app/bcda/service"
+	"github.com/CMSgov/bcda-app/bcda/servicemux"
+	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
+	"github.com/google/fhir/go/fhirversion"
+	"github.com/google/fhir/go/jsonformat"
+
+	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
+	fhirdatatypes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
+	fhirresources "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
+	fhircapabilitystatement "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/capability_statement_go_proto"
+	fhirvaluesets "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/valuesets_go_proto"
+)
+
+var (
+	h          *api.Handler
+	marshaller *jsonformat.Marshaller
+)
+
+func init() {
+	var err error
+
+	resources, ok := service.GetDataTypes([]string{
+		"Patient",
+		"Coverage",
+		"ExplanationOfBenefit",
+	}...)
+
+	if ok {
+		h = api.NewHandler(resources, "/v3/fhir", "v3")
+	} else {
+		panic("Failed to configure resource DataTypes")
+	}
+
+	// Ensure that we write the serialized FHIR resources as a single line.
+	// Needed to comply with the NDJSON format that we are using.
+	marshaller, err = jsonformat.NewMarshaller(false, "", "", fhirversion.R4)
+	if err != nil {
+		log.API.Fatalf("Failed to create marshaller %s", err)
+	}
+}
+
+// NOTE: The below are all just copies of v3/api
+
+/*
+swagger:route GET /api/v1/alr/$export alrData alrRequest
+
+# Start FHIR R4 data export for all supported resource types
+
+Initiates a job to collect Assignment List Report data for your ACO. Supported resource types are Patient, Coverage, Group, Risk Assessment, Observation, and Covid Episode.
+
+Produces:
+- application/fhir+json
+
+Security:
+
+	bearer_token:
+
+Responses:
+
+	202: BulkRequestResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	429: tooManyRequestsResponse
+	500: errorResponse
+*/
+func ALRRequest(w http.ResponseWriter, r *http.Request) {
+	h.ALRRequest(w, r)
+}
+
+/*
+swagger:route GET /api/v3/Patient/$export bulkDatav3 bulkPatientRequestv3
+
+Start FHIR R4 data export for all supported resource types.
+
+Initiates a job to collect data from the Blue Button API for your ACO. Supported resource types are Patient, Coverage, and ExplanationOfBenefit.
+
+Produces:
+- application/fhir+json
+
+Security:
+
+	bearer_token:
+
+Responses:
+
+	202: BulkRequestResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	429: tooManyRequestsResponse
+	500: errorResponse
+*/
+func BulkPatientRequest(w http.ResponseWriter, r *http.Request) {
+	h.BulkPatientRequest(w, r)
+}
+
+/*
+		swagger:route GET /api/v3/Group/{groupId}/$export bulkDatav3 bulkGroupRequestv3
+
+	    Start FHIR R4 data export (for the specified group identifier) for all supported resource types
+
+		Initiates a job to collect data from the Blue Button API for your ACO. The only Group identifier supported by the system are `all` and `runout`.
+
+		The `all` identifier returns data for the group of all patients attributed to the requesting ACO.  If used when specifying `_since`: all claims data which has been updated since the specified date will be returned for beneficiaries which have been attributed to the ACO since before the specified date; and all historical claims data will be returned for beneficiaries which have been newly attributed to the ACO since the specified date.
+
+		The `runout` identifier returns claims runouts data.
+
+		Produces:
+		- application/fhir+json
+
+		Security:
+			bearer_token:
+
+		Responses:
+			202: BulkRequestResponse
+			400: badRequestResponse
+			401: invalidCredentials
+			429: tooManyRequestsResponse
+			500: errorResponse
+*/
+func BulkGroupRequest(w http.ResponseWriter, r *http.Request) {
+	h.BulkGroupRequest(w, r)
+}
+
+/*
+swagger:route GET /api/v3/jobs/{jobId} jobv3 jobStatusv3
+
+# Get job status
+
+Returns the current status of an export job.
+
+Produces:
+- application/fhir+json
+
+Schemes: http, https
+
+Security:
+
+	bearer_token:
+
+Responses:
+
+	202: jobStatusResponse
+	200: completedJobResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	410: goneResponse
+	500: errorResponse
+*/
+func JobStatus(w http.ResponseWriter, r *http.Request) {
+	h.JobStatus(w, r)
+}
+
+/*
+swagger:route GET /api/v3/jobs jobv3 jobsStatusv3
+
+# Get jobs statuses
+
+Returns the current statuses of export jobs. Supported status types are Completed, Archived, Expired, Failed, FailedExpired,
+In Progress, Pending, Cancelled, and CancelledExpired. If no status(s) is provided, all jobs will be returned.
+
+Note on job status to fhir task resource status mapping:
+Due to the fhir task status field having a smaller set of values, the following statuses will be set to different fhir values in the response
+
+Archived, Expired -> Completed
+FailedExpired -> Failed
+Pending -> In Progress
+CancelledExpired -> Cancelled
+
+Though the status name has been remapped the response will still only contain jobs pertaining to the provided job status in the request.
+
+Produces:
+- application/fhir+json
+
+Schemes: http, https
+
+Security:
+
+	bearer_token:
+
+Responses:
+
+	200: jobsStatusResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	410: goneResponse
+	500: errorResponse
+*/
+func JobsStatus(w http.ResponseWriter, r *http.Request) {
+	h.JobsStatus(w, r)
+}
+
+/*
+swagger:route DELETE /api/v3/jobs/{jobId} jobv3 deleteJobv3
+
+# Cancel a job
+
+Cancels a currently running job.
+
+Produces:
+- application/fhir+json
+
+Schemes: http, https
+
+Security:
+
+	bearer_token:
+
+Responses:
+
+	202: deleteJobResponse
+	400: badRequestResponse
+	401: invalidCredentials
+	404: notFoundResponse
+	410: goneResponse
+	500: errorResponse
+*/
+func DeleteJob(w http.ResponseWriter, r *http.Request) {
+	h.DeleteJob(w, r)
+}
+
+/*
+swagger:route GET /api/v3/attribution_status attributionStatusv3 attributionStatus
+
+# Get attribution status
+
+Returns the status of the latest ingestion for attribution and claims runout files. The response will contain the Type to identify which ingestion and a Timestamp for the last time it was updated.
+
+Produces:
+- application/json
+
+Schemes: http, https
+
+Security:
+
+	bearer_token:
+
+Responses:
+
+	200: AttributionFileStatusResponse
+	404: notFoundResponse
+*/
+func AttributionStatus(w http.ResponseWriter, r *http.Request) {
+	h.AttributionStatus(w, r)
+}
+
+/*
+swagger:route GET /api/v3/metadata metadatav3 metadata
+
+# Get metadata
+
+Returns metadata about the API.
+
+Produces:
+- application/fhir+json
+
+Schemes: http, https
+
+Responses:
+
+	200: MetadataResponse
+*/
+func Metadata(w http.ResponseWriter, r *http.Request) {
+	dt := time.Now()
+	bbServer := conf.GetEnv("BB_SERVER_LOCATION")
+
+	scheme := "http"
+	if servicemux.IsHTTPS(r) {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
+
+	statement := &fhircapabilitystatement.CapabilityStatement{
+		Status: &fhircapabilitystatement.CapabilityStatement_StatusCode{Value: fhircodes.PublicationStatusCode_ACTIVE},
+		Date: &fhirdatatypes.DateTime{
+			ValueUs:   dt.UTC().UnixNano() / int64(time.Microsecond),
+			Timezone:  time.UTC.String(),
+			Precision: fhirdatatypes.DateTime_SECOND,
+		},
+		Publisher: &fhirdatatypes.String{Value: "Centers for Medicare & Medicaid Services"},
+		Kind:      &fhircapabilitystatement.CapabilityStatement_KindCode{Value: fhircodes.CapabilityStatementKindCode_INSTANCE},
+		Instantiates: []*fhirdatatypes.Canonical{
+			{Value: bbServer + "/v3/fhir/metadata"},
+			{Value: "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data"},
+		},
+		Software: &fhircapabilitystatement.CapabilityStatement_Software{
+			Name:    &fhirdatatypes.String{Value: "Beneficiary Claims Data API"},
+			Version: &fhirdatatypes.String{Value: constants.Version},
+			ReleaseDate: &fhirdatatypes.DateTime{
+				ValueUs:   dt.UTC().UnixNano() / int64(time.Microsecond),
+				Timezone:  time.UTC.String(),
+				Precision: fhirdatatypes.DateTime_SECOND,
+			},
+		},
+		Implementation: &fhircapabilitystatement.CapabilityStatement_Implementation{
+			Description: &fhirdatatypes.String{Value: "The Beneficiary Claims Data API (BCDA) enables Accountable Care Organizations (ACOs) participating in the Shared Savings Program to retrieve Medicare Part A, Part B, and Part D claims data for their prospectively assigned or assignable beneficiaries."},
+			Url:         &fhirdatatypes.Url{Value: baseURL},
+		},
+		FhirVersion: &fhircapabilitystatement.CapabilityStatement_FhirVersionCode{Value: fhircodes.FHIRVersionCode_V_4_0_1},
+		Format: []*fhircapabilitystatement.CapabilityStatement_FormatCode{
+			{Value: "application/json"},
+			{Value: "application/fhir+json"},
+		},
+		Rest: []*fhircapabilitystatement.CapabilityStatement_Rest{
+			{
+				Mode: &fhircapabilitystatement.CapabilityStatement_Rest_ModeCode{Value: fhircodes.RestfulCapabilityModeCode_SERVER},
+				Security: &fhircapabilitystatement.CapabilityStatement_Rest_Security{
+					Cors: &fhirdatatypes.Boolean{Value: true},
+					Service: []*fhirdatatypes.CodeableConcept{
+						{
+							Coding: []*fhirdatatypes.Coding{
+								{
+									Display: &fhirdatatypes.String{Value: "OAuth"},
+									Code:    &fhirdatatypes.Code{Value: "OAuth"},
+									System:  &fhirdatatypes.Uri{Value: "http://terminology.hl7.org/CodeSystem/restful-security-service"},
+								},
+							},
+							Text: &fhirdatatypes.String{Value: "OAuth"},
+						},
+					},
+					Extension: []*fhirdatatypes.Extension{
+						{
+							Url: &fhirdatatypes.Uri{Value: "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"},
+							Extension: []*fhirdatatypes.Extension{
+								{
+									Url: &fhirdatatypes.Uri{Value: "token"},
+									Value: &fhirdatatypes.Extension_ValueX{
+										Choice: &fhirdatatypes.Extension_ValueX_Uri{
+											Uri: &fhirdatatypes.Uri{Value: baseURL + "/auth/token"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Interaction: []*fhircapabilitystatement.CapabilityStatement_Rest_SystemInteraction{
+					{
+						Code: &fhircapabilitystatement.CapabilityStatement_Rest_SystemInteraction_CodeType{Value: fhirvaluesets.SystemRestfulInteractionValueSet_BATCH},
+					},
+					{
+						Code: &fhircapabilitystatement.CapabilityStatement_Rest_SystemInteraction_CodeType{Value: fhirvaluesets.SystemRestfulInteractionValueSet_SEARCH_SYSTEM},
+					},
+				},
+				Resource: []*fhircapabilitystatement.CapabilityStatement_Rest_Resource{
+					{
+						Type: &fhircapabilitystatement.CapabilityStatement_Rest_Resource_TypeCode{Value: fhircodes.ResourceTypeCode_PATIENT},
+						Operation: []*fhircapabilitystatement.CapabilityStatement_Rest_Resource_Operation{
+							{
+								Name:       &fhirdatatypes.String{Value: "patient-export"},
+								Definition: &fhirdatatypes.Canonical{Value: "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"},
+							},
+						},
+					},
+					{
+						Type: &fhircapabilitystatement.CapabilityStatement_Rest_Resource_TypeCode{Value: fhircodes.ResourceTypeCode_GROUP},
+						Operation: []*fhircapabilitystatement.CapabilityStatement_Rest_Resource_Operation{
+							{
+								Name:       &fhirdatatypes.String{Value: "group-export"},
+								Definition: &fhirdatatypes.Canonical{Value: "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resource := &fhirresources.ContainedResource{
+		OneofResource: &fhirresources.ContainedResource_CapabilityStatement{CapabilityStatement: statement},
+	}
+	b, err := marshaller.Marshal(resource)
+	if err != nil {
+		log.API.Errorf("Failed to marshal Capability Statement %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set(constants.ContentType, constants.JsonContentType)
+	if _, err = w.Write(b); err != nil {
+		log.API.Errorf("Failed to write data %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/bcda/api/v3/api_test.go
+++ b/bcda/api/v3/api_test.go
@@ -1,0 +1,658 @@
+package v3
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CMSgov/bcda-app/bcda/api"
+	"github.com/CMSgov/bcda-app/bcda/auth"
+	"github.com/CMSgov/bcda-app/bcda/client"
+	"github.com/CMSgov/bcda-app/bcda/constants"
+	"github.com/CMSgov/bcda-app/bcda/database"
+	"github.com/CMSgov/bcda-app/bcda/models"
+	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
+	"github.com/CMSgov/bcda-app/bcda/service"
+	"github.com/CMSgov/bcda-app/bcda/web/middleware"
+	"github.com/CMSgov/bcda-app/conf"
+	"github.com/CMSgov/bcda-app/log"
+	"github.com/sirupsen/logrus"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/fhir/go/fhirversion"
+	"github.com/google/fhir/go/jsonformat"
+	fhircodes "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
+	fhirresources "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
+	fhiroo "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/operation_outcome_go_proto"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	expiryHeaderFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+)
+
+var (
+	acoUnderTest = uuid.Parse(constants.LargeACOUUID)
+)
+
+type APITestSuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func (s *APITestSuite) SetupSuite() {
+	origDate := conf.GetEnv("CCLF_REF_DATE")
+	conf.SetEnv(s.T(), "CCLF_REF_DATE", time.Now().Format("060102 15:01:01"))
+	conf.SetEnv(s.T(), "BB_REQUEST_RETRY_INTERVAL_MS", "10")
+	origBBCert := conf.GetEnv("BB_CLIENT_CERT_FILE")
+	conf.SetEnv(s.T(), "BB_CLIENT_CERT_FILE", "../../../shared_files/decrypted/bfd-dev-test-cert.pem")
+	origBBKey := conf.GetEnv("BB_CLIENT_KEY_FILE")
+	conf.SetEnv(s.T(), "BB_CLIENT_KEY_FILE", "../../../shared_files/decrypted/bfd-dev-test-key.pem")
+
+	s.T().Cleanup(func() {
+		conf.SetEnv(s.T(), "CCLF_REF_DATE", origDate)
+		conf.SetEnv(s.T(), "BB_CLIENT_CERT_FILE", origBBCert)
+		conf.SetEnv(s.T(), "BB_CLIENT_KEY_FILE", origBBKey)
+	})
+
+	s.db = database.Connection
+
+	// Set up the logger since we're using the real client
+	client.SetLogger(log.BBAPI)
+}
+
+func (s *APITestSuite) TearDownTest() {
+	postgrestest.DeleteJobsByACOID(s.T(), s.db, acoUnderTest)
+}
+
+func TestAPITestSuite(t *testing.T) {
+	suite.Run(t, new(APITestSuite))
+}
+
+func (s *APITestSuite) TestJobStatusBadInputs() {
+	tests := []struct {
+		name          string
+		jobID         string
+		expStatusCode int
+		expErrCode    string
+	}{
+		{"InvalidJobID", "abcd", 400, "could not parse job id"},
+		{"DoesNotExist", "0", 404, "Job not found."},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v3/jobs/%s", tt.jobID), nil)
+			rr := httptest.NewRecorder()
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("jobID", tt.jobID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			ad := s.makeContextValues(acoUnderTest)
+			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+
+			JobStatus(rr, req)
+
+			respOO := getOperationOutcome(t, rr.Body.Bytes())
+
+			assert.Equal(t, fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+			assert.Equal(t, fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+			assert.Equal(t, tt.expErrCode, respOO.Issue[0].Diagnostics.Value)
+		})
+	}
+}
+
+func (s *APITestSuite) TestJobStatusNotComplete() {
+	tests := []struct {
+		status        models.JobStatus
+		expStatusCode int
+	}{
+		{models.JobStatusPending, http.StatusAccepted},
+		{models.JobStatusInProgress, http.StatusAccepted},
+		{models.JobStatusFailed, http.StatusInternalServerError},
+		{models.JobStatusFailedExpired, http.StatusInternalServerError},
+		{models.JobStatusExpired, http.StatusGone},
+		{models.JobStatusArchived, http.StatusGone},
+		{models.JobStatusCancelled, http.StatusNotFound},
+		{models.JobStatusCancelledExpired, http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(string(tt.status), func(t *testing.T) {
+			j := models.Job{
+				ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+				RequestURL: constants.V3Path + constants.PatientEOBPath,
+				Status:     tt.status,
+			}
+			postgrestest.CreateJobs(t, s.db, &j)
+			defer postgrestest.DeleteJobByID(t, s.db, j.ID)
+
+			req := s.createJobStatusRequest(acoUnderTest, j.ID)
+			rr := httptest.NewRecorder()
+
+			JobStatus(rr, req)
+			assert.Equal(t, tt.expStatusCode, rr.Code)
+			switch rr.Code {
+			case http.StatusAccepted:
+				assert.Contains(t, rr.Header().Get("X-Progress"), tt.status)
+				assert.Equal(t, "", rr.Header().Get("Expires"))
+			case http.StatusInternalServerError:
+				assert.Contains(t, rr.Body.String(), "Service encountered numerous errors")
+			case http.StatusGone:
+				assertExpiryEquals(t, j.CreatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
+			}
+		})
+	}
+}
+
+// https://stackoverflow.com/questions/34585957/postgresql-9-3-how-to-insert-upper-case-uuid-into-table
+func (s *APITestSuite) TestJobStatusCompleted() {
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: constants.V3Path + constants.PatientEOBPath,
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+
+	var expectedUrls []string
+	for i := 1; i <= 10; i++ {
+		fileName := fmt.Sprintf("%s.ndjson", uuid.NewRandom().String())
+		expectedurl := fmt.Sprintf("%s/%s/%s", constants.ExpectedTestUrl, fmt.Sprint(j.ID), fileName)
+		expectedUrls = append(expectedUrls, expectedurl)
+		postgrestest.CreateJobKeys(s.T(), s.db,
+			models.JobKey{JobID: j.ID, FileName: fileName, ResourceType: "ExplanationOfBenefit"})
+	}
+
+	req := s.createJobStatusRequest(acoUnderTest, j.ID)
+	rr := httptest.NewRecorder()
+
+	JobStatus(rr, req)
+
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+	assert.Equal(s.T(), constants.JsonContentType, rr.Header().Get(constants.ContentType))
+	str := rr.Header().Get("Expires")
+	fmt.Println(str)
+	assertExpiryEquals(s.T(), j.CreatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
+
+	var rb api.BulkResponseBody
+	err := json.Unmarshal(rr.Body.Bytes(), &rb)
+	if err != nil {
+		s.T().Error(err)
+	}
+
+	assert.Equal(s.T(), j.RequestURL, rb.RequestURL)
+	assert.Equal(s.T(), true, rb.RequiresAccessToken)
+	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
+	assert.Equal(s.T(), len(expectedUrls), len(rb.Files))
+	// Order of these values is impossible to know so this is the only way
+	for _, fileItem := range rb.Files {
+		inOutput := false
+		for _, expectedUrl := range expectedUrls {
+			if fileItem.URL == expectedUrl {
+				inOutput = true
+				break
+			}
+		}
+		assert.True(s.T(), inOutput)
+
+	}
+	assert.Empty(s.T(), rb.Errors)
+}
+
+func (s *APITestSuite) TestJobStatusCompletedErrorFileExists() {
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: constants.V3Path + constants.PatientEOBPath,
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+
+	fileName := fmt.Sprintf("%s.ndjson", uuid.NewRandom().String())
+	jobKey := models.JobKey{
+		JobID:        j.ID,
+		FileName:     fileName,
+		ResourceType: "ExplanationOfBenefit",
+	}
+	postgrestest.CreateJobKeys(s.T(), s.db, jobKey)
+
+	f := fmt.Sprintf("%s/%s", conf.GetEnv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID))
+	if _, err := os.Stat(f); os.IsNotExist(err) {
+		err = os.MkdirAll(f, os.ModePerm)
+		if err != nil {
+			s.T().Error(err)
+		}
+	}
+
+	errFileName := strings.Split(jobKey.FileName, ".")[0]
+	errFilePath := fmt.Sprintf("%s/%s/%s-error.ndjson", conf.GetEnv("FHIR_PAYLOAD_DIR"), fmt.Sprint(j.ID), errFileName)
+	_, err := os.Create(errFilePath)
+	if err != nil {
+		s.T().Error(err)
+	}
+
+	req := s.createJobStatusRequest(acoUnderTest, j.ID)
+	rr := httptest.NewRecorder()
+
+	JobStatus(rr, req)
+
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+	assert.Equal(s.T(), constants.JsonContentType, rr.Header().Get(constants.ContentType))
+
+	var rb api.BulkResponseBody
+	err = json.Unmarshal(rr.Body.Bytes(), &rb)
+	if err != nil {
+		s.T().Error(err)
+	}
+
+	dataurl := fmt.Sprintf("%s/%s/%s", constants.ExpectedTestUrl, fmt.Sprint(j.ID), fileName)
+	errorurl := fmt.Sprintf("%s/%s/%s-error.ndjson", constants.ExpectedTestUrl, fmt.Sprint(j.ID), errFileName)
+
+	assert.Equal(s.T(), j.RequestURL, rb.RequestURL)
+	assert.Equal(s.T(), true, rb.RequiresAccessToken)
+	assert.Equal(s.T(), "ExplanationOfBenefit", rb.Files[0].Type)
+	assert.Equal(s.T(), dataurl, rb.Files[0].URL)
+	for _, file := range rb.Files {
+		assert.NotContains(s.T(), file.URL, "-error.ndjson")
+	}
+	assert.Equal(s.T(), "OperationOutcome", rb.Errors[0].Type)
+	assert.Equal(s.T(), errorurl, rb.Errors[0].URL)
+
+	os.Remove(errFilePath)
+}
+
+// This job is old, but has not yet been marked as expired.
+func (s *APITestSuite) TestJobStatusNotExpired() {
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: constants.V3Path + constants.PatientEOBPath,
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+
+	j.UpdatedAt = time.Now().Add(-(h.JobTimeout + time.Second))
+	postgrestest.UpdateJob(s.T(), s.db, j)
+
+	req := s.createJobStatusRequest(acoUnderTest, j.ID)
+	rr := httptest.NewRecorder()
+
+	JobStatus(rr, req)
+
+	assert.Equal(s.T(), http.StatusGone, rr.Code)
+	assertExpiryEquals(s.T(), j.UpdatedAt.Add(h.JobTimeout), rr.Header().Get("Expires"))
+}
+
+func (s *APITestSuite) TestJobsStatus() {
+	req := httptest.NewRequest("GET", "/api/v3/jobs", nil)
+	ad := s.makeContextValues(acoUnderTest)
+	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	rr := httptest.NewRecorder()
+
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v3/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+	defer postgrestest.DeleteJobByID(s.T(), s.db, j.ID)
+
+	JobsStatus(rr, req)
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+}
+
+func (s *APITestSuite) TestJobsStatusNotFound() {
+	req := httptest.NewRequest("GET", "/api/v3/jobs", nil)
+	ad := s.makeContextValues(acoUnderTest)
+	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	rr := httptest.NewRecorder()
+
+	JobsStatus(rr, req)
+	assert.Equal(s.T(), http.StatusNotFound, rr.Code)
+}
+
+func (s *APITestSuite) TestJobsStatusNotFoundWithStatus() {
+	req := httptest.NewRequest("GET", "/api/v3/jobs?_status=Failed", nil)
+	ad := s.makeContextValues(acoUnderTest)
+	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	rr := httptest.NewRecorder()
+
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v3/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusCompleted,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+	defer postgrestest.DeleteJobByID(s.T(), s.db, j.ID)
+
+	JobsStatus(rr, req)
+	assert.Equal(s.T(), http.StatusNotFound, rr.Code)
+}
+
+func (s *APITestSuite) TestJobsStatusWithStatus() {
+	req := httptest.NewRequest("GET", "/api/v3/jobs?_status=Failed", nil)
+	ad := s.makeContextValues(acoUnderTest)
+	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	rr := httptest.NewRecorder()
+
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v3/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusFailed,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+	defer postgrestest.DeleteJobByID(s.T(), s.db, j.ID)
+
+	JobsStatus(rr, req)
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+}
+
+func (s *APITestSuite) TestJobsStatusWithStatuses() {
+	req := httptest.NewRequest("GET", "/api/v3/jobs?_status=Completed,Failed", nil)
+	ad := s.makeContextValues(acoUnderTest)
+	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	rr := httptest.NewRecorder()
+
+	j := models.Job{
+		ACOID:      acoUnderTest,
+		RequestURL: "/api/v3/Patient/$export?_type=ExplanationOfBenefit",
+		Status:     models.JobStatusFailed,
+	}
+	postgrestest.CreateJobs(s.T(), s.db, &j)
+	defer postgrestest.DeleteJobByID(s.T(), s.db, j.ID)
+
+	JobsStatus(rr, req)
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+}
+
+func (s *APITestSuite) TestDeleteJobBadInputs() {
+	tests := []struct {
+		name          string
+		jobID         string
+		expStatusCode int
+		expErrCode    string
+	}{
+		{"InvalidJobID", "abcd", 400, "could not parse job id"},
+		{"DoesNotExist", "0", 404, "Job not found."},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v3/jobs/%s", tt.jobID), nil)
+			rr := httptest.NewRecorder()
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("jobID", tt.jobID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			ad := s.makeContextValues(acoUnderTest)
+			req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+			JobStatus(rr, req)
+
+			respOO := getOperationOutcome(t, rr.Body.Bytes())
+
+			assert.Equal(t, fhircodes.IssueSeverityCode_ERROR, respOO.Issue[0].Severity.Value)
+			assert.Equal(t, fhircodes.IssueTypeCode_EXCEPTION, respOO.Issue[0].Code.Value)
+			assert.Equal(t, tt.expErrCode, respOO.Issue[0].Diagnostics.Value)
+		})
+	}
+}
+
+func (s *APITestSuite) TestDeleteJob() {
+	tests := []struct {
+		status        models.JobStatus
+		expStatusCode int
+	}{
+		{models.JobStatusPending, http.StatusAccepted},
+		{models.JobStatusInProgress, http.StatusAccepted},
+		{models.JobStatusFailed, http.StatusGone},
+		{models.JobStatusExpired, http.StatusGone},
+		{models.JobStatusArchived, http.StatusGone},
+		{models.JobStatusCompleted, http.StatusGone},
+		{models.JobStatusCancelled, http.StatusGone},
+		{models.JobStatusFailedExpired, http.StatusGone},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(string(tt.status), func(t *testing.T) {
+			j := models.Job{
+				ACOID:      uuid.Parse("DBBD1CE1-AE24-435C-807D-ED45953077D3"),
+				RequestURL: "/api/v3/Patient/$export?_type=Patient,Coverage",
+				Status:     tt.status,
+			}
+			postgrestest.CreateJobs(t, s.db, &j)
+			defer postgrestest.DeleteJobByID(t, s.db, j.ID)
+
+			req := s.createJobStatusRequest(acoUnderTest, j.ID)
+			rr := httptest.NewRecorder()
+
+			newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+			req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+
+			DeleteJob(rr, req)
+			assert.Equal(t, tt.expStatusCode, rr.Code)
+			if rr.Code == http.StatusGone {
+				assert.Contains(t, rr.Body.String(), "job was not cancelled because it is not Pending or In Progress")
+			}
+		})
+	}
+}
+func (s *APITestSuite) TestMetadataResponse() {
+	ts := httptest.NewServer(http.HandlerFunc(Metadata))
+	defer ts.Close()
+
+	unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.R4)
+	assert.NoError(s.T(), err)
+
+	res, err := http.Get(ts.URL)
+	assert.NoError(s.T(), err)
+
+	assert.Equal(s.T(), "application/json", res.Header.Get(constants.ContentType))
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
+
+	resp, err := io.ReadAll(res.Body)
+	assert.NoError(s.T(), err)
+
+	resource, err := unmarshaller.Unmarshal(resp)
+	assert.NoError(s.T(), err)
+	cs := resource.(*fhirresources.ContainedResource).GetCapabilityStatement()
+
+	// Expecting an R4 response so we'll evaluate some fields to reflect that
+	assert.Equal(s.T(), fhircodes.FHIRVersionCode_V_4_0_1, cs.FhirVersion.Value)
+	assert.Equal(s.T(), 1, len(cs.Rest))
+	assert.Equal(s.T(), 2, len(cs.Rest[0].Resource))
+	assert.Len(s.T(), cs.Instantiates, 2)
+	assert.Contains(s.T(), cs.Instantiates[0].Value, "/v3/fhir/metadata")
+	resourceData := []struct {
+		rt           fhircodes.ResourceTypeCode_Value
+		opName       string
+		opDefinition string
+	}{
+		{fhircodes.ResourceTypeCode_PATIENT, "patient-export", "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"},
+		{fhircodes.ResourceTypeCode_GROUP, "group-export", "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"},
+	}
+
+	for _, rd := range resourceData {
+		for _, r := range cs.Rest[0].Resource {
+			if r.Type.Value == rd.rt {
+				assert.NotNil(s.T(), r)
+				assert.Equal(s.T(), 1, len(r.Operation))
+				assert.Equal(s.T(), rd.opName, r.Operation[0].Name.Value)
+				assert.Equal(s.T(), rd.opDefinition, r.Operation[0].Definition.Value)
+				break
+			}
+		}
+	}
+
+	extensions := cs.Rest[0].Security.Extension
+	assert.Len(s.T(), extensions, 1)
+	assert.Equal(s.T(), "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris", extensions[0].Url.Value)
+
+	subExtensions := extensions[0].Extension
+	assert.Len(s.T(), subExtensions, 1)
+	assert.Equal(s.T(), "token", subExtensions[0].Url.Value)
+	assert.Equal(s.T(), ts.URL+"/auth/token", subExtensions[0].GetValue().GetUri().Value)
+
+}
+
+func (s *APITestSuite) TestResourceTypes() {
+	tests := []struct {
+		name          string
+		resourceTypes []string
+		statusCode    int
+	}{
+		{"Supported type - Patient", []string{"Patient"}, http.StatusAccepted},
+		{"Supported type - Coverage", []string{"Coverage"}, http.StatusAccepted},
+		{"Supported type - Patient,Coverage", []string{"Patient", "Coverage"}, http.StatusAccepted},
+		{"Supported type - EOB", []string{"ExplanationOfBenefit"}, http.StatusAccepted},
+		{"Supported type - default", nil, http.StatusAccepted},
+	}
+
+	resources, _ := service.GetDataTypes([]string{
+		"Patient",
+		"Coverage",
+		"ExplanationOfBenefit",
+	}...)
+
+	h := api.NewHandler(resources, "/v3/fhir", "v3")
+	mockSvc := &service.MockService{}
+
+	mockSvc.On("GetQueJobs", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*models.JobEnqueueArgs{}, nil)
+	mockAco := service.ACOConfig{
+		Data: []string{"adjudicated"},
+	}
+	mockSvc.On("GetACOConfigForID", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockAco, true)
+
+	h.Svc = mockSvc
+
+	for idx, handler := range []http.HandlerFunc{h.BulkGroupRequest, h.BulkPatientRequest} {
+		for _, tt := range tests {
+			s.T().Run(fmt.Sprintf("%s-%d", tt.name, idx), func(t *testing.T) {
+				rr := httptest.NewRecorder()
+
+				ep := "Group"
+				if idx == 1 {
+					ep = "Patient"
+				}
+
+				u, err := url.Parse(fmt.Sprintf("/api/v3/%s/$export", ep))
+				assert.NoError(t, err)
+
+				rp := middleware.RequestParameters{
+					Version:       "v3",
+					ResourceTypes: tt.resourceTypes,
+				}
+
+				req := httptest.NewRequest("GET", u.String(), nil)
+				rctx := chi.NewRouteContext()
+				rctx.URLParams.Add("groupId", "all")
+				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+				ad := s.getAuthData()
+				req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+				req = req.WithContext(middleware.SetRequestParamsCtx(req.Context(), rp))
+				newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+				req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+
+				handler(rr, req)
+				assert.Equal(t, tt.statusCode, rr.Code)
+				assert.Empty(t, rr.Body.String())
+				if rr.Code == http.StatusAccepted {
+					assert.NotEmpty(t, rr.Header().Get("Content-Location"))
+				}
+			})
+		}
+	}
+}
+
+func (s *APITestSuite) TestGetAttributionStatus() {
+	req := httptest.NewRequest("GET", "/api/v3/attribution_status", nil)
+	ad := s.makeContextValues(acoUnderTest)
+	req = req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	rr := httptest.NewRecorder()
+
+	AttributionStatus(rr, req)
+	assert.Equal(s.T(), http.StatusOK, rr.Code)
+
+	var resp api.AttributionFileStatusResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	assert.NoError(s.T(), err)
+
+	aco := postgrestest.GetACOByUUID(s.T(), s.db, acoUnderTest)
+	cclfFile := postgrestest.GetLatestCCLFFileByCMSIDAndType(s.T(), s.db, *aco.CMSID, models.FileTypeDefault)
+
+	assert.Equal(s.T(), "last_attribution_update", resp.Data[0].Type)
+	assert.Equal(s.T(), cclfFile.Timestamp.Format("2006-01-02 15:04:05"), resp.Data[0].Timestamp.Format("2006-01-02 15:04:05"))
+}
+
+func (s *APITestSuite) getAuthData() (data auth.AuthData) {
+	aco := postgrestest.GetACOByUUID(s.T(), s.db, acoUnderTest)
+	return auth.AuthData{ACOID: acoUnderTest.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
+}
+
+func (s *APITestSuite) makeContextValues(acoID uuid.UUID) (data auth.AuthData) {
+	aco := postgrestest.GetACOByUUID(s.T(), s.db, acoID)
+	return auth.AuthData{ACOID: aco.UUID.String(), CMSID: *aco.CMSID, TokenID: uuid.NewRandom().String()}
+}
+
+func (s *APITestSuite) createJobStatusRequest(acoID uuid.UUID, jobID uint) *http.Request {
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v3/jobs/%d", jobID), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("jobID", fmt.Sprint(jobID))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	ad := s.makeContextValues(acoID)
+	newLogEntry := MakeTestStructuredLoggerEntry(logrus.Fields{"cms_id": "A9999", "request_id": uuid.NewRandom().String()})
+	req = req.WithContext(context.WithValue(req.Context(), log.CtxLoggerKey, newLogEntry))
+	return req.WithContext(context.WithValue(req.Context(), auth.AuthDataContextKey, ad))
+}
+
+// Compare expiry header against the expected time value.
+// There seems to be some slight difference in precision here,
+// so we'll compare up to seconds
+func assertExpiryEquals(t *testing.T, expectedTime time.Time, expiry string) {
+	expiryTime, err := time.Parse(expiryHeaderFormat, expiry)
+	if err != nil {
+		t.Fatalf("Failed to parse %s to time.Time %s", expiry, err)
+	}
+
+	assert.Equal(t, time.Duration(0), expectedTime.Round(time.Second).Sub(expiryTime.Round(time.Second)))
+}
+
+func getOperationOutcome(t *testing.T, data []byte) *fhiroo.OperationOutcome {
+	unmarshaller, err := jsonformat.NewUnmarshaller("UTC", fhirversion.R4)
+	assert.NoError(t, err)
+	container, err := unmarshaller.Unmarshal(data)
+	assert.NoError(t, err)
+	return container.(*fhirresources.ContainedResource).GetOperationOutcome()
+}
+
+func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *log.StructuredLoggerEntry {
+	var lggr logrus.Logger
+	newLogEntry := &log.StructuredLoggerEntry{Logger: lggr.WithFields(logFields)}
+	return newLogEntry
+}

--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -211,6 +211,8 @@ func getRespWriter(path string) fhirResponseWriter {
 		return responseutils.NewResponseWriter()
 	} else if strings.Contains(path, "/v2/") {
 		return responseutilsv2.NewResponseWriter()
+	} else if strings.Contains(path, "/v3/") {
+		return responseutilsv2.NewResponseWriter() // TODO: V3
 	} else {
 		// CommonAuth is used in requests not exclusive to v1 or v2 (ie data requests or /_version).
 		// In the cases we cannot discern a version we default to v1

--- a/bcda/constants/test_constants.go
+++ b/bcda/constants/test_constants.go
@@ -18,6 +18,7 @@ const TestRouter = "Test router"
 // Path Constants
 const V1Path = "/api/v1/"
 const V2Path = "/api/v2/"
+const V3Path = "/api/v3/"
 const EOBExportPath = "ExplanationOfBenefit/$export"
 const PatientEOBPath = "Patient/$export?_type=ExplanationOfBenefit"
 const GroupExportPath = "Group/all/$export"

--- a/bcda/constants/test_constants.go
+++ b/bcda/constants/test_constants.go
@@ -18,7 +18,7 @@ const TestRouter = "Test router"
 // Path Constants
 const V1Path = "/api/v1/"
 const V2Path = "/api/v2/"
-const V3Path = "/api/v3/"
+const V3Path = "/api/demo/"
 const EOBExportPath = "ExplanationOfBenefit/$export"
 const PatientEOBPath = "Patient/$export?_type=ExplanationOfBenefit"
 const GroupExportPath = "Group/all/$export"

--- a/bcda/logging/middleware.go
+++ b/bcda/logging/middleware.go
@@ -148,6 +148,8 @@ func getRespWriter(path string) fhirResponseWriter {
 		return responseutils.NewResponseWriter()
 	} else if strings.Contains(path, "/v2/") {
 		return responseutilsv2.NewResponseWriter()
+	} else if strings.Contains(path, "/v3/") {
+		return responseutilsv2.NewResponseWriter() // TODO: V3
 	} else {
 		return responseutils.NewResponseWriter()
 	}

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -10,7 +10,6 @@ import (
 
 	responseutils "github.com/CMSgov/bcda-app/bcda/responseutils"
 	responseutilsv2 "github.com/CMSgov/bcda-app/bcda/responseutils/v2"
-	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/log"
 )
 
@@ -24,10 +23,10 @@ type RequestParameters struct {
 	ResourceTypes []string
 	Version       string // e.g. v1, v2
 	RequestURL    string
-	TypeFilter    string
+	// TypeFilter    string
 }
 
-const BBSystemURL = "https://bluebutton.cms.gov/fhir/CodeSystem/Adjudication-Status"
+// const BBSystemURL = "https://bluebutton.cms.gov/fhir/CodeSystem/Adjudication-Status"
 
 // requestkey is an unexported context key to avoid collisions
 type requestkey int
@@ -127,25 +126,25 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 		}
 
 		// TODO: V3 _typeFilter
-		params, ok = r.URL.Query()["_typeFilter"]
-		if ok {
-			allowedQueryParams := []string{
-				"ExplanationOfBenefit?",
-				"ExplanationOfBenefit?tag=PartiallyAdjudicated",
-				"ExplanationOfBenefit?_tag=Adjudicated",
-				"ExplanationOfBenefit?_tag=PartiallyAdjudicated,Adjudicated",
-				"ExplanationOfBenefit?_source=FISS",
-				"ExplanationOfBenefit?_source=MCS",
-			}
-			if utils.ContainsString(allowedQueryParams, params[0]) {
-				rp.TypeFilter = params[0]
-			} else {
-				errMsg := fmt.Sprintf("invalid _typeFilter (or currently unimplemented query) %s", params[0])
-				log.API.Error(errMsg)
-				rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
-				return
-			}
-		}
+		// params, ok = r.URL.Query()["_typeFilter"]
+		// if ok {
+		// 	allowedQueryParams := []string{
+		// 		"ExplanationOfBenefit?",
+		// 		"ExplanationOfBenefit?tag=PartiallyAdjudicated",
+		// 		"ExplanationOfBenefit?_tag=Adjudicated",
+		// 		"ExplanationOfBenefit?_tag=PartiallyAdjudicated,Adjudicated",
+		// 		"ExplanationOfBenefit?_source=FISS",
+		// 		"ExplanationOfBenefit?_source=MCS",
+		// 	}
+		// 	if utils.ContainsString(allowedQueryParams, params[0]) {
+		// 		rp.TypeFilter = params[0]
+		// 	} else {
+		// 		errMsg := fmt.Sprintf("invalid _typeFilter (or currently unimplemented query) %s", params[0])
+		// 		log.API.Error(errMsg)
+		// 		rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
+		// 		return
+		// 	}
+		// }
 
 		ctx := SetRequestParamsCtx(r.Context(), rp)
 

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -10,6 +10,7 @@ import (
 
 	responseutils "github.com/CMSgov/bcda-app/bcda/responseutils"
 	responseutilsv2 "github.com/CMSgov/bcda-app/bcda/responseutils/v2"
+	"github.com/CMSgov/bcda-app/bcda/utils"
 	"github.com/CMSgov/bcda-app/log"
 )
 
@@ -23,7 +24,10 @@ type RequestParameters struct {
 	ResourceTypes []string
 	Version       string // e.g. v1, v2
 	RequestURL    string
+	TypeFilter    string
 }
+
+const BBSystemURL = "https://bluebutton.cms.gov/fhir/CodeSystem/Adjudication-Status"
 
 // requestkey is an unexported context key to avoid collisions
 type requestkey int
@@ -120,6 +124,27 @@ func ValidateRequestURL(next http.Handler) http.Handler {
 				}
 			}
 			rp.ResourceTypes = resourceTypes
+		}
+
+		// TODO: V3 _typeFilter
+		params, ok = r.URL.Query()["_typeFilter"]
+		if ok {
+			allowedQueryParams := []string{
+				"ExplanationOfBenefit?",
+				"ExplanationOfBenefit?tag=PartiallyAdjudicated",
+				"ExplanationOfBenefit?_tag=Adjudicated",
+				"ExplanationOfBenefit?_tag=PartiallyAdjudicated,Adjudicated",
+				"ExplanationOfBenefit?_source=FISS",
+				"ExplanationOfBenefit?_source=MCS",
+			}
+			if utils.ContainsString(allowedQueryParams, params[0]) {
+				rp.TypeFilter = params[0]
+			} else {
+				errMsg := fmt.Sprintf("invalid _typeFilter (or currently unimplemented query) %s", params[0])
+				log.API.Error(errMsg)
+				rw.Exception(r.Context(), w, http.StatusBadRequest, responseutils.RequestErr, errMsg)
+				return
+			}
 		}
 
 		ctx := SetRequestParamsCtx(r.Context(), rp)

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -195,6 +195,8 @@ func getRespWriter(version string) (fhirResponseWriter, error) {
 		return responseutils.NewResponseWriter(), nil
 	case "v2":
 		return responseutilsv2.NewResponseWriter(), nil
+	case "v3":
+		return responseutilsv2.NewResponseWriter(), nil // TODO: V3
 	default:
 		return nil, fmt.Errorf("unexpected API version: %s", version)
 	}

--- a/bcda/web/router.go
+++ b/bcda/web/router.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "github.com/CMSgov/bcda-app/bcda/api/v1"
 	v2 "github.com/CMSgov/bcda-app/bcda/api/v2"
+	v3 "github.com/CMSgov/bcda-app/bcda/api/v3"
 	"github.com/CMSgov/bcda-app/bcda/auth"
 	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
@@ -78,6 +79,21 @@ func NewAPIRouter() http.Handler {
 			r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Delete(m.WrapHandler(constants.JOBIDPath, v2.DeleteJob))
 			r.With(commonAuth...).Get(m.WrapHandler("/attribution_status", v2.AttributionStatus))
 			r.Get(m.WrapHandler("/metadata", v2.Metadata))
+		})
+	}
+
+	if utils.GetEnvBool("VERSION_3_ENDPOINT_ACTIVE", true) {
+		r.Route("/api/demo", func(r chi.Router) {
+			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Patient/$export", v3.BulkPatientRequest))
+			if conf.GetEnv("ENABLE_ALR_ENDPOINTS") == "true" {
+				r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/alr/$export", v3.ALRRequest))
+			}
+			r.With(append(commonAuth, requestValidators...)...).Get(m.WrapHandler("/Group/{groupId}/$export", v3.BulkGroupRequest))
+			r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Get(m.WrapHandler(constants.JOBIDPath, v3.JobStatus))
+			r.With(append(commonAuth, nonExportRequestValidators...)...).Get(m.WrapHandler("/jobs", v3.JobsStatus))
+			r.With(append(commonAuth, auth.RequireTokenJobMatch)...).Delete(m.WrapHandler(constants.JOBIDPath, v3.DeleteJob))
+			r.With(commonAuth...).Get(m.WrapHandler("/attribution_status", v3.AttributionStatus))
+			r.Get(m.WrapHandler("/metadata", v3.Metadata))
 		})
 	}
 

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -249,9 +249,9 @@ func (s *RouterTestSuite) TestV2EndpointsEnabled() {
 
 func (s *RouterTestSuite) TestV3EndpointsDisabled() {
 	// Set the V3 endpoints to be off and restart the router so the test router has the correct configuration
-	v3Active := conf.GetEnv("VERSION_2_ENDPOINT_ACTIVE")
-	defer conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", v3Active)
-	conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", "false")
+	v3Active := conf.GetEnv("VERSION_3_ENDPOINT_ACTIVE")
+	defer conf.SetEnv(s.T(), "VERSION_3_ENDPOINT_ACTIVE", v3Active)
+	conf.SetEnv(s.T(), "VERSION_3_ENDPOINT_ACTIVE", "false")
 	s.apiRouter = NewAPIRouter()
 
 	res := s.getAPIRoute(constants.V3Path + constants.PatientExportPath)
@@ -268,9 +268,9 @@ func (s *RouterTestSuite) TestV3EndpointsDisabled() {
 
 func (s *RouterTestSuite) TestV3EndpointsEnabled() {
 	// Set the V3 endpoints to be on and restart the router so the test router has the correct configuration
-	v3Active := conf.GetEnv("VERSION_2_ENDPOINT_ACTIVE")
-	defer conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", v3Active)
-	conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", "true")
+	v3Active := conf.GetEnv("VERSION_3_ENDPOINT_ACTIVE")
+	defer conf.SetEnv(s.T(), "VERSION_3_ENDPOINT_ACTIVE", v3Active)
+	conf.SetEnv(s.T(), "VERSION_3_ENDPOINT_ACTIVE", "true")
 	s.apiRouter = NewAPIRouter()
 
 	res := s.getAPIRoute(constants.V3Path + constants.PatientExportPath)

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -260,9 +260,9 @@ func (s *RouterTestSuite) TestV3EndpointsDisabled() {
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 	res = s.getAPIRoute(constants.V3Path + constants.ALRExportPath)
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
-	res = s.getAPIRoute("/api/v3/jobs/{jobID}")
+	res = s.getAPIRoute(constants.V3Path + "jobs/{jobID}")
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
-	res = s.getAPIRoute("/api/v3/metadata")
+	res = s.getAPIRoute(constants.V3Path + "metadata")
 	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
 }
 
@@ -279,13 +279,13 @@ func (s *RouterTestSuite) TestV3EndpointsEnabled() {
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
 	res = s.getAPIRoute(constants.V3Path + constants.ALRExportPath)
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
-	res = s.getAPIRoute("/api/v3/jobs/{jobID}")
+	res = s.getAPIRoute(constants.V3Path + "jobs/{jobID}")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
-	res = s.getAPIRoute("/api/v3/jobs")
+	res = s.getAPIRoute(constants.V3Path + "jobs")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
-	res = s.getAPIRoute("/api/v3/attribution_status")
+	res = s.getAPIRoute(constants.V3Path + "attribution_status")
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
-	res = s.getAPIRoute("/api/v3/metadata")
+	res = s.getAPIRoute(constants.V3Path + "metadata")
 	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 }
 

--- a/bcda/web/router_test.go
+++ b/bcda/web/router_test.go
@@ -247,6 +247,48 @@ func (s *RouterTestSuite) TestV2EndpointsEnabled() {
 	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
 }
 
+func (s *RouterTestSuite) TestV3EndpointsDisabled() {
+	// Set the V3 endpoints to be off and restart the router so the test router has the correct configuration
+	v3Active := conf.GetEnv("VERSION_2_ENDPOINT_ACTIVE")
+	defer conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", v3Active)
+	conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", "false")
+	s.apiRouter = NewAPIRouter()
+
+	res := s.getAPIRoute(constants.V3Path + constants.PatientExportPath)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+	res = s.getAPIRoute(constants.V3Path + constants.GroupExportPath)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+	res = s.getAPIRoute(constants.V3Path + constants.ALRExportPath)
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+	res = s.getAPIRoute("/api/v3/jobs/{jobID}")
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+	res = s.getAPIRoute("/api/v3/metadata")
+	assert.Equal(s.T(), http.StatusNotFound, res.StatusCode)
+}
+
+func (s *RouterTestSuite) TestV3EndpointsEnabled() {
+	// Set the V3 endpoints to be on and restart the router so the test router has the correct configuration
+	v3Active := conf.GetEnv("VERSION_2_ENDPOINT_ACTIVE")
+	defer conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", v3Active)
+	conf.SetEnv(s.T(), "VERSION_2_ENDPOINT_ACTIVE", "true")
+	s.apiRouter = NewAPIRouter()
+
+	res := s.getAPIRoute(constants.V3Path + constants.PatientExportPath)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute(constants.V3Path + constants.GroupExportPath)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute(constants.V3Path + constants.ALRExportPath)
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute("/api/v3/jobs/{jobID}")
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute("/api/v3/jobs")
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute("/api/v3/attribution_status")
+	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)
+	res = s.getAPIRoute("/api/v3/metadata")
+	assert.Equal(s.T(), http.StatusOK, res.StatusCode)
+}
+
 func (s *RouterTestSuite) TestJobStatusRoute() {
 	res := s.getAPIRoute(constants.V1Path + constants.JobsFilePath)
 	assert.Equal(s.T(), http.StatusUnauthorized, res.StatusCode)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9018

## 🛠 Changes

Duplicating v2 routes at /demo namespace to demo out v3 requests to BFD.  Gated by feature flag.  Removal of Claim and Claim Response for v3 requests.  Initial stubbing out of typefilter (commented out for now).

## ℹ️ Context

For the Connectathon we want a barebones functionality for v3 requests to BFD.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
