### PR TITLE
BCDA-9355: Remove init from servicemux package

### DIFF
--- a/bcda/servicemux/servicemux_test.go
+++ b/bcda/servicemux/servicemux_test.go
@@ -244,6 +244,17 @@ func TestServiceMuxTestSuite(t *testing.T) {
 	suite.Run(t, new(ServiceMuxTestSuite))
 }
 
+func (s *ServiceMuxTestSuite) TestGetKeepAliveConfig() {
+
+	ln := getKeepAliveConfig()
+	assert.Equal(s.T(), ln, 60)
+
+	os.Setenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL", "240")
+	ln = getKeepAliveConfig()
+	assert.Equal(s.T(), ln, 240)
+	os.Unsetenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL")
+}
+
 func getOrigVars() (origTLSCert, origTLSKey, origHTTPOnly string) {
 	return conf.GetEnv("BCDA_TLS_CERT"), conf.GetEnv("BCDA_TLS_KEY"), conf.GetEnv("HTTP_ONLY")
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9355

## 🛠 Changes

remove init() from `servicemux` package.

## ℹ️ Context

Generous init() usage across the repo often makes testing cumbersome. This change is part of the effort to remove init() across the project to simplify testing.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tests pass and were modified.
