### PR TITLE
BCDA-9107: use ssas health endpoint in app health check

### DIFF
--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -510,7 +510,7 @@ func (c *SSASClient) GetVersion() (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.New("SSAS server failed to return version ")
+		return "", errors.New("SSAS server failed to return version")
 	}
 
 	type ssasVersion struct {
@@ -524,4 +524,22 @@ func (c *SSASClient) GetVersion() (string, error) {
 		return "", errors.New("Unable to parse version from response")
 	}
 	return versionInfo.Version, nil
+}
+
+func (c *SSASClient) GetHealth() error {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/_health", c.baseURL), nil)
+	if err != nil {
+		return err
+	}
+	if err := c.setAuthHeader(req); err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("SSAS server health check failed")
+	}
+	return nil
 }

--- a/bcda/auth/client/ssas.go
+++ b/bcda/auth/client/ssas.go
@@ -356,43 +356,6 @@ func (c *SSASClient) GetToken(credentials Credentials, r http.Request) (string, 
 	return fmt.Sprintf(`{"access_token": "%s", "expires_in": "%s", "token_type":"bearer"}`, t.AccessToken, t.ExpiresIn), nil
 }
 
-func (c *SSASClient) Ping() error {
-
-	tokenString := "None"
-	public := conf.GetEnv("SSAS_PUBLIC_URL")
-	url := fmt.Sprintf("%s/introspect", public)
-	body, err := json.Marshal(struct {
-		Token string `json:"token"`
-	}{Token: tokenString})
-	if err != nil {
-		return errors.Wrap(err, constants.RequestStructErr)
-	}
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
-	if err != nil {
-		return errors.Wrap(err, constants.RequestStructErr)
-	}
-
-	clientID := conf.GetEnv("BCDA_SSAS_CLIENT_ID")
-	secret := conf.GetEnv("BCDA_SSAS_SECRET")
-	if clientID == "" || secret == "" {
-		return errors.New(constants.MissingIDSecretErr)
-	}
-	req.SetBasicAuth(clientID, secret)
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "introspect request failed")
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("introspect request failed; %v", resp.StatusCode)
-	}
-
-	return nil
-}
-
 // CallSSASIntrospect verifies that the tokenString presented was issued by the public server.
 // It does so using the introspect endpoint as defined by https://tools.ietf.org/html/rfc7662
 func (c *SSASClient) CallSSASIntrospect(ctx context.Context, tokenString string) ([]byte, error) {

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -296,7 +296,7 @@ func (s *SSASClientTestSuite) TestGetVersionTable() {
 		{header: http.StatusOK, env: EnvVars{SSAS_URL: "localhost"}, errorExpected: true, message: "Get \"localhost/_version\": unsupported protocol scheme \"\"", versionString: "{\"version\":\"foo\"}\n"},
 		{header: http.StatusOK, env: EnvVars{BCDA_SSAS_CLIENT_ID: "-1"}, errorExpected: true, message: "missing clientID or secret", versionString: "{\"version\":\"foo\"}\n"},
 		{header: http.StatusOK, env: EnvVars{}, errorExpected: true, message: "Unable to parse version from response", versionString: "{\"foo\":\"foo\"}\n"},
-		{header: http.StatusBadGateway, env: EnvVars{}, errorExpected: true, message: "SSAS server failed to return version ", versionString: "{\"version\":\"foo\"}\n"},
+		{header: http.StatusBadGateway, env: EnvVars{}, errorExpected: true, message: "SSAS server failed to return version", versionString: "{\"version\":\"foo\"}\n"},
 	}
 
 	for _, tc := range tests {
@@ -331,6 +331,52 @@ func (s *SSASClientTestSuite) TestGetVersionTable() {
 			assert.Equal(s.T(), tc.message, version)
 		}
 
+	}
+}
+
+func (s *SSASClientTestSuite) TestHealthTable() {
+	tests := []struct {
+		header        int
+		env           EnvVars
+		errorExpected bool
+		message       string
+	}{
+		{header: http.StatusOK, env: EnvVars{}, errorExpected: false, message: "foo"},
+		{header: http.StatusOK, env: EnvVars{SSAS_URL: "localhost"}, errorExpected: true, message: "Get \"localhost/_health\": unsupported protocol scheme \"\""},
+		{header: http.StatusOK, env: EnvVars{BCDA_SSAS_CLIENT_ID: "-1"}, errorExpected: true, message: "missing clientID or secret"},
+		{header: http.StatusBadGateway, env: EnvVars{}, errorExpected: true, message: "SSAS server health check failed"},
+	}
+
+	for _, tc := range tests {
+		router := chi.NewRouter()
+		router.Get("/_health", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(tc.header)
+
+			_, err := io.WriteString(w, "{\"database\":\"ok\"}")
+			if err != nil {
+				s.FailNow("Failed to create SSAS server", err.Error())
+			}
+		})
+		server := httptest.NewServer(router)
+
+		conf.SetEnv(s.T(), "SSAS_URL", server.URL)
+		conf.SetEnv(s.T(), "SSAS_PUBLIC_URL", server.URL)
+		conf.SetEnv(s.T(), "SSAS_USE_TLS", "false")
+		conf.SetEnv(s.T(), "BCDA_SSAS_CLIENT_ID", server.URL)
+		s.setEnvVars(tc.env)
+		client, err := authclient.NewSSASClient()
+
+		if err != nil {
+			s.FailNow(constants.CreateSsasErr, err.Error())
+		}
+		err = client.GetHealth()
+
+		if tc.errorExpected {
+			assert.EqualError(s.T(), err, tc.message)
+		} else {
+			assert.Nil(s.T(), err)
+		}
 	}
 }
 

