### PR TITLE
BCDA-9400: Add tagging for lifecycle management

### DIFF
--- a/.github/workflows/admin-aco-deny-deploy.yml
+++ b/.github/workflows/admin-aco-deny-deploy.yml
@@ -76,8 +76,11 @@ jobs:
       - name: Upload and reload
         run: |
           aws s3 cp --no-progress function.zip \
-            s3://$BUCKET/function-${{ github.sha }}.zip \
-            --tagging "lifecycle-transition=ia"
+            s3://$BUCKET/function-${{ github.sha }}.zip
+          aws s3api put-object-tagging \
+            --bucket $BUCKET \
+            --key function-${{ github.sha }}.zip \
+            --tagging 'TagSet=[{Key=lifecycle-transition,Value=ia}]'
           aws lambda update-function-code --function-name bcda-$ENVIRONMENT-admin-aco-deny \
             --s3-bucket $BUCKET --s3-key function-${{ github.sha }}.zip
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9400

## 🛠 Changes

- Updated the workflow to add the `lifecycle-transition:ia` tag when uploading the Lambda deployment package.
- Every time the workflow uploads a new Lambda deployment package, it will automatically tag the object with l`ifecycle-transition=ia`
- The S3 lifecycle rule in the CDAP repo will now apply to these tagged objects
- When a new deployment happens and the previous version becomes "noncurrent", it will automatically transition to Standard-IA storage after 3 days

## ℹ️ Context

We were not using lifecycle transitions on our buckets, and a Security Hub control failed. Remediating it by adding a basic lifecycle transition.

The workflow has been updated to include the `--tagging "lifecycle-transition=ia"` parameter in the S3 upload command.

## 🧪 Validation

Using the AWS console when the Lambda is deployed into lower environments.
