### PR TITLE
BCDA-10050: adjust data metric setters

### DIFF
--- a/bcda/models/postgres/repository.go
+++ b/bcda/models/postgres/repository.go
@@ -489,7 +489,8 @@ func (r *Repository) CreateJob(ctx context.Context, j models.Job) (uint, error) 
 		j.Status,
 		j.TransactionTime,
 		j.JobCount,
-		sqlbuilder.Raw("NOW()"), sqlbuilder.Raw("NOW()"),
+		sqlbuilder.Raw("NOW()"),
+		sqlbuilder.Raw("NOW()"),
 		j.BenesAttributedToACO,
 	)
 

--- a/bcda/models/postgres/repository_test.go
+++ b/bcda/models/postgres/repository_test.go
@@ -844,7 +844,7 @@ func (r *RepositoryTestSuite) TestJobsMethods() {
 
 	failed := models.Job{ACOID: aco.UUID, RequestURL: reqURL, Status: models.JobStatusFailed, JobCount: 10}
 	pending := models.Job{ACOID: aco.UUID, RequestURL: reqURL, Status: models.JobStatusPending, JobCount: 30}
-	completed := models.Job{ACOID: aco.UUID, RequestURL: reqURL, Status: models.JobStatusCompleted, JobCount: 40}
+	completed := models.Job{ACOID: aco.UUID, RequestURL: reqURL, Status: models.JobStatusCompleted, JobCount: 40, BenesAttributedToACO: 20}
 
 	failed.ID, err = r.repository.CreateJob(ctx, failed)
 	assert.NoError(err)
@@ -931,10 +931,13 @@ func (r *RepositoryTestSuite) TestJobsMethods() {
 	assert.True(newFailed.UpdatedAt.After(newCompleted.UpdatedAt))
 
 	// Verify BenesAttributedToACO
+	updatedCompleted, err := r.repository.GetJobByID(ctx, completed.ID)
+	assert.NoError(err)
+	assert.Equal(20, updatedCompleted.BenesAttributedToACO)
 	completed.BenesAttributedToACO = 10
 	err = r.repository.UpdateJob(ctx, completed)
 	assert.Nil(err)
-	updatedCompleted, err := r.repository.GetJobByID(ctx, completed.ID)
+	updatedCompleted, err = r.repository.GetJobByID(ctx, completed.ID)
 	assert.Nil(err)
 	assert.Equal(10, updatedCompleted.BenesAttributedToACO)
 

--- a/bcdaworker/cleanup/cleanup_test.go
+++ b/bcdaworker/cleanup/cleanup_test.go
@@ -86,11 +86,12 @@ func (s *CleanupTestSuite) TestArchiveExpiring() {
 	// timestamp to ensure that the job gets archived (older than the default 24h window)
 	t := time.Now().Add(-48 * time.Hour)
 	j := models.Job{
-		ACOID:      uuid.Parse(constants.TestACOID),
-		RequestURL: constants.V1Path + constants.EOBExportPath,
-		Status:     models.JobStatusCompleted,
-		CreatedAt:  t,
-		UpdatedAt:  t,
+		ACOID:                uuid.Parse(constants.TestACOID),
+		RequestURL:           constants.V1Path + constants.EOBExportPath,
+		Status:               models.JobStatusCompleted,
+		CreatedAt:            t,
+		UpdatedAt:            t,
+		BenesAttributedToACO: 10,
 	}
 	postgrestest.CreateJobs(s.T(), s.db, &j)
 
@@ -134,8 +135,11 @@ func (s *CleanupTestSuite) TestArchiveExpiring() {
 
 	testJob := postgrestest.GetJobByID(s.T(), s.db, j.ID)
 
-	// check the status of the job
+	// check the status of the job and that no other fields were modified
+	assert.Equal(uuid.Parse(constants.TestACOID), testJob.ACOID)
+	assert.Equal((constants.V1Path + constants.EOBExportPath), testJob.RequestURL)
 	assert.Equal(models.JobStatusArchived, testJob.Status)
+	assert.Equal(10, testJob.BenesAttributedToACO)
 
 	// clean up
 	os.RemoveAll(conf.GetEnv("FHIR_ARCHIVE_DIR"))
@@ -150,11 +154,12 @@ func (s *CleanupTestSuite) TestArchiveExpiringWithoutPayloadDir() {
 	t := time.Now().Add(-48 * time.Hour)
 
 	j := models.Job{
-		ACOID:      uuid.Parse(constants.TestACOID),
-		RequestURL: constants.V1Path + constants.EOBExportPath,
-		Status:     models.JobStatusCompleted,
-		CreatedAt:  t,
-		UpdatedAt:  t,
+		ACOID:                uuid.Parse(constants.TestACOID),
+		RequestURL:           constants.V1Path + constants.EOBExportPath,
+		Status:               models.JobStatusCompleted,
+		CreatedAt:            t,
+		UpdatedAt:            t,
+		BenesAttributedToACO: 10,
 	}
 	postgrestest.CreateJobs(s.T(), s.db, &j)
 
@@ -164,8 +169,11 @@ func (s *CleanupTestSuite) TestArchiveExpiringWithoutPayloadDir() {
 
 	testJob := postgrestest.GetJobByID(s.T(), s.db, j.ID)
 
-	// check the status of the job
+	// check the status of the job and that no other fields were modified
+	assert.Equal(uuid.Parse(constants.TestACOID), testJob.ACOID)
+	assert.Equal((constants.V1Path + constants.EOBExportPath), testJob.RequestURL)
 	assert.Equal(models.JobStatusArchived, testJob.Status)
+	assert.Equal(10, testJob.BenesAttributedToACO)
 
 	// clean up
 	os.RemoveAll(conf.GetEnv("FHIR_ARCHIVE_DIR"))
@@ -174,9 +182,10 @@ func (s *CleanupTestSuite) TestArchiveExpiringWithoutPayloadDir() {
 func (s *CleanupTestSuite) TestArchiveExpiringWithThreshold() {
 	// save a job to our db
 	j := models.Job{
-		ACOID:      uuid.Parse(constants.TestACOID),
-		RequestURL: constants.V1Path + constants.EOBExportPath,
-		Status:     models.JobStatusCompleted,
+		ACOID:                uuid.Parse(constants.TestACOID),
+		RequestURL:           constants.V1Path + constants.EOBExportPath,
+		Status:               models.JobStatusCompleted,
+		BenesAttributedToACO: 10,
 	}
 	postgrestest.CreateJobs(s.T(), s.db, &j)
 
@@ -210,8 +219,11 @@ func (s *CleanupTestSuite) TestArchiveExpiringWithThreshold() {
 	assert.FileExists(s.T(), dataPath, "File not Found")
 
 	testJob := postgrestest.GetJobByID(s.T(), s.db, j.ID)
-	// check the status of the job
+	// check the status of the job and that no other fields were modified
+	assert.Equal(s.T(), uuid.Parse(constants.TestACOID), testJob.ACOID)
+	assert.Equal(s.T(), (constants.V1Path + constants.EOBExportPath), testJob.RequestURL)
 	assert.Equal(s.T(), models.JobStatusCompleted, testJob.Status)
+	assert.Equal(s.T(), 10, testJob.BenesAttributedToACO)
 
 	// clean up
 	os.Remove(dataPath)

--- a/bcdaworker/repository/postgres/repository.go
+++ b/bcdaworker/repository/postgres/repository.go
@@ -86,7 +86,7 @@ func (r *Repository) GetCCLFBeneficiaryByID(ctx context.Context, id uint) (*mode
 
 func (r *Repository) GetJobByID(ctx context.Context, jobID uint) (*models.Job, error) {
 	sb := sqlFlavor.NewSelectBuilder()
-	sb.Select("id", "aco_id", "request_url", "status", "transaction_time", "job_count", "created_at", "updated_at")
+	sb.Select("id", "aco_id", "request_url", "status", "transaction_time", "job_count", "created_at", "updated_at", "benes_attributed_to_aco")
 	sb.From("jobs").Where(sb.Equal("id", jobID))
 
 	query, args := sb.Build()
@@ -96,8 +96,17 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID uint) (*models.Job, e
 		transactionTime, createdAt, updatedAt sql.NullTime
 	)
 
-	err := r.QueryRowContext(ctx, query, args...).Scan(&j.ID, &j.ACOID, &j.RequestURL, &j.Status, &transactionTime,
-		&j.JobCount, &createdAt, &updatedAt)
+	err := r.QueryRowContext(ctx, query, args...).Scan(
+		&j.ID,
+		&j.ACOID,
+		&j.RequestURL,
+		&j.Status,
+		&transactionTime,
+		&j.JobCount,
+		&createdAt,
+		&updatedAt,
+		&j.BenesAttributedToACO,
+	)
 	j.TransactionTime, j.CreatedAt, j.UpdatedAt = transactionTime.Time, createdAt.Time, updatedAt.Time
 
 	if err != nil {

--- a/bcdaworker/repository/postgres/repository_test.go
+++ b/bcdaworker/repository/postgres/repository_test.go
@@ -3,26 +3,31 @@ package postgres_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models"
+	bcdaPostgres "github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres/postgrestest"
 	"github.com/CMSgov/bcda-app/bcda/testUtils"
 	"github.com/CMSgov/bcda-app/bcdaworker/repository"
 	"github.com/CMSgov/bcda-app/bcdaworker/repository/postgres"
+	"github.com/CMSgov/bcda-app/db"
 	"github.com/ccoveille/go-safecast"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
 )
 
 type RepositoryTestSuite struct {
 	suite.Suite
 
-	db         *sql.DB
-	repository *postgres.Repository
+	db          *sql.DB
+	repository  *postgres.Repository
+	dbContainer db.TestDatabaseContainer
 }
 
 func TestRepositoryTestSuite(t *testing.T) {
@@ -30,8 +35,30 @@ func TestRepositoryTestSuite(t *testing.T) {
 }
 
 func (r *RepositoryTestSuite) SetupSuite() {
-	r.db = database.Connect()
+	var err error
+	r.dbContainer, err = db.NewTestDatabaseContainer()
+	require.NoError(r.T(), err)
+}
+
+func (s *RepositoryTestSuite) TearDownSuite() {
+	defer func() {
+		if err := testcontainers.TerminateContainer(s.dbContainer.Container); err != nil {
+			s.T().Log(fmt.Errorf("failed to terminate container: %w", err))
+		}
+	}()
+}
+
+func (r *RepositoryTestSuite) SetupTest() {
+	var err error
+	r.db, err = r.dbContainer.NewSqlDbConnection()
+	require.NoError(r.T(), err)
 	r.repository = postgres.NewRepository(r.db)
+}
+
+func (r *RepositoryTestSuite) TearDownTest() {
+	r.db.Close()
+	err := r.dbContainer.RestoreSnapshot("Base")
+	require.NoError(r.T(), err)
 }
 
 // TestACOMethods validates the CRUD operations associated with the acos table
@@ -81,6 +108,7 @@ func (r *RepositoryTestSuite) TestCCLFBeneficiariesMethods() {
 
 // TestJobsMethods validates the CRUD operations associated with the jobs table
 func (r *RepositoryTestSuite) TestJobsMethods() {
+	var err error
 	// Account for time precision in postgres
 	now := time.Now().Round(time.Millisecond).UTC()
 
@@ -94,13 +122,22 @@ func (r *RepositoryTestSuite) TestJobsMethods() {
 	postgrestest.CreateACO(r.T(), r.db, aco)
 	defer postgrestest.DeleteACO(r.T(), r.db, aco.UUID)
 
-	failed := models.Job{ACOID: aco.UUID, Status: models.JobStatusFailed, TransactionTime: now}
-	completed := models.Job{ACOID: aco.UUID, Status: models.JobStatusCompleted, TransactionTime: now}
-	postgrestest.CreateJobs(r.T(), r.db, &failed, &completed)
+	failed := models.Job{ACOID: aco.UUID, Status: models.JobStatusFailed, TransactionTime: now, BenesAttributedToACO: 5}
+	completed := models.Job{ACOID: aco.UUID, Status: models.JobStatusCompleted, TransactionTime: now, BenesAttributedToACO: 10}
+	// postgrestest.CreateJobs(r.T(), r.db, &failed, &completed)
 
-	failed1, err := r.repository.GetJobByID(ctx, failed.ID)
+	bcdaRepo := bcdaPostgres.NewRepository(r.db)
+	failed.ID, err = bcdaRepo.CreateJob(ctx, failed)
 	assert.NoError(err)
-	assertJobsEqual(assert, failed, *failed1)
+	completed.ID, err = bcdaRepo.CreateJob(ctx, completed)
+	assert.NoError(err)
+
+	failedRetr, err := r.repository.GetJobByID(ctx, failed.ID)
+	assert.NoError(err)
+	assert.Equal(failed.ACOID, failedRetr.ACOID)
+	assert.Equal(failed.Status, failedRetr.Status)
+	assert.Equal(failed.TransactionTime, failedRetr.TransactionTime)
+	assert.Equal(failed.BenesAttributedToACO, failedRetr.BenesAttributedToACO)
 
 	failed.Status = models.JobStatusArchived
 	assert.NoError(r.repository.UpdateJobStatus(ctx, failed.ID, failed.Status))
@@ -108,23 +145,28 @@ func (r *RepositoryTestSuite) TestJobsMethods() {
 	assert.NoError(err)
 
 	assert.True(afterUpdate.UpdatedAt.After(failed.UpdatedAt))
-	// Allows us to compare all of the Job fields
-	failed.UpdatedAt = afterUpdate.UpdatedAt
-	assertJobsEqual(assert, failed, *afterUpdate)
+	assert.Equal(failed.ACOID, afterUpdate.ACOID)
+	assert.Equal(failed.Status, afterUpdate.Status)
+	assert.Equal(failed.TransactionTime, afterUpdate.TransactionTime)
+	assert.Equal(failed.BenesAttributedToACO, afterUpdate.BenesAttributedToACO)
 
 	failed.Status = models.JobStatusExpired
 	assert.NoError(r.repository.UpdateJobStatusCheckStatus(ctx, failed.ID, models.JobStatusArchived, failed.Status))
 	afterUpdate, err = r.repository.GetJobByID(ctx, failed.ID)
 	assert.NoError(err)
 	assert.True(afterUpdate.UpdatedAt.After(failed.UpdatedAt))
-	// Allows us to compare all of the Job fields
-	failed.UpdatedAt = afterUpdate.UpdatedAt
-	assertJobsEqual(assert, failed, *afterUpdate)
+	assert.Equal(failed.ACOID, afterUpdate.ACOID)
+	assert.Equal(failed.Status, afterUpdate.Status)
+	assert.Equal(failed.TransactionTime, afterUpdate.TransactionTime)
+	assert.Equal(failed.BenesAttributedToACO, afterUpdate.BenesAttributedToACO)
 
 	// After all of these updates, the completed job should remain untouched
-	completed1, err := r.repository.GetJobByID(ctx, completed.ID)
+	completedRetr, err := r.repository.GetJobByID(ctx, completed.ID)
 	assert.NoError(err)
-	assertJobsEqual(assert, completed, *completed1)
+	assert.Equal(completed.ACOID, completedRetr.ACOID)
+	assert.Equal(completed.Status, completedRetr.Status)
+	assert.Equal(completed.TransactionTime, completedRetr.TransactionTime)
+	assert.Equal(completed.BenesAttributedToACO, completedRetr.BenesAttributedToACO)
 
 	// Negative cases
 	_, err = r.repository.GetJobByID(ctx, 0)

--- a/bcdaworker/repository/postgres/repository_test.go
+++ b/bcdaworker/repository/postgres/repository_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/CMSgov/bcda-app/db"
 	"github.com/ccoveille/go-safecast"
 	"github.com/pborman/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
@@ -237,9 +236,4 @@ func (r *RepositoryTestSuite) TestJobKeyMethods() {
 
 	_, err = r.repository.GetJobKey(ctx, jobID, -1)
 	assert.EqualError(err, repository.ErrJobKeyNotFound.Error())
-}
-
-func assertJobsEqual(assert *assert.Assertions, expected, actual models.Job) {
-	expected.TransactionTime, actual.TransactionTime = expected.TransactionTime.UTC(), actual.TransactionTime.UTC()
-	assert.Equal(expected, actual)
 }

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -441,13 +441,13 @@ func appendErrorToFile(ctx context.Context, fileUUID string,
 func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, fileUUID string, tmpDir string, hasEntriesCount *int) {
 	defer w.Flush()
 	logger := log.GetCtxLogger(ctx)
+	hasAtLeastOneEntry := false
 
 	for _, entry := range b.Entries {
 		if entry["resource"] == nil {
 			continue
 		}
-
-		*hasEntriesCount++
+		hasAtLeastOneEntry = true
 
 		entryJSON, err := json.Marshal(entry["resource"])
 		// This is unlikely to happen because we just unmarshalled this data a few lines above.
@@ -464,6 +464,10 @@ func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmod
 			appendErrorToFile(ctx, fileUUID, fhircodes.IssueTypeCode_EXCEPTION,
 				responseutils.InternalErr, fmt.Sprintf("Error writing %s to file for beneficiary %s in ACO %s", jsonType, beneficiaryID, acoID), tmpDir)
 		}
+	}
+
+	if hasAtLeastOneEntry {
+		*hasEntriesCount++
 	}
 }
 

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -331,7 +331,11 @@ func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.A
 				//MBI is appended inside file, not printed out to system logs
 				return fmt.Sprintf("Error retrieving %s for beneficiary MBI %s in ACO %s", jobArgs.ResourceType, bene.MBI, jobArgs.ACOID), fhircodes.IssueTypeCode_NOT_FOUND, err
 			}
-			fhirBundleToResourceNDJSON(ctx, w, b, jobArgs.ResourceType, beneID, cmsID, fileUUID, tmpDir, &benesWithDataCount)
+			hadData := fhirBundleToResourceNDJSON(ctx, w, b, jobArgs.ResourceType, beneID, cmsID, fileUUID, tmpDir)
+			if hadData {
+				benesWithDataCount++
+			}
+
 			return "", 0, nil
 		}()
 
@@ -438,7 +442,7 @@ func appendErrorToFile(ctx context.Context, fileUUID string,
 	}
 }
 
-func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, fileUUID string, tmpDir string, hasEntriesCount *int) {
+func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmodels.Bundle, jsonType, beneficiaryID, acoID, fileUUID string, tmpDir string) (hadData bool) {
 	defer w.Flush()
 	logger := log.GetCtxLogger(ctx)
 	hasAtLeastOneEntry := false
@@ -466,9 +470,7 @@ func fhirBundleToResourceNDJSON(ctx context.Context, w *bufio.Writer, b *fhirmod
 		}
 	}
 
-	if hasAtLeastOneEntry {
-		*hasEntriesCount++
-	}
+	return hasAtLeastOneEntry
 }
 
 func CheckJobCompleteAndCleanup(ctx context.Context, r repository.Repository, jobID uint) (jobCompleted bool, err error) {

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -210,18 +210,19 @@ func (s *WorkerTestSuite) TestGetBlueButtonID_NonHappyPaths() {
 
 func (s *WorkerTestSuite) TestWriteResourcesToFile() {
 	tests := []struct {
-		resource      string
-		jobKeysCount  int
-		fileCount     int
-		expectedCount int
-		err           error
+		resource                   string
+		jobKeysCount               int
+		fileCount                  int
+		entriesCount               int
+		expectedBenesWithDataCount int
+		err                        error
 	}{
-		{"ExplanationOfBenefit", 1, 1, 33, nil},
-		{"Coverage", 1, 1, 3, nil},
-		{"Patient", 1, 1, 1, nil},
-		{"Claim", 1, 1, 1, nil},
-		{"ClaimResponse", 1, 1, 1, nil},
-		{"UnsupportedResource", 1, 0, 0, errors.Errorf("unsupported resource")},
+		{"ExplanationOfBenefit", 1, 1, 33, 1, nil},
+		{"Coverage", 1, 1, 3, 1, nil},
+		{"Patient", 1, 1, 1, 1, nil},
+		{"Claim", 1, 1, 1, 1, nil},
+		{"ClaimResponse", 1, 1, 1, 1, nil},
+		{"UnsupportedResource", 1, 0, 0, 0, errors.Errorf("unsupported resource")},
 	}
 
 	for _, tt := range tests {
@@ -242,8 +243,8 @@ func (s *WorkerTestSuite) TestWriteResourcesToFile() {
 			} else {
 				assert.Equal(s.T(), 0, jobKeys[0].BenesRetrievedPercent)
 			}
-			assert.Equal(s.T(), tt.expectedCount, jobKeys[0].BenesWithData)
-			VerifyFileContent(s.T(), files, tt.resource, tt.expectedCount, s.tempDir)
+			assert.Equal(s.T(), tt.expectedBenesWithDataCount, jobKeys[0].BenesWithData)
+			VerifyFileContent(s.T(), files, tt.resource, tt.entriesCount, s.tempDir)
 		})
 	}
 }
@@ -311,6 +312,7 @@ func VerifyFileContent(t *testing.T, files []fs.DirEntry, resource string, expec
 		}
 		scan := scanner.Scan()
 		assert.False(t, scan, "There should be only %d entries in the file.", expectedCount)
+		assert.NoError(t, scanner.Err())
 	}
 }
 
@@ -363,7 +365,7 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFileWithErrorsBelowFailureThreshold(
 	assert.NotEqual(s.T(), "blank.ndjson", jobKeys[0].FileName)
 	assert.Contains(s.T(), jobKeys[1].FileName, "error.ndjson")
 	assert.Equal(s.T(), 33, jobKeys[0].BenesRetrievedPercent)
-	assert.Equal(s.T(), 33, jobKeys[0].BenesWithData)
+	assert.Equal(s.T(), 1, jobKeys[0].BenesWithData)
 	assert.Len(s.T(), jobKeys, 2)
 	assert.NoError(s.T(), err)
 	errorFilePath := fmt.Sprintf("%s/%s", s.tempDir, jobKeys[1].FileName)
@@ -1045,16 +1047,20 @@ func (s *WorkerTestSuite) TestFhirBundleToResourceNDJSON() {
 	b := fhirmodels.Bundle{Entries: entries}
 	beneID := "MBITEST"
 	acoID := "A9994"
-	entriesCount := 0
+	benesWithDataCount := 0
 
-	fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./", &entriesCount)
-	assert.Equal(s.T(), 2, entriesCount)
+	fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./", &benesWithDataCount)
+	assert.Equal(s.T(), 1, benesWithDataCount)
 
 	_, err = f.Seek(0, io.SeekStart)
 	assert.Nil(s.T(), err)
 	data, err := io.ReadAll(f)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "{\"test\":\"entry\"}\n{\"test2\":\"entry2\"}\n", string(data))
+
+	// test that we increment again with additional bene
+	fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./", &benesWithDataCount)
+	assert.Equal(s.T(), 2, benesWithDataCount)
 }
 
 func (s *WorkerTestSuite) TestFhirBundleToResourceNDJSON_NoEntries() {

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -1047,20 +1047,15 @@ func (s *WorkerTestSuite) TestFhirBundleToResourceNDJSON() {
 	b := fhirmodels.Bundle{Entries: entries}
 	beneID := "MBITEST"
 	acoID := "A9994"
-	benesWithDataCount := 0
 
-	fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./", &benesWithDataCount)
-	assert.Equal(s.T(), 1, benesWithDataCount)
+	hasEntries := fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./")
+	assert.True(s.T(), hasEntries)
 
 	_, err = f.Seek(0, io.SeekStart)
 	assert.Nil(s.T(), err)
 	data, err := io.ReadAll(f)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "{\"test\":\"entry\"}\n{\"test2\":\"entry2\"}\n", string(data))
-
-	// test that we increment again with additional bene
-	fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./", &benesWithDataCount)
-	assert.Equal(s.T(), 2, benesWithDataCount)
 }
 
 func (s *WorkerTestSuite) TestFhirBundleToResourceNDJSON_NoEntries() {
@@ -1079,10 +1074,9 @@ func (s *WorkerTestSuite) TestFhirBundleToResourceNDJSON_NoEntries() {
 	b := fhirmodels.Bundle{Entries: entries}
 	beneID := "MBITEST"
 	acoID := "A9994"
-	entriesCount := 0
 
-	fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./", &entriesCount)
-	assert.Equal(s.T(), 0, entriesCount)
+	hasEntries := fhirBundleToResourceNDJSON(ctx, w, &b, "ExplanationOfBenefit", beneID, acoID, fileUUID, "./")
+	assert.False(s.T(), hasEntries)
 
 	_, err = f.Seek(0, io.SeekStart)
 	assert.Nil(s.T(), err)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10050

## 🛠 Changes

Fixed a few issues with how we are setting certain job related metrics.

## ℹ️ Context

We released these a few months ago to help with various job related data metrics collection and analysis.  Some of these were eventually seen as not working as intended.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
