### PR TITLE
BCDA-9938: support multi token/tuples in typefilter/tag

### DIFF
--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -830,7 +830,7 @@ func (h *Handler) authorizedResourceAccess(dataType service.ClaimType, cmsID str
 }
 
 // validateTypeFilterPACEligibility validates that ACOs requesting SharedSystem
-// tags in _typeFilter have PAC data access. Handles parsing of multiple comma-separated tag codes. 
+// tags in _typeFilter have PAC data access. Handles parsing of multiple comma-separated tag codes.
 // Returns error if validation fails (and writes response).
 func (h *Handler) validateTypeFilterPACEligibility(ctx context.Context, typeFilter [][]string, cmsID string, w http.ResponseWriter) error {
 	// Tags that require PAC eligibility

--- a/bcda/api/requests.go
+++ b/bcda/api/requests.go
@@ -830,7 +830,8 @@ func (h *Handler) authorizedResourceAccess(dataType service.ClaimType, cmsID str
 }
 
 // validateTypeFilterPACEligibility validates that ACOs requesting SharedSystem
-// tags in _typeFilter have PAC data access. Returns error if validation fails (and writes response).
+// tags in _typeFilter have PAC data access. Handles parsing of multiple comma-separated tag codes. 
+// Returns error if validation fails (and writes response).
 func (h *Handler) validateTypeFilterPACEligibility(ctx context.Context, typeFilter [][]string, cmsID string, w http.ResponseWriter) error {
 	// Tags that require PAC eligibility
 	tagsRequiringPAC := []string{"SharedSystem"}
@@ -841,8 +842,8 @@ func (h *Handler) validateTypeFilterPACEligibility(ctx context.Context, typeFilt
 		if len(paramPair) == 2 && paramPair[0] == "_tag" {
 			tagValue := paramPair[1]
 			// Extract tag code from either short format or URL format
-			tagCode := extractTagCodeFromValue(tagValue)
-			requestedTagCodes = append(requestedTagCodes, tagCode)
+			tagCodes := extractTagCodeFromValue(tagValue)
+			requestedTagCodes = append(requestedTagCodes, tagCodes...)
 		}
 	}
 
@@ -884,15 +885,22 @@ func (h *Handler) validateTypeFilterPACEligibility(ctx context.Context, typeFilt
 	return nil
 }
 
-// extractTagCodeFromValue extracts the tag code from either a short format (e.g., "SharedSystem")
-// or a full URL format (e.g., "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|SharedSystem")
-func extractTagCodeFromValue(tagValue string) string {
-	// Check if it's a URL format with pipe separator
-	if pipeIdx := strings.LastIndex(tagValue, "|"); pipeIdx != -1 {
-		return tagValue[pipeIdx+1:]
+// extractTagCodeFromValue extracts tag codes from either a short format (e.g., "SharedSystem")
+// or a full URL format (e.g., "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|SharedSystem").
+// It supports processing a comma-separated list of tags, returning a slice of all extracted codes.
+func extractTagCodeFromValue(tagValue string) []string {
+	var codes []string
+	tags := strings.Split(tagValue, ",")
+	for _, tag := range tags {
+		// Check if it's a URL format with pipe separator
+		if pipeIdx := strings.LastIndex(tag, "|"); pipeIdx != -1 {
+			codes = append(codes, tag[pipeIdx+1:])
+		} else {
+			// Otherwise, it's short format, return as-is
+			codes = append(codes, tag)
+		}
 	}
-	// Otherwise, it's short format, return as-is
-	return tagValue
+	return codes
 }
 
 // omitSharedSystemForNonPAC ensures that non-PAC eligible ACOs in v3 do not receive SharedSystem data
@@ -916,9 +924,14 @@ func (h *Handler) omitSharedSystemForNonPAC(ctx context.Context, typeFilter [][]
 	hasRelevantFilter := false
 	for _, paramPair := range typeFilter {
 		if len(paramPair) == 2 && paramPair[0] == "_tag" {
-			tagCode := extractTagCodeFromValue(paramPair[1])
-			if tagCode == "NationalClaimsHistory" || tagCode == "DDPS" {
-				hasRelevantFilter = true
+			tagCodes := extractTagCodeFromValue(paramPair[1])
+			for _, tagCode := range tagCodes {
+				if tagCode == "NationalClaimsHistory" || tagCode == "DDPS" {
+					hasRelevantFilter = true
+					break
+				}
+			}
+			if hasRelevantFilter {
 				break
 			}
 		}

--- a/bcda/api/requests_test.go
+++ b/bcda/api/requests_test.go
@@ -1435,9 +1435,14 @@ func TestValidateTypeFilterPACEligibility(t *testing.T) {
 			requiresPACCheck := false
 			for _, paramPair := range test.typeFilter {
 				if len(paramPair) == 2 && paramPair[0] == "_tag" {
-					tagCode := extractTagCodeFromValue(paramPair[1])
-					if tagCode == "SharedSystem" {
-						requiresPACCheck = true
+					tagCodes := extractTagCodeFromValue(paramPair[1])
+					for _, code := range tagCodes {
+						if code == "SharedSystem" {
+							requiresPACCheck = true
+							break
+						}
+					}
+					if requiresPACCheck {
 						break
 					}
 				}
@@ -1479,14 +1484,16 @@ func TestExtractTagCodeFromValue(t *testing.T) {
 	tests := []struct {
 		name     string
 		tagValue string
-		expected string
+		expected []string
 	}{
-		{"shortFormat", "SharedSystem", "SharedSystem"},
-		{"shortFormatNotFinalAction", "NotFinalAction", "NotFinalAction"},
-		{"urlFormatSystemType", "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|SharedSystem", "SharedSystem"},
-		{"urlFormatFinalAction", "https://bluebutton.cms.gov/fhir/CodeSystem/Final-Action|FinalAction", "FinalAction"},
-		{"urlFormatWithMultiplePipes", "https://example.com|system|SharedSystem", "SharedSystem"},
-		{"emptyString", "", ""},
+		{"shortFormat", "SharedSystem", []string{"SharedSystem"}},
+		{"shortFormatNotFinalAction", "NotFinalAction", []string{"NotFinalAction"}},
+		{"urlFormatSystemType", "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|SharedSystem", []string{"SharedSystem"}},
+		{"urlFormatFinalAction", "https://bluebutton.cms.gov/fhir/CodeSystem/Final-Action|FinalAction", []string{"FinalAction"}},
+		{"urlFormatWithMultiplePipes", "https://example.com|system|SharedSystem", []string{"SharedSystem"}},
+		{"emptyString", "", []string{""}},
+		{"commaSeparatedShort", "SharedSystem,NationalClaimsHistory", []string{"SharedSystem", "NationalClaimsHistory"}},
+		{"commaSeparatedUrl", "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|SharedSystem,https://bluebutton.cms.gov/fhir/CodeSystem/Final-Action|FinalAction", []string{"SharedSystem", "FinalAction"}},
 	}
 
 	for _, tt := range tests {

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -177,6 +177,8 @@ func validateResourceTypes(r *http.Request, rw fhirResponseWriter, w http.Respon
 	return resourceTypes, true
 }
 
+// validateTypeFilterParameter parses the _typeFilter subquery and validates its contents.
+// For _tag, it validates each comma-separated token to correctly resolve compound query filters.
 func validateTypeFilterParameter(r *http.Request, rw fhirResponseWriter, w http.ResponseWriter, version string) ([]TypeFilterParameter, bool) {
 	ctx := r.Context()
 	params, ok := r.URL.Query()["_typeFilter"]
@@ -240,16 +242,19 @@ func validateTypeFilterParameter(r *http.Request, rw fhirResponseWriter, w http.
 				return nil, false
 			}
 
-			if slices.Contains([]string{"service-date", "_tag"}, paramName) {
+			if slices.Contains([]string{"service-date", "_tag", "outcome"}, paramName) {
 				if paramName == "_tag" {
-					if err := validateTagSubqueryParameter(paramValue); err != nil {
-						ctx, _ = log.WriteWarnWithFields(
-							ctx,
-							fmt.Sprintf("%s: %s", responseutils.RequestErr, err.Error()),
-							logrus.Fields{"resp_status": http.StatusBadRequest},
-						)
-						rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.RequestErr, err.Error())
-						return nil, false
+					tags := strings.Split(paramValue, ",")
+					for _, tag := range tags {
+						if err := validateTagSubqueryParameter(tag); err != nil {
+							ctx, _ = log.WriteWarnWithFields(
+								ctx,
+								fmt.Sprintf("%s: %s", responseutils.RequestErr, err.Error()),
+								logrus.Fields{"resp_status": http.StatusBadRequest},
+							)
+							rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.RequestErr, err.Error())
+							return nil, false
+						}
 					}
 				}
 				// TODO: add service-date validation

--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -243,19 +243,22 @@ func validateTypeFilterParameter(r *http.Request, rw fhirResponseWriter, w http.
 			}
 
 			if slices.Contains([]string{"service-date", "_tag", "outcome"}, paramName) {
-				if paramName == "_tag" {
-					tags := strings.Split(paramValue, ",")
-					for _, tag := range tags {
-						if err := validateTagSubqueryParameter(tag); err != nil {
-							ctx, _ = log.WriteWarnWithFields(
-								ctx,
-								fmt.Sprintf("%s: %s", responseutils.RequestErr, err.Error()),
-								logrus.Fields{"resp_status": http.StatusBadRequest},
-							)
-							rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.RequestErr, err.Error())
-							return nil, false
-						}
-					}
+				var validationErr error
+				switch paramName {
+				case "_tag":
+					validationErr = validateSubqueryParameterList(paramValue, validateTagSubqueryParameter)
+				case "outcome":
+					validationErr = validateSubqueryParameterList(paramValue, validateOutcomeSubqueryParameter)
+				}
+
+				if validationErr != nil {
+					ctx, _ = log.WriteWarnWithFields(
+						ctx,
+						fmt.Sprintf("%s: %s", responseutils.RequestErr, validationErr.Error()),
+						logrus.Fields{"resp_status": http.StatusBadRequest},
+					)
+					rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.RequestErr, validationErr.Error())
+					return nil, false
 				}
 				// TODO: add service-date validation
 				typeFilterSubqueryParams = append(typeFilterSubqueryParams, TypeFilterSubqueryParam{Name: paramName, Value: paramValue})
@@ -378,6 +381,17 @@ func ValidateRequestHeaders(next http.Handler) http.Handler {
 	})
 }
 
+// validateSubqueryParameterList splits a comma-separated parameter value and validates each individual value
+// against the provided validation function. It returns the first error encountered, if any.
+func validateSubqueryParameterList(paramValue string, validateFunc func(string) error) error {
+	for _, val := range strings.Split(paramValue, ",") {
+		if err := validateFunc(val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateTagSubqueryParameter ensure that _tag param is a valid token (sysyem|code)
 func validateTagSubqueryParameter(tag string) error {
 
@@ -399,6 +413,14 @@ func validateTagSubqueryParameter(tag string) error {
 		return fmt.Errorf("invalid _tag value: %s", tag)
 	}
 
+	return nil
+}
+
+// validateOutcomeSubqueryParameter ensure that outcome param is a valid value (complete or partial)
+func validateOutcomeSubqueryParameter(outcome string) error {
+	if outcome != "complete" && outcome != "partial" {
+		return fmt.Errorf("invalid outcome value: %s. Supported outcome values are 'complete' and 'partial'", outcome)
+	}
 	return nil
 }
 

--- a/bcda/web/middleware/validation_test.go
+++ b/bcda/web/middleware/validation_test.go
@@ -155,6 +155,26 @@ func TestValidateTagSubqueryParameter(t *testing.T) {
 	}
 }
 
+func TestValidateOutcomeSubqueryParameter(t *testing.T) {
+	tests := []struct {
+		name         string
+		outcomeValue string
+		expected     error
+	}{
+		{"validComplete", "complete", nil},
+		{"validPartial", "partial", nil},
+		{"invalidValue", "invalid", fmt.Errorf("invalid outcome value: invalid. Supported outcome values are 'complete' and 'partial'")},
+		{"emptyValue", "", fmt.Errorf("invalid outcome value: . Supported outcome values are 'complete' and 'partial'")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOutcomeSubqueryParameter(tt.outcomeValue)
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
 func TestValidateTypeFilterTagCodes(t *testing.T) {
 	baseV3 := constants.V3Path + "Patient/$export?"
 	ctx := context.Background()
@@ -235,6 +255,13 @@ func TestValidateTypeFilterTagCodes(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:        "invalidOutcome",
+			url:         fmt.Sprintf("%s_typeFilter=ExplanationOfBenefit%%3Foutcome%%3Dinvalid_status", baseV3),
+			shouldFail:  true,
+			errMsg:      "invalid outcome value: invalid_status. Supported outcome values are 'complete' and 'partial'",
+			description: "Outcome must be complete or partial",
 		},
 		{
 			name:        "validTagDDPS",

--- a/bcda/web/middleware/validation_test.go
+++ b/bcda/web/middleware/validation_test.go
@@ -203,6 +203,40 @@ func TestValidateTypeFilterTagCodes(t *testing.T) {
 			},
 		},
 		{
+			name:        "validTagSharedSystemComma",
+			url:         fmt.Sprintf("%s_typeFilter=ExplanationOfBenefit%%3F_tag%%3Dhttps%%3A%%2F%%2Fbluebutton.cms.gov%%2Ffhir%%2FCodeSystem%%2FSystem-Type%%7CSharedSystem,https%%3A%%2F%%2Fbluebutton.cms.gov%%2Ffhir%%2FCodeSystem%%2FFinal-Action%%7CFinalAction", baseV3),
+			shouldFail:  false,
+			description: "Valid comma-separated tags should pass",
+			expectedTypeFilter: []TypeFilterParameter{
+				{
+					ResourceType: "ExplanationOfBenefit",
+					QueryParameters: []TypeFilterSubqueryParam{
+						{
+							Name:  "_tag",
+							Value: "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|SharedSystem,https://bluebutton.cms.gov/fhir/CodeSystem/Final-Action|FinalAction",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "validOutcomeComma",
+			url:         fmt.Sprintf("%s_typeFilter=ExplanationOfBenefit%%3Foutcome%%3Dpartial,complete", baseV3),
+			shouldFail:  false,
+			description: "Valid comma-separated outcome should pass",
+			expectedTypeFilter: []TypeFilterParameter{
+				{
+					ResourceType: "ExplanationOfBenefit",
+					QueryParameters: []TypeFilterSubqueryParam{
+						{
+							Name:  "outcome",
+							Value: "partial,complete",
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "validTagDDPS",
 			url:         fmt.Sprintf("%s_typeFilter=ExplanationOfBenefit%%3F_tag%%3Dhttps%%3A%%2F%%2Fbluebutton.cms.gov%%2Ffhir%%2FCodeSystem%%2FSystem-Type%%7CDDPS", baseV3),
 			shouldFail:  false,


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9938

## 🛠 Changes

- update `_typeFilter` validator
  - update the parsing logic to accept `outcome` parameter and correctly parse comma-separated values found inside `_tag` strings
- Update `extractTagCodeFromValue()`
  - format/return a slice of split `_tag` codes ([]string) and not parsing entire comma-separated strings as single entities.
  - update instances calling this helper method.

## ℹ️ Context

For a v3 user, we want to support a comma-separated list of tokens (e.g., `_tags` or `outcomes`) in the `_typeFilter` subquery of the `$export` request so that resources with one or more of the specified tokens are returned.

Requests like
`_typeFilter=ExplanationOfBenefit?_tag=[systemA]|[codeX],[systemB]|[code]`
return EOB resources where Meta.tag contains at least one of the [system]|[code] tuples
OR
`_typeFilter=ExplanationOfBenefit?outcome=partial,complete`
return EOB resources where the outcome is either `partial` or `complete.`

## 🧪 Validation

Unit tests
