### PR TITLE
BCDA-9374: Remove resourcetype init

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -42,7 +42,7 @@ type Handler struct {
 	Enq        queueing.Enqueuer
 	Svc        service.Service
 
-	supportedDataTypes     map[string]service.DataType
+	supportedDataTypes     map[string]service.ClaimType
 	supportedResourceTypes []string
 	supportedStatuses      map[models.JobStatus]struct{}
 	bbBasePath             string
@@ -62,11 +62,11 @@ type fhirResponseWriter interface {
 	JobsBundle(context.Context, http.ResponseWriter, []*models.Job, string)
 }
 
-func NewHandler(dataTypes map[string]service.DataType, basePath string, apiVersion string, db *sql.DB, pool *pgxv5Pool.Pool) *Handler {
+func NewHandler(dataTypes map[string]service.ClaimType, basePath string, apiVersion string, db *sql.DB, pool *pgxv5Pool.Pool) *Handler {
 	return newHandler(dataTypes, basePath, apiVersion, db, pool)
 }
 
-func newHandler(dataTypes map[string]service.DataType, basePath string, apiVersion string, db *sql.DB, pool *pgxv5Pool.Pool) *Handler {
+func newHandler(dataTypes map[string]service.ClaimType, basePath string, apiVersion string, db *sql.DB, pool *pgxv5Pool.Pool) *Handler {
 	h := &Handler{JobTimeout: time.Hour * time.Duration(utils.GetEnvInt("ARCHIVE_THRESHOLD_HR", 24))}
 
 	h.Enq = queueing.NewEnqueuer(db, pool)
@@ -631,7 +631,7 @@ func (h *Handler) validateResources(resourceTypes []string, cmsID string) error 
 	return nil
 }
 
-func (h *Handler) authorizedResourceAccess(dataType service.DataType, cmsID string) bool {
+func (h *Handler) authorizedResourceAccess(dataType service.ClaimType, cmsID string) bool {
 	if cfg, ok := h.Svc.GetACOConfigForID(cmsID); ok {
 		return (dataType.Adjudicated && utils.ContainsString(cfg.Data, constants.Adjudicated)) ||
 			(dataType.PartiallyAdjudicated && utils.ContainsString(cfg.Data, constants.PartiallyAdjudicated))

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -72,7 +72,7 @@ type RequestsTestSuite struct {
 
 	acoID uuid.UUID
 
-	resourceType map[string]service.DataType
+	resourceType map[string]service.ClaimType
 }
 
 func TestRequestsTestSuite(t *testing.T) {
@@ -91,7 +91,7 @@ func (s *RequestsTestSuite) SetupSuite() {
 		testfixtures.Directory("testdata/"),
 	)
 
-	s.resourceType = map[string]service.DataType{
+	s.resourceType = map[string]service.ClaimType{
 		"Patient":              {Adjudicated: true},
 		"Coverage":             {Adjudicated: true},
 		"ExplanationOfBenefit": {Adjudicated: true},
@@ -240,7 +240,7 @@ func (s *RequestsTestSuite) TestJobsStatusV1() {
 				)
 			}
 
-			h := newHandler(map[string]service.DataType{
+			h := newHandler(map[string]service.ClaimType{
 				"Patient":              {},
 				"Coverage":             {},
 				"ExplanationOfBenefit": {},
@@ -354,7 +354,7 @@ func (s *RequestsTestSuite) TestJobsStatusV2() {
 
 				}
 			}
-			h := newHandler(map[string]service.DataType{
+			h := newHandler(map[string]service.ClaimType{
 				"Patient":              {},
 				"Coverage":             {},
 				"ExplanationOfBenefit": {},
@@ -560,7 +560,7 @@ func (s *RequestsTestSuite) TestDataTypeAuthorization() {
 		Data:               []string{},
 	}
 
-	dataTypeMap := map[string]service.DataType{
+	dataTypeMap := map[string]service.ClaimType{
 		"Coverage":             {Adjudicated: true},
 		"Patient":              {Adjudicated: true},
 		"ExplanationOfBenefit": {Adjudicated: true},
@@ -1050,7 +1050,7 @@ func TestBulkRequest_Integration(t *testing.T) {
 		Data:               []string{"adjudicated"},
 	}
 
-	dataTypeMap := map[string]service.DataType{
+	dataTypeMap := map[string]service.ClaimType{
 		"Coverage":             {Adjudicated: true},
 		"Patient":              {Adjudicated: true},
 		"ExplanationOfBenefit": {Adjudicated: true},
@@ -1204,7 +1204,7 @@ func MakeTestStructuredLoggerEntry(logFields logrus.Fields) *log.StructuredLogge
 func (s *RequestsTestSuite) TestValidateResources() {
 	apiVersion := "v1"
 	fhirPath := "/" + apiVersion + "/fhir"
-	h := newHandler(map[string]service.DataType{
+	h := newHandler(map[string]service.ClaimType{
 		"Patient":              {},
 		"Coverage":             {},
 		"ExplanationOfBenefit": {},

--- a/bcda/service/resources.go
+++ b/bcda/service/resources.go
@@ -2,16 +2,23 @@ package service
 
 import "github.com/CMSgov/bcda-app/bcda/constants"
 
-// DataType is used to identify the type of data returned by each resource
-type DataType struct {
+// ClaimType is used to identify the type of data returned by each resource
+type ClaimType struct {
 	Adjudicated          bool
 	PartiallyAdjudicated bool
 }
 
-var dataTypeMap map[string]DataType
+var fhirResourceTypeMap = map[string]ClaimType{
+	"Patient":              {Adjudicated: true},
+	"Coverage":             {Adjudicated: true},
+	"ExplanationOfBenefit": {Adjudicated: true},
+	"Observation":          {Adjudicated: true},
+	"Claim":                {PartiallyAdjudicated: true},
+	"ClaimResponse":        {PartiallyAdjudicated: true},
+}
 
 // SupportsDataType checks if the dataType is supported by the instanced DataType object
-func (r DataType) SupportsDataType(dataType string) bool {
+func (r ClaimType) SupportsDataType(dataType string) bool {
 	switch dataType {
 	case constants.PartiallyAdjudicated:
 		return r.PartiallyAdjudicated
@@ -22,41 +29,29 @@ func (r DataType) SupportsDataType(dataType string) bool {
 	}
 }
 
-// init creates a map of ResourceType => DataType configurations to be used by later functions
-func init() {
-	dataTypeMap = map[string]DataType{
-		"Patient":              {Adjudicated: true},
-		"Coverage":             {Adjudicated: true},
-		"ExplanationOfBenefit": {Adjudicated: true},
-		"Observation":          {Adjudicated: true},
-		"Claim":                {PartiallyAdjudicated: true},
-		"ClaimResponse":        {PartiallyAdjudicated: true},
-	}
-}
-
 // GetDataType gets the DataType associated with the given resourceName
-func GetDataType(resourceName string) (DataType, bool) {
-	resource, ok := dataTypeMap[resourceName]
+func GetDataType(resourceName string) (ClaimType, bool) {
+	resource, ok := fhirResourceTypeMap[resourceName]
 
 	return resource, ok
 }
 
 // GetDataTypes creates a map of the given resourceNames with their associated DataType objects
 // It returns the resource map and a status flag, with true meaning all resources were found and mapped.
-func GetDataTypes(resourceNames ...string) (map[string]DataType, bool) {
+func GetDataTypes(resourceNames ...string) (map[string]ClaimType, bool) {
 	foundAll := true
 
-	returnMap := make(map[string]DataType, len(resourceNames))
+	returnMap := make(map[string]ClaimType, len(resourceNames))
 
 	if len(resourceNames) == 0 {
 		// If no resource specified, return copy of full map
-		for name, entry := range dataTypeMap {
+		for name, entry := range fhirResourceTypeMap {
 			returnMap[name] = entry
 		}
 	} else {
 		// If resources specified, return map subset
 		for _, name := range resourceNames {
-			if entry, ok := dataTypeMap[name]; ok {
+			if entry, ok := fhirResourceTypeMap[name]; ok {
 				returnMap[name] = entry
 			} else {
 				foundAll = false

--- a/bcda/service/resources_test.go
+++ b/bcda/service/resources_test.go
@@ -20,37 +20,37 @@ func TestResourcesTestSuite(t *testing.T) {
 func (s *ResourcesTestSuite) TestSupportsDataType() {
 	tests := []struct {
 		name         string
-		dataType     DataType
+		dataType     ClaimType
 		dataTypeName string
 		expected     bool
 	}{
 		{
 			"Valid Adjudicated Type",
-			DataType{Adjudicated: true, PartiallyAdjudicated: false},
+			ClaimType{Adjudicated: true, PartiallyAdjudicated: false},
 			constants.Adjudicated,
 			true,
 		},
 		{
 			"Valid Partially-Adjudicated Type",
-			DataType{Adjudicated: false, PartiallyAdjudicated: true},
+			ClaimType{Adjudicated: false, PartiallyAdjudicated: true},
 			constants.PartiallyAdjudicated,
 			true,
 		},
 		{
 			"Invalid Type",
-			DataType{Adjudicated: true, PartiallyAdjudicated: true},
+			ClaimType{Adjudicated: true, PartiallyAdjudicated: true},
 			"invalid-type",
 			false,
 		},
 		{
 			"Invalid Partially-Adjudicated Type",
-			DataType{Adjudicated: true, PartiallyAdjudicated: false},
+			ClaimType{Adjudicated: true, PartiallyAdjudicated: false},
 			constants.PartiallyAdjudicated,
 			false,
 		},
 		{
 			"Invalid Adjudicated Type",
-			DataType{Adjudicated: false, PartiallyAdjudicated: true},
+			ClaimType{Adjudicated: false, PartiallyAdjudicated: true},
 			constants.Adjudicated,
 			false,
 		},
@@ -66,16 +66,16 @@ func (s *ResourcesTestSuite) TestSupportsDataType() {
 func (s *ResourcesTestSuite) TestGetDataType() {
 	tests := []struct {
 		resourceName string
-		expectedType DataType
+		expectedType ClaimType
 		expectedOk   bool
 	}{
-		{"Patient", DataType{Adjudicated: true}, true},
-		{"Coverage", DataType{Adjudicated: true}, true},
-		{"ExplanationOfBenefit", DataType{Adjudicated: true}, true},
-		{"Observation", DataType{Adjudicated: true}, true},
-		{"Claim", DataType{Adjudicated: false, PartiallyAdjudicated: true}, true},
-		{"ClaimResponse", DataType{Adjudicated: false, PartiallyAdjudicated: true}, true},
-		{"InvalidResource", DataType{}, false},
+		{"Patient", ClaimType{Adjudicated: true}, true},
+		{"Coverage", ClaimType{Adjudicated: true}, true},
+		{"ExplanationOfBenefit", ClaimType{Adjudicated: true}, true},
+		{"Observation", ClaimType{Adjudicated: true}, true},
+		{"Claim", ClaimType{Adjudicated: false, PartiallyAdjudicated: true}, true},
+		{"ClaimResponse", ClaimType{Adjudicated: false, PartiallyAdjudicated: true}, true},
+		{"InvalidResource", ClaimType{}, false},
 	}
 
 	for _, tt := range tests {
@@ -91,13 +91,13 @@ func (s *ResourcesTestSuite) TestGetDataTypes() {
 	tests := []struct {
 		name          string
 		resourceNames []string
-		expectedTypes map[string]DataType
+		expectedTypes map[string]ClaimType
 		expectedOk    bool
 	}{
 		{
 			"Empty resource names",
 			[]string{},
-			map[string]DataType{
+			map[string]ClaimType{
 				"Patient":              {Adjudicated: true},
 				"Coverage":             {Adjudicated: true},
 				"ExplanationOfBenefit": {Adjudicated: true},
@@ -110,7 +110,7 @@ func (s *ResourcesTestSuite) TestGetDataTypes() {
 		{
 			"Valid resource names",
 			[]string{"Patient", "Claim"},
-			map[string]DataType{
+			map[string]ClaimType{
 				"Patient": {Adjudicated: true},
 				"Claim":   {Adjudicated: false, PartiallyAdjudicated: true},
 			},
@@ -119,7 +119,7 @@ func (s *ResourcesTestSuite) TestGetDataTypes() {
 		{
 			"One invalid resource names",
 			[]string{"Patient", "InvalidResource", "Claim"},
-			map[string]DataType{
+			map[string]ClaimType{
 				"Patient": {Adjudicated: true},
 				"Claim":   {Adjudicated: false, PartiallyAdjudicated: true},
 			},
@@ -128,7 +128,7 @@ func (s *ResourcesTestSuite) TestGetDataTypes() {
 		{
 			"All invalid resource names",
 			[]string{"InvalidResource1", "InvalidResource2"},
-			map[string]DataType{},
+			map[string]ClaimType{},
 			false,
 		},
 	}

--- a/bcda/servicemux/servicemux_test.go
+++ b/bcda/servicemux/servicemux_test.go
@@ -246,13 +246,20 @@ func TestServiceMuxTestSuite(t *testing.T) {
 
 func (s *ServiceMuxTestSuite) TestGetKeepAliveConfig() {
 
+	oka := os.Getenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL")
+
 	ln := getKeepAliveConfig()
 	assert.Equal(s.T(), ln, 60)
 
 	os.Setenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL", "240")
 	ln = getKeepAliveConfig()
 	assert.Equal(s.T(), ln, 240)
-	os.Unsetenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL")
+
+	if oka == "" {
+		os.Unsetenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL")
+	} else {
+		os.Setenv("SERVICE_MUX_KEEP_ALIVE_INTERVAL", oka)
+	}
 }
 
 func getOrigVars() (origTLSCert, origTLSKey, origHTTPOnly string) {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9374

## 🛠 Changes

- Removed init and put variable initialization as unexported package level var
- Renamed `DataType` to `ClaimType`
- Renamed `dataTypeMap` to `fhirResourceTypeMap`

## ℹ️ Context

Part of the ongoing effort to remove init() across the project to make development and testing faster + more reliable.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
