### PR TITLE
Fix workspace name

### DIFF
--- a/ops/services/10-config/main.tf
+++ b/ops/services/10-config/main.tf
@@ -1,7 +1,7 @@
 locals {
   service      = "config"
   default_tags = module.platform.default_tags
-  env          = terraform.workspacegit
+  env          = terraform.workspace
   app          = "bcda"
 }
 


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

Updated workspace name to be `terraform.workspace`.

## ℹ️ Context

Fix typo in terraform file that is causing tf failures.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation


