### PR TITLE
BCDA-9945: Re-enable v3 EOB

### DIFF
--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -335,19 +335,7 @@ func (s *service) getEffectiveQueueJobConfig(args worker_types.PrepareJobArgs) (
 		effectiveDataTypes = append(effectiveDataTypes, constants.PartiallyAdjudicated)
 	}
 
-	return filterV3ResourceTypes(resourceTypes), effectiveDataTypes, nil
-}
-
-// filterV3ResourceTypes enforces BFD v3 limitations by allowing only supported resource types.
-func filterV3ResourceTypes(resourceTypes []string) []string {
-	filtered := make([]string, 0, len(resourceTypes))
-	for _, resourceType := range resourceTypes {
-		if resourceType == "Patient" || resourceType == "Coverage" {
-			filtered = append(filtered, resourceType)
-		}
-	}
-
-	return filtered
+	return resourceTypes, effectiveDataTypes, nil
 }
 
 // chunkBeneficiaryIDs splits beneficiaries into fixed-size ID batches for queueing.

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -1840,22 +1840,6 @@ func TestCreateQueueJobs(t *testing.T) {
 			jobs[1].ResourceType,
 		})
 	})
-
-	t.Run("v3 excludes EOB jobs", func(t *testing.T) {
-		cfg := newQueueJobTestConfig(t, []ACOConfig{
-			newQueueJobTestACO("CKCC", `^C\d{4}`, []string{constants.Adjudicated}),
-		}, []string{"CKCC"})
-		svc := newQueueJobTestService(t, cfg)
-		args := newQueueJobTestArgs("C5678", []string{"ExplanationOfBenefit"})
-		args.BFDPath = constants.BFDV3Path
-
-		jobs, err := svc.createQueueJobs(newQueueJobTestContext(), args, time.Time{}, []*models.CCLFBeneficiary{
-			getCCLFBeneficiary(1, "MBI1"),
-		})
-
-		assert.NoError(t, err)
-		assert.Len(t, jobs, 0, "v3 must not create EOB jobs; only Patient and Coverage are allowed")
-	})
 }
 
 func TestFormatSinceArg(t *testing.T) {
@@ -1897,7 +1881,7 @@ func TestGetEffectiveQueueJobConfig(t *testing.T) {
 
 		resourceTypes, dataTypes, err := svc.getEffectiveQueueJobConfig(args)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"Patient", "Coverage"}, resourceTypes)
+		assert.Equal(t, []string{"Patient", "Coverage", "ExplanationOfBenefit"}, resourceTypes)
 		assert.Equal(t, []string{constants.Adjudicated, constants.PartiallyAdjudicated}, dataTypes)
 	})
 
@@ -1911,14 +1895,9 @@ func TestGetEffectiveQueueJobConfig(t *testing.T) {
 
 		resourceTypes, dataTypes, err := svc.getEffectiveQueueJobConfig(args)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"Patient", "Coverage"}, resourceTypes)
+		assert.Equal(t, []string{"Patient", "Coverage", "ExplanationOfBenefit"}, resourceTypes)
 		assert.Equal(t, []string{constants.Adjudicated}, dataTypes)
 	})
-}
-
-func TestFilterV3ResourceTypes(t *testing.T) {
-	filtered := filterV3ResourceTypes([]string{"Patient", "Coverage", "ExplanationOfBenefit", "Claim"})
-	assert.Equal(t, []string{"Patient", "Coverage"}, filtered)
 }
 
 func TestChunkBeneficiaryIDs(t *testing.T) {

--- a/test/postman_test/BCDA_V3_Tests.postman_collection.json
+++ b/test/postman_test/BCDA_V3_Tests.postman_collection.json
@@ -1534,10 +1534,6 @@
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "// EOB is temporarily disabled in v3",
-                          "pm.environment.set(\"eobv3DataUrl\", (pm.environment.get(\"scheme\") + \"://\" + pm.environment.get(\"host\")));",
-                          "return;",
-                          "",
                           "var v3Disabled = pm.globals.get(\"v3Disabled\") == \"true\"",
                           "if (v3Disabled) {",
                           "    console.log(\"Not running EOB export v3 job status, v3 endpoints have been disabled\");",
@@ -1605,9 +1601,6 @@
                       "listen": "prerequest",
                       "script": {
                         "exec": [
-                          "// EOB is temporarily disabled in v3",
-                          "return;",
-                          "",
                           "var v3Disabled = pm.globals.get(\"v3Disabled\") == \"true\"",
                           "if (v3Disabled) {",
                           "    return;",
@@ -1698,9 +1691,6 @@
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "// EOB is temporarily disabled in v3",
-                          "return;",
-                          "",
                           "var v3Disabled = pm.globals.get(\"v3Disabled\") == \"true\"",
                           "if (v3Disabled) {",
                           "    console.log(\"Not running EOB export v3 data, v3 endpoints have been disabled\");",
@@ -1834,10 +1824,6 @@
                       "listen": "test",
                       "script": {
                         "exec": [
-                          "// EOB is temporarily disabled in v3",
-                          "pm.environment.set(\"groupRunoutv3DataUrl\", (pm.environment.get(\"scheme\") + \"://\" + pm.environment.get(\"host\")));",
-                          "return;",
-                          "",
                           "pm.test(\"Status code is 202 or 200\", function() {",
                           "     pm.expect(pm.response.code).to.be.oneOf([202,200]);",
                           "});",
@@ -1897,9 +1883,6 @@
                       "listen": "prerequest",
                       "script": {
                         "exec": [
-                          "// EOB is temporarily disabled in v3",
-                          "return;",
-                          "",
                           "const retryDelay = 5000;",
                           "const maxRetries = 25;",
                           "",


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9945

## 🛠 Changes

Re-enabled EOB v3 resource types.

## ℹ️ Context

EOB v3 was temporarily removed due to limitations in BFD.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
