### PR TITLE
BCDA-9962: update postman test assertion

### DIFF
--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -7832,7 +7832,7 @@
                   "});",
                   "",
                   "pm.test(\"Issue details text are attribution information not found\", function () {",
-                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"No up-to-date attribution information\")",
+                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file not found\")",
                   "});",
                   ""
                 ],
@@ -7905,7 +7905,7 @@
                   "});",
                   "",
                   "pm.test(\"Issue details text are attribution information not found\", function () {",
-                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"No up-to-date attribution information\")",
+                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file not found\")",
                   "});",
                   ""
                 ],

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -7832,7 +7832,7 @@
                   "});",
                   "",
                   "pm.test(\"Issue details text are attribution information not found\", function () {",
-                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file\")",
+                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file not found\")",
                   "});",
                   ""
                 ],
@@ -7905,7 +7905,7 @@
                   "});",
                   "",
                   "pm.test(\"Issue details text are attribution information not found\", function () {",
-                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file\")",
+                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file not found\")",
                   "});",
                   ""
                 ],

--- a/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
+++ b/test/postman_test/BCDA_Tests_Sequential.postman_collection.json
@@ -7832,7 +7832,7 @@
                   "});",
                   "",
                   "pm.test(\"Issue details text are attribution information not found\", function () {",
-                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file not found\")",
+                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file\")",
                   "});",
                   ""
                 ],
@@ -7905,7 +7905,7 @@
                   "});",
                   "",
                   "pm.test(\"Issue details text are attribution information not found\", function () {",
-                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file not found\")",
+                  "    pm.expect(respJson.issue[0].diagnostics).to.include(\"failed to start job; attribution file\")",
                   "});",
                   ""
                 ],


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9962

## 🛠 Changes

- Updated test assertion

## ℹ️ Context

We are appropriately getting an error back from the API that the CCLF file is out of date, but we are getting a different error string in the response than what we are expecting in the smoke test. Smoke tests are updated to match the new string for missing attribution files

## 🧪 Validation

Executed postman tests in dev