### PR TITLE
[PLT-1347] Rename the terraform_gf directory to terraform, post-migration

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -159,13 +159,13 @@ jobs:
           echo "WORKER_AMI=$WORKER_AMI" >> $GITHUB_ENV
       - name: Install terraform
         with:
-          directory: ./terraform_gf
+          directory: ./terraform
         uses: cmsgov/cdap/actions/setup-tfenv-terraform@main
       - name: Init, Plan Terraform
         run: |
           IFS=":@" read -r -a STRS <<< ${{ env.DATABASE_URL }}
           export APP_DB_PW=${STRS[2]}
-          cd terraform_gf/${{ env.RELEASE_ENV }}
+          cd terraform/${{ env.RELEASE_ENV }}
           touch bcda-release-api-worker-vars.tfvars
           export TF_CLI_ARGS="-no-color"
           terraform init
@@ -178,7 +178,7 @@ jobs:
             -out 'bcda-release-api-worker.tfplan'
       - name: Terraform Apply
         run: |
-          cd terraform_gf/${{ env.RELEASE_ENV }}
+          cd terraform/${{ env.RELEASE_ENV }}
           export TF_CLI_ARGS="-no-color"
           terraform init
           terraform apply bcda-release-api-worker.tfplan


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1347

## 🛠 Changes

terraform_gf was renamed to terraform

## ℹ️ Context

To maintain standard directory naming across app repos.

## 🧪 Validation

see plan
