### PR TITLE
BCDA-9377: Remove init from main.go for api and worker

### DIFF
--- a/bcda/main.go
+++ b/bcda/main.go
@@ -47,9 +47,7 @@ import (
 	"github.com/CMSgov/bcda-app/log"
 )
 
-func init() {
-	log.SetupLoggers()
-	client.SetLogger(log.BBAPI)
+func setupDirs() {
 
 	isEtlMode := conf.GetEnv("BCDA_ETL_MODE")
 	if isEtlMode != "true" {
@@ -83,6 +81,9 @@ func createETLDirs() {
 }
 
 func main() {
+	log.SetupLoggers()
+	client.SetLogger(log.BBAPI)
+	setupDirs()
 	app := bcdacli.GetApp()
 	err := app.Run(os.Args)
 	if err != nil {

--- a/bcdaworker/main.go
+++ b/bcdaworker/main.go
@@ -20,11 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func init() {
-	createWorkerDirs()
-	client.SetLogger(log.BBWorker)
-}
-
 func createWorkerDirs() {
 	staging := conf.GetEnv("FHIR_STAGING_DIR")
 	err := os.MkdirAll(staging, 0744)
@@ -98,6 +93,8 @@ func waitForSig() {
 func main() {
 	fmt.Println("Starting bcdaworker...")
 	log.SetupLoggers()
+	createWorkerDirs()
+	client.SetLogger(log.BBWorker)
 	db := database.Connect()
 	healthChecker := health.NewHealthChecker(db)
 	queue := queueing.StartRiver(db, utils.GetEnvInt("WORKER_POOL_SIZE", 4))

--- a/bcdaworker/main_test.go
+++ b/bcdaworker/main_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestClearTempDirectory(t *testing.T) {
+	createWorkerDirs()
 	tempDirPrefix := conf.GetEnv("FHIR_TEMP_DIR")
 	tempDir, err := os.MkdirTemp(tempDirPrefix, "bananas")
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9377

## 🛠 Changes

- removed init from `bcda/main.go` and `bcdaworker/main.go`.
- added directory setup to `bcdaworker/main_test.go`

## ℹ️ Context

Part of ongoing effort to remove init to improve test suite.


<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tests passing.
