### PR TITLE
BCDA-9138: Move /demo to BFD v3

### DIFF
--- a/bcda/client/bluebutton.go
+++ b/bcda/client/bluebutton.go
@@ -222,7 +222,10 @@ func (bbc *BlueButtonClient) GetExplanationOfBenefit(jobData worker_types.JobEnq
 	header.Add("IncludeTaxNumbers", "true")
 	params := GetDefaultParams()
 	params.Set("patient", patientID)
-	params.Set("excludeSAMHSA", "true")
+
+	if bbc.BBBasePath != constants.BFDV3Path { // TODO: V3
+		params.Set("excludeSAMHSA", "true")
+	}
 
 	updateParamWithServiceDate(&params, claimsWindow)
 	updateParamWithLastUpdated(&params, jobData.Since, jobData.TransactionTime)

--- a/bcda/constants/constants.go
+++ b/bcda/constants/constants.go
@@ -49,7 +49,7 @@ const CCLF8FileNum = int(8)
 
 const BFDV1Path = "/v1/fhir"
 const BFDV2Path = "/v2/fhir"
-const BFDV3Path = "/v2/fhir" // TODO: V3
+const BFDV3Path = "/v3/fhir" // TODO: V3
 const V3Version = "demo"
 
 const GetExistingBenes = "GetExistingBenes"

--- a/bcdaworker/queueing/worker_prepare.go
+++ b/bcdaworker/queueing/worker_prepare.go
@@ -162,8 +162,7 @@ func (p *PrepareJobWorker) GetBundleLastUpdated(basepath string, jobData worker_
 		b, err := p.v2Client.GetPatient(jobData, "0")
 		return b.Meta.LastUpdated, err
 	case constants.BFDV3Path:
-		b, err := p.v3Client.GetPatient(jobData, "0")
-		return b.Meta.LastUpdated, err
+		return jobData.TransactionTime, nil // TODO: V3
 	default:
 		return time.Time{}, errors.New("no BFD base path")
 	}

--- a/bcdaworker/queueing/worker_prepare.go
+++ b/bcdaworker/queueing/worker_prepare.go
@@ -33,6 +33,7 @@ type PrepareJobWorker struct {
 	svc      service.Service
 	v1Client client.APIClient
 	v2Client client.APIClient
+	v3Client client.APIClient
 	r        models.Repository
 }
 
@@ -62,8 +63,13 @@ func NewPrepareJobWorker() (*PrepareJobWorker, error) {
 		logger.Fatalf("failed to load bfd client. Err: %v", err)
 		return &PrepareJobWorker{}, err
 	}
+	v3, err := client.NewBlueButtonClient(client.NewConfig(constants.BFDV3Path))
+	if err != nil {
+		logger.Fatalf("failed to load bfd client. Err: %v", err)
+		return &PrepareJobWorker{}, err
+	}
 
-	return &PrepareJobWorker{svc: svc, v1Client: v1, v2Client: v2, r: repository}, nil
+	return &PrepareJobWorker{svc: svc, v1Client: v1, v2Client: v2, v3Client: v3, r: repository}, nil
 
 }
 
@@ -154,6 +160,9 @@ func (p *PrepareJobWorker) GetBundleLastUpdated(basepath string, jobData worker_
 		return b.Meta.LastUpdated, err
 	case constants.BFDV2Path:
 		b, err := p.v2Client.GetPatient(jobData, "0")
+		return b.Meta.LastUpdated, err
+	case constants.BFDV3Path:
+		b, err := p.v3Client.GetPatient(jobData, "0")
 		return b.Meta.LastUpdated, err
 	default:
 		return time.Time{}, errors.New("no BFD base path")

--- a/bcdaworker/worker/bluebutton.go
+++ b/bcdaworker/worker/bluebutton.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/CMSgov/bcda-app/bcda/client"
+	"github.com/CMSgov/bcda-app/bcda/constants"
 	models "github.com/CMSgov/bcda-app/bcda/models"
 	"github.com/CMSgov/bcda-app/bcdaworker/queueing/worker_types"
 	"github.com/pkg/errors"
@@ -36,6 +37,9 @@ func getBlueButtonID(bb client.APIClient, mbi string, jobData worker_types.JobEn
 		if strings.Contains(identifier.System, "us-mbi") {
 			if identifier.Value == mbi {
 				foundIdentifier = true
+				if jobData.BBBasePath == constants.BFDV3Path { // TODO: V3
+					foundBlueButtonID = true
+				}
 			}
 		} else if strings.Contains(identifier.System, "bene_id") && identifier.Value == blueButtonID {
 			foundBlueButtonID = true

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/CMSgov/bcda-app/bcda/cclf/metrics"
 	"github.com/CMSgov/bcda-app/bcda/client"
-	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/models"
 	fhirmodels "github.com/CMSgov/bcda-app/bcda/models/fhir"
 	"github.com/CMSgov/bcda-app/bcda/responseutils"
@@ -329,7 +328,7 @@ func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.A
 			// before gathering EOB/Coverage results; however with partially-adjudicated data
 			// that is not yet possible because their are no Patient FHIR resources. This
 			// boolean indicates whether or not we need to skip that lookup step
-			fetchBBId := jobArgs.DataType != constants.PartiallyAdjudicated
+			fetchBBId := !utils.ContainsString([]string{"Claim", "ClaimResponse"}, jobArgs.ResourceType)
 			bene, err := getBeneficiary(ctx, r, uint(id), bb, fetchBBId, jobArgs)
 			if err != nil {
 				//MBI is appended inside file, not printed out to system logs


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9138

## 🛠 Changes

- Point the /demo endpoint at BFD V3 (instead of V2)
- fetch bluebutton (FHIR) ID for all resources except claim/claimResponse (instead of looking at adjudication-level)
- changes for only v3:
  - Do not pass the `excludeSAMHSA` for v3
  - Use Transaction time as lastupdated param
  - update patient ID lookup to only require mbi match

## ℹ️ Context

Change was added to make \demo endpoint work for connectathon. when we implement the real v3, we'll probably want to refactor the code.

## 🧪 Validation

Test the /$export and /jobs endpoints for demo and v2:
 - http://localhost:3000/api/demo/Group/all/$export
 - http://localhost:3000/api/demo/Patient/$export?_typeFilter=ExplanationOfBenefit%3F_tag%3DAdjudicated

 - http://localhost:3000/api/v2/Group/all/$export
 - http://localhost:3000/api/v2/Patient/$export?_typeFilter=ExplanationOfBenefit%3F_tag%3DAdjudicated
