### PR TITLE
PLT-1666 transfer Mia's work in bcda-ops to new location in bcda-app

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -754,7 +754,7 @@ resource "aws_sns_topic" "cloudwatch_alarms_topic" {
 
 # CDAP-managed alarm-to-slack service queue
 data "aws_sqs_queue" "alarm_to_slack" {
-  name = "bcda-test-alarm-to-slack"
+  name = "cdap-test-alarm-to-slack"
 }
 
 resource "aws_sns_topic_subscription" "alarm_to_slack" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -796,7 +796,7 @@ resource "aws_sns_topic" "cloudwatch_alarms_topic" {
 
 # CDAP-managed alarm-to-slack service queue
 data "aws_sqs_queue" "alarm_to_slack" {
-  name = "bcda-test-alarm-to-slack"
+  name = "cdap-test-alarm-to-slack"
 }
 
 resource "aws_sns_topic_subscription" "alarm_to_slack" {


### PR DESCRIPTION
## 🎫 Ticket


## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Points dev and test SNS topic that handles alarms to the SQS queue associated with CDAP's alarm-to-slack. 

## ℹ️ Context
With the introduction of a cdap-test and cdap-prod, we no longer have to rely on bcda-test and bcda-prod for resources that exist in both AWS accounts. We can migrate onto all CDAP managed and named resources. 

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
These changes will affect only dev and test and testing will be completed there before migrating prod and sandbox onto the cdap managed function. 

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->