### PR TITLE
BCDA-9060: Update FHIR Scan to point to dev

### DIFF
--- a/.github/workflows/fhirscan.yml
+++ b/.github/workflows/fhirscan.yml
@@ -25,7 +25,7 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            CLIENT_CREDENTIALS_PARAMS=/bcda/opensbx/small_client_credentials
+            CLIENT_CREDENTIALS_PARAMS=/bcda/dev/dev_client_credentials
       - name: Run Inferno
         id: run
         run: |
@@ -41,4 +41,4 @@ jobs:
           CLIENT_SECRET=$(echo $CLIENT_CREDENTIALS_PARAMS | jq -r .client_secret)
 
           docker build --no-cache -t fhir_testing -f Dockerfiles/Dockerfile.fhir_testing .
-          docker run --add-host=host.docker.internal:host-gateway --rm -e BULK_URL="https://sandbox.bcda.cms.gov/api/v2/" -e CLIENT_ID="$CLIENT_ID" -e CLIENT_SECRET="$CLIENT_SECRET" -e TOKEN_URL="https://sandbox.bcda.cms.gov/auth/token" fhir_testing
+          docker run --add-host=host.docker.internal:host-gateway --rm -e BULK_URL="https://dev.bcda.cms.gov/api/v2/" -e CLIENT_ID="$CLIENT_ID" -e CLIENT_SECRET="$CLIENT_SECRET" -e TOKEN_URL="https://dev.bcda.cms.gov/auth/token" fhir_testing


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9060

## 🛠 Changes

Updated the FHIR Scan workflow to point at the dev deployment instead of sandbox

## ℹ️ Context

initially, i pointed at sandbox to get it working because there were some issues with dev. But it's all good now, and this makes more sense to point at dev.

## 🧪 Validation

Go to the FHIR Scan workflow https://github.com/CMSgov/bcda-app/actions/workflows/fhirscan.yml, click "Run workflow", select a branch (this PR is `colby/BCDA-9060`), and then run. then make sure it passes
