### PR TITLE
BCDA-9367: Add new auto deploy to dev workflow

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -2,8 +2,6 @@
 name: Deploy All
 
 on:
-  schedule:
-    - cron: 0 12 * * 1-5 # every workday at 8am EST (autodeploy to dev)
   workflow_dispatch:
     inputs:
       release_version:
@@ -49,6 +47,35 @@ on:
           - 'large'
           - 'extra-large'
           - 'paca'
+        default: 'dev'
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'Release version/tag (or branch name)'
+        required: true
+        type: string
+      ops_release_version:
+        description: 'Release version/tag for bcda-ops (or branch name)'
+        required: true
+        type: string
+      ssas_release_version:
+        description: 'Release version/tag for bcda-ssas (or branch name)'
+        required: true
+        type: string
+      env:
+        description: 'Environment you want to deploy to (dev, test, sandbox, prod)'
+        required: true
+        type: string
+        default: dev
+      confirm_env:
+        description: 'Confirm the environment you want to deploy to'
+        required: true
+        type: string
+        default: dev
+      test_aco:
+        description: Run the smoke tests using the selected ACO
+        required: true
+        type: string
         default: 'dev'
 
 permissions:

--- a/.github/workflows/dev-daily-autodeploy.yml
+++ b/.github/workflows/dev-daily-autodeploy.yml
@@ -2,8 +2,6 @@
 name: Deploy main to dev daily
 
 on:
-  push:
-    branches: [carl-9367-adjust-dev-autodeploy]
   schedule:
     - cron: 0 12 * * 1-5 # every workday at 8am EST
 

--- a/.github/workflows/dev-daily-autodeploy.yml
+++ b/.github/workflows/dev-daily-autodeploy.yml
@@ -1,0 +1,33 @@
+# Deploy BCDA/SSAS and Worker ec2 instances to dev daily
+name: Deploy main to dev daily
+
+on:
+  push:
+    branches: [carl-9367-adjust-dev-autodeploy]
+  schedule:
+    - cron: 0 12 * * 1-5 # every workday at 8am EST
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build_and_package_all:
+    uses: ./.github/workflows/build-and-package-all.yml
+    with:
+      release_version: main
+      ops_release_version: main
+      ssas_release_version: main
+    secrets: inherit
+  
+  deploy_all:
+    needs: [build_and_package_all]
+    uses: ./.github/workflows/deploy-all.yml
+    with:
+      release_version: main
+      ops_release_version: main
+      ssas_release_version: main
+      env: dev
+      confirm_env: dev
+      test_aco: dev
+    secrets: inherit

--- a/.github/workflows/package-rpms.yml
+++ b/.github/workflows/package-rpms.yml
@@ -91,7 +91,7 @@ jobs:
           aws s3 cp --only-show-errors $BCDA_WORKER_RPM s3://${{ env.BCDA_RPMS_BUCKET }}/bcdaworker-release-latest.rpm
       
       - name: Upload BCDA RPM to s3 dev
-        if: ${{ inputs.release_version == '' || inputs.release_version == 'main' }}
+        if: ${{ matrix.vars.account_id == 'NON_PROD_ACCOUNT_ID' && inputs.release_version == 'main' }}
         working-directory: ./bcda
         run: |
           export BCDA_RPM=`ls bcda-*.rpm | tr '\n' ' '`
@@ -100,7 +100,7 @@ jobs:
           aws s3 cp --only-show-errors $BCDA_RPM s3://${{ env.BCDA_RPMS_BUCKET }}/bcda-dev-latest.rpm
       
       - name: Upload BCDA Worker RPM to s3 dev
-        if: ${{ inputs.release_version == '' || inputs.release_version == 'main' }}
+        if: ${{ matrix.vars.account_id == 'NON_PROD_ACCOUNT_ID' && inputs.release_version == 'main'}}
         working-directory: ./bcdaworker
         run: |
           export BCDA_WORKER_RPM=`ls bcdaworker-*.rpm | tr '\n' ' '`

--- a/.github/workflows/package-rpms.yml
+++ b/.github/workflows/package-rpms.yml
@@ -75,8 +75,7 @@ jobs:
           BCDA_GPG_RPM_PASSPHRASE=${{ env.BCDA_GPG_RPM_PASSPHRASE }} GPG_RPM_USER="${{ env.GPG_RPM_USER }}" GPG_RPM_EMAIL=${{ env.GPG_RPM_EMAIL }} GPG_PUB_KEY_FILE=${{ env.GPG_PUB_KEY_FILE }} GPG_SEC_KEY_FILE=${{ env.GPG_SEC_KEY_FILE }} make package version=`echo ${{ inputs.release_version }} | sed 's/.*\///'`
       
       - name: Upload BCDA RPM to s3 prod
-        # TODO: should we be checking blank release_version or should we be checking inputs.release_env == 'dev' ?
-        if: ${{ inputs.release_version != '' }}
+        if: ${{ inputs.release_version != '' && inputs.release_version != 'main' }}
         working-directory: ./bcda
         run: |
           export BCDA_RPM=`ls bcda-*.rpm | tr '\n' ' '`
@@ -84,7 +83,7 @@ jobs:
           aws s3 cp --only-show-errors $BCDA_RPM s3://${{ env.BCDA_RPMS_BUCKET }}/bcda-release-latest.rpm
 
       - name: Upload BCDA Worker RPM to s3 prod
-        if: ${{ inputs.release_version != '' }}
+        if: ${{ inputs.release_version != '' && inputs.release_version != 'main' }}
         working-directory: ./bcdaworker
         run: |
           export BCDA_WORKER_RPM=`ls bcdaworker-*.rpm | tr '\n' ' '`
@@ -92,7 +91,7 @@ jobs:
           aws s3 cp --only-show-errors $BCDA_WORKER_RPM s3://${{ env.BCDA_RPMS_BUCKET }}/bcdaworker-release-latest.rpm
       
       - name: Upload BCDA RPM to s3 dev
-        if: ${{ inputs.release_version == '' }}
+        if: ${{ inputs.release_version == '' || inputs.release_version == 'main' }}
         working-directory: ./bcda
         run: |
           export BCDA_RPM=`ls bcda-*.rpm | tr '\n' ' '`
@@ -101,7 +100,7 @@ jobs:
           aws s3 cp --only-show-errors $BCDA_RPM s3://${{ env.BCDA_RPMS_BUCKET }}/bcda-dev-latest.rpm
       
       - name: Upload BCDA Worker RPM to s3 dev
-        if: ${{ inputs.release_version == '' }}
+        if: ${{ inputs.release_version == '' || inputs.release_version == 'main' }}
         working-directory: ./bcdaworker
         run: |
           export BCDA_WORKER_RPM=`ls bcdaworker-*.rpm | tr '\n' ' '`


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9367

## 🛠 Changes

Added a new workflow to address issues with the daily dev deploy from main.

## ℹ️ Context

The daily dev deploy to main has been having troubles since our greenfield migration.  We are no longer getting the latest changes deployed to dev daily.  Adding this new workflow should address this.  It felt better to create a new workflow then to try to finagle existing workflows (which would have involved a lot of if else checks and such).

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Testing workflow in PR pushes.  (Successful run: https://github.com/CMSgov/bcda-app/actions/runs/17082274241)
