### PR TITLE
BCDA-10049: update workflow action dependencies to node24

### DIFF
--- a/.github/workflows/admin-aco-deny-deploy.yml
+++ b/.github/workflows/admin-aco-deny-deploy.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Build admin-aco-deny zip file

--- a/.github/workflows/admin-aco-deny-deploy.yml
+++ b/.github/workflows/admin-aco-deny-deploy.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build admin-aco-deny zip file

--- a/.github/workflows/admin-create-aco-creds-deploy.yml
+++ b/.github/workflows/admin-create-aco-creds-deploy.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Build admin-create-aco-creds zip file

--- a/.github/workflows/admin-create-aco-creds-deploy.yml
+++ b/.github/workflows/admin-create-aco-creds-deploy.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build admin-create-aco-creds zip file

--- a/.github/workflows/admin-create-aco-deploy.yml
+++ b/.github/workflows/admin-create-aco-deploy.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build admin_create_aco zip file

--- a/.github/workflows/admin-create-aco-deploy.yml
+++ b/.github/workflows/admin-create-aco-deploy.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Build admin_create_aco zip file

--- a/.github/workflows/admin-create-group-deploy.yml
+++ b/.github/workflows/admin-create-group-deploy.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build create-group zip file

--- a/.github/workflows/admin-create-group-deploy.yml
+++ b/.github/workflows/admin-create-group-deploy.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Build create-group zip file

--- a/.github/workflows/attribution-import-deploy.yml
+++ b/.github/workflows/attribution-import-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install Datadog Orchestrion APM

--- a/.github/workflows/bene-prefs-import-deploy.yml
+++ b/.github/workflows/bene-prefs-import-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Install Datadog Orchestrion APM

--- a/.github/workflows/bene-prefs-import-deploy.yml
+++ b/.github/workflows/bene-prefs-import-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install Datadog Orchestrion APM

--- a/.github/workflows/cclf-import-deploy.yml
+++ b/.github/workflows/cclf-import-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build cclf-import zip file

--- a/.github/workflows/cclf-import-deploy.yml
+++ b/.github/workflows/cclf-import-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: bcda
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Build cclf-import zip file

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -32,7 +32,7 @@ jobs:
           repository: CMSgov/bcda-app
           ref: ${{ env.REF }}
       - name: Get Go # TEMP
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Tidy modules
@@ -55,7 +55,7 @@ jobs:
           repository: CMSgov/bcda-app
           ref: ${{ env.REF }}
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Install Ansible

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -32,7 +32,7 @@ jobs:
           repository: CMSgov/bcda-app
           ref: ${{ env.REF }}
       - name: Get Go # TEMP
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Tidy modules
@@ -55,7 +55,7 @@ jobs:
           repository: CMSgov/bcda-app
           ref: ${{ env.REF }}
       - name: Get Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install Ansible
@@ -77,7 +77,7 @@ jobs:
         run: make test
         timeout-minutes: 20
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report
           path: ./test_results/latest/testcoverage.out
@@ -104,7 +104,7 @@ jobs:
           repository: CMSgov/bcda-app
           fetch-depth: 0
       - name: Download code coverage
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report
       - name: Run quality gate scan

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -104,7 +104,7 @@ jobs:
           repository: CMSgov/bcda-app
           fetch-depth: 0
       - name: Download code coverage
-        uses: actions/download-artifact@v4.2.1
+        uses: actions/download-artifact@v8.0.1
         with:
           name: code-coverage-report
       - name: Run quality gate scan

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -77,7 +77,7 @@ jobs:
         run: make test
         timeout-minutes: 20
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: code-coverage-report
           path: ./test_results/latest/testcoverage.out

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -240,7 +240,7 @@ jobs:
           aws ecs update-service --cluster bcda-${{ env.RELEASE_ENV }} --service bcda-${{ env.RELEASE_ENV }}-ssas --force-new-deployment
           aws ecs update-service --cluster bcda-${{ env.RELEASE_ENV }} --service bcda-${{ env.RELEASE_ENV }}-worker --force-new-deployment
       - name: Upload notify script
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: notify-script
           path: ./scripts/mark_deployment.py

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -240,7 +240,7 @@ jobs:
           aws ecs update-service --cluster bcda-${{ env.RELEASE_ENV }} --service bcda-${{ env.RELEASE_ENV }}-ssas --force-new-deployment
           aws ecs update-service --cluster bcda-${{ env.RELEASE_ENV }} --service bcda-${{ env.RELEASE_ENV }}-worker --force-new-deployment
       - name: Upload notify script
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: notify-script
           path: ./scripts/mark_deployment.py

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -55,7 +55,7 @@ jobs:
           params: |
             DB_URL=/bcda/${{ inputs.env }}/sensitive/api/DATABASE_URL
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Get golang-migrate

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -55,7 +55,7 @@ jobs:
           params: |
             DB_URL=/bcda/${{ inputs.env }}/sensitive/api/DATABASE_URL
       - name: Get Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Get golang-migrate

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -74,7 +74,7 @@ jobs:
           repository: CMSgov/bcda-app 
           ref: ${{ env.RELEASE_VERSION }}
       - name: Download release scripts
-        uses: actions/download-artifact@v4.2.1
+        uses: actions/download-artifact@v8.0.1
         with:
           name: release-scripts
           path: scripts/tag_and_release

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${{ env.BCDA_GPG_PUB_KEY }}" > ./${{ env.GPG_KEY_FILE_NAME }}
           GITHUB_REPO_PATH='/CMSgov/bcda-ops' GITHUB_ACCESS_TOKEN=${{ env.OPS_GITHUB_TOKEN }} GITHUB_USER='${{ env.RELEASE_GITHUB_USER }}' GITHUB_EMAIL='${{ env.RELEASE_GITHUB_EMAIL }}' GITHUB_GPG_KEY_FILE=${{ env.GPG_KEY_FILE_NAME }} bash scripts/tag_and_release/release.sh ${{ env.MANUAL_TAG_ARGS }}
       - name: Upload release scripts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-scripts
           path: |

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -62,7 +62,7 @@ jobs:
           echo "${{ env.BCDA_GPG_PUB_KEY }}" > ./${{ env.GPG_KEY_FILE_NAME }}
           GITHUB_REPO_PATH='/CMSgov/bcda-ops' GITHUB_ACCESS_TOKEN=${{ env.OPS_GITHUB_TOKEN }} GITHUB_USER='${{ env.RELEASE_GITHUB_USER }}' GITHUB_EMAIL='${{ env.RELEASE_GITHUB_EMAIL }}' GITHUB_GPG_KEY_FILE=${{ env.GPG_KEY_FILE_NAME }} bash scripts/tag_and_release/release.sh ${{ env.MANUAL_TAG_ARGS }}
       - name: Upload release scripts
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-scripts
           path: |
@@ -74,7 +74,7 @@ jobs:
           repository: CMSgov/bcda-app 
           ref: ${{ env.RELEASE_VERSION }}
       - name: Download release scripts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-scripts
           path: scripts/tag_and_release


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10049

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

- upgraded the versions of the following workflow actions to newer versions that do not use Node20:
  -  setup-go
  - upload-artifact
  - download-artifact

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

Actions were upgraded to address warnings we're seeing in our workflow logs
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: ACTION_NAME. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file.
```

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

View the workflows run as part of this PR and ensure that there are no Node-related error messages present.
