### PR TITLE
BCDA-9366: Add nil response handling to BFD requests

### DIFF
--- a/bcda/client/fhir/client.go
+++ b/bcda/client/fhir/client.go
@@ -2,6 +2,7 @@ package fhir
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -128,6 +129,9 @@ func getResponse(c *http.Client, req *http.Request) (body []byte, err error) {
 	s := newrelic.StartExternalSegment(txn, req)
 
 	resp, err := c.Do(req)
+	if resp == nil {
+		return nil, errors.New("response from BFD is nil")
+	}
 	if err != nil {
 		if innerErr := resp.Body.Close(); innerErr != nil {
 			return nil, innerErr


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9366

## 🛠 Changes

Add error handling for nil response from BFD.

## ℹ️ Context

A nil response from BFD was breaking the resp.Body portion of the error check.  This was then crashing the server and obfuscating any relevant, helpful logs.  This should resolve that situation.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local testing and linting.
