### PR TITLE
BCDA-8772: upgrade golang to 1.24

### DIFF
--- a/Dockerfiles/Dockerfile.bcda_prod
+++ b/Dockerfiles/Dockerfile.bcda_prod
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.20 AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG GO_FLAGS
 RUN apk update upgrade
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install "$GO_FLAGS"
 
 # ------------------------------------------------------------------------
-FROM golang:1.23.1-alpine3.20
+FROM golang:1.24-alpine
 
 ARG ENVIRONMENT
 # only add dev packages if the environment argument was set to development

--- a/Dockerfiles/Dockerfile.bcdaworker_prod
+++ b/Dockerfiles/Dockerfile.bcdaworker_prod
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.20 AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG GO_FLAGS
 RUN apk update upgrade
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install "$GO_FLAGS"
 
 # ------------------------------------------------------------------------
-FROM golang:1.23.1-alpine3.20
+FROM golang:1.24-alpine
 
 ARG ENVIRONMENT
 # only add dev packages if the environment argument was set to development

--- a/Dockerfiles/Dockerfile.package
+++ b/Dockerfiles/Dockerfile.package
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.20
+FROM golang:1.24-alpine
 
 ENV CGO_ENABLED=0
 

--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.23.1-alpine3.20 AS base
+FROM golang:1.24-alpine AS base
 
 RUN apk update upgrade
 RUN apk add git
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go install -v ./ssas/service/main
 
-FROM golang:1.23.1-alpine3.20 AS prod
+FROM golang:1.24-alpine AS prod
 
 RUN apk update upgrade
 RUN apk add openssl

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.23.1-alpine3.20
+FROM golang:1.24-alpine
 
 RUN apk update upgrade
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CMSgov/bcda-app
 
-go 1.23.1
+go 1.24.1
 
 require (
 	github.com/BurntSushi/toml v0.4.1

--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.23.1
+go 1.24.1
+
+toolchain go1.24.4
 
 use (
 	.


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8772

## 🛠 Changes

Upgrade golang to 1.24

## ℹ️ Context

Security updates.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Run full test suite successfully, CI/CD testing tbd.
