### PR TITLE
BCDA-9225: remove superfluous precommit args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
     rev: v2.2.1
     hooks:
       - id: golangci-lint
-        args: ['--new', '-v', '--fast-only']
+        args: ['-v']


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9225

## 🛠 Changes

Removed args that are unneeded and don't play nicely with newer versions of golangci-lint pre-commit hook

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
