### PR TITLE
define app so we can deploy

### DIFF
--- a/ops/services/10-config/main.tf
+++ b/ops/services/10-config/main.tf
@@ -1,7 +1,8 @@
 locals {
   service      = "config"
   default_tags = module.platform.default_tags
-  env          = terraform.workspace
+  env          = terraform.workspacegit
+  app          = "bcda"
 }
 
 module "platform" {


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

Defining local variable "app".

## ℹ️ Context

Made because missing app name was causing failure to deploy terraform from 10-config folder. This blocked the deployment because it requires this to deploy SOPS changes.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