--- a/bcda/auth/client/ssas_test.go
+++ b/bcda/auth/client/ssas_test.go
@@ -584,38 +584,6 @@ func TestSSASClientTestSuite(t *testing.T) {
 	suite.Run(t, new(SSASClientTestSuite))
 }
 
-func (s *SSASClientTestSuite) TestPingTable() {
-	tests := []struct {
-		fnInput       []string
-		env           EnvVars
-		errorExpected bool
-		message       string
-	}{
-		{fnInput: []string{}, env: EnvVars{}, errorExpected: false},
-		{fnInput: []string{}, env: EnvVars{BCDA_SSAS_CLIENT_ID: "fake"}, errorExpected: true, message: "introspect request failed; 401"},
-		{fnInput: []string{}, env: EnvVars{SSAS_PUBLIC_URL: "localhost"}, errorExpected: true, message: "introspect request failed: Post \"localhost/introspect\": unsupported protocol scheme \"\""},
-		{fnInput: []string{}, env: EnvVars{BCDA_SSAS_CLIENT_ID: "-1"}, errorExpected: true, message: "missing clientID or secret"},
-	}
-
-	for _, tc := range tests {
-
-		s.setEnvVars(tc.env)
-		client, err := authclient.NewSSASClient()
-
-		if err != nil {
-			s.FailNow(constants.CreateSsasErr, err.Error())
-		}
-		err = client.Ping()
-
-		if tc.errorExpected {
-			assert.EqualError(s.T(), err, tc.message)
-		} else {
-			assert.Nil(s.T(), err)
-		}
-
-	}
-}
-
 func (s *SSASClientTestSuite) TestGetPublicKeyTable() {
 	tests := []struct {
 		fnInput       []string

--- a/bcda/health/health.go
+++ b/bcda/health/health.go
@@ -50,9 +50,9 @@ func IsSsasOK() (result string, ok bool) {
 		log.Auth.Errorf("no client for SSAS. no provider set; %s", err.Error())
 		return "No client for SSAS. no provider set", false
 	}
-	if err := c.Ping(); err != nil {
-		log.API.Error("Health check: ssas ping error: ", err.Error())
-		return "Cannot authenticate with SSAS", false
+	if err := c.GetHealth(); err != nil {
+		log.API.Error("Health check: ssas health check error: ", err.Error())
+		return "Cannot connect to SSAS", false
 	}
 	return "ok", true
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9107

## 🛠 Changes

- pointed the bcda-app `/_health` check endpoint to hit the ssas `_/health` check endpoint instead of `/introspect`

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Tested locally by curling `localhost:3000/_health`
