### PR TITLE
BCDA-10023: update default cutoff date

### DIFF
--- a/bcda/service/config.go
+++ b/bcda/service/config.go
@@ -28,7 +28,7 @@ func LoadConfig() (cfg *Config, err error) {
 
 type Config struct {
 	SuppressionLookbackDays int         `conf:"BCDA_SUPPRESSION_LOOKBACK_DAYS" conf_default:"60"`
-	CutoffDurationDays      int         `conf:"CCLF_CUTOFF_DATE_DAYS" conf_default:"45"`
+	CutoffDurationDays      int         `conf:"CCLF_CUTOFF_DATE_DAYS" conf_default:"50"`
 	ACOConfigs              []ACOConfig `conf:"aco_config"`
 	V3EnabledACOs           []string    `conf:"v3_enabled_acos"` // Simple list of ACOs with v3 access
 	CutoffDuration          time.Duration

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -1988,7 +1988,7 @@ func newQueueJobTestConfig(t *testing.T, acoConfigs []ACOConfig, v3NoPartialClai
 
 	cfg := &Config{
 		SuppressionLookbackDays: int(30),
-		CutoffDurationDays:      45,
+		CutoffDurationDays:      50,
 		ACOConfigs:              acoConfigs,
 		V3NoPartialClaimsModels: v3NoPartialClaimsModels,
 		RunoutConfig: RunoutConfig{


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10017

## 🛠 Changes

Update the cutoff default to be the same as the param store
