### PR TITLE
BCDA-9920: Remove job priorities

### DIFF
--- a/bcda/service/service.go
+++ b/bcda/service/service.go
@@ -570,17 +570,11 @@ func (s *service) setClaimsDate(args *worker_types.JobEnqueueArgs, prepareArgs w
 // Priority is based on the request parameters that the job is executing on.
 // Note: River queue library requires a priority between 1 and 4 (inclusive)
 func (s *service) GetJobPriority(acoID string, resourceType string, sinceParam bool) int16 {
-	var priority int16
 	if isPriorityACO(acoID) {
-		priority = int16(1) // priority level for jobs for synthetic ACOs that are used for smoke testing
-	} else if resourceType == "Patient" || resourceType == "Coverage" {
-		priority = int16(2) // priority level for jobs that only request smaller resources
-	} else if sinceParam {
-		priority = int16(3) // priority level for jobs that only request data for a limited timeframe
+		return int16(1) // priority level for jobs for synthetic ACOs that are used for smoke testing
 	} else {
-		priority = int16(4) // default priority level for jobs
+		return int16(4) // default priority level for jobs
 	}
-	return priority
 }
 
 // GetACOConfigForID gets first matching currently loaded ACOConfig for the specified cmsID

--- a/bcda/service/service_test.go
+++ b/bcda/service/service_test.go
@@ -1217,10 +1217,6 @@ func (s *ServiceTestSuite) TestGetJobPriority_Integration() {
 		s.T().Run(string(tt.name), func(t *testing.T) {
 			if isPriorityACO(tt.acoID) {
 				expectedPriority = 1
-			} else if tt.resourceType == "Patient" || tt.resourceType == "Coverage" {
-				expectedPriority = 2
-			} else if len(tt.expSince) > 0 || tt.RequestType == constants.RetrieveNewBeneHistData {
-				expectedPriority = 3
 			}
 
 			sinceParam := (len(tt.expSince) > 0) || tt.RequestType == constants.RetrieveNewBeneHistData


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9920

## 🛠 Changes

Remove complex job priority rules.  It should now default all actual job requests to the same priority and thus it should be first come first serve.

## ℹ️ Context

The complex prioritization was causing issues where earlier jobs could sometimes end up getting pushed way back in the job queue and thus take much longer.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
