### PR TITLE
BCDA-10243: Adjust file download loggers to be a bit more helpful

### DIFF
--- a/bcda/api/v1/api.go
+++ b/bcda/api/v1/api.go
@@ -275,18 +275,18 @@ func ServeData(w http.ResponseWriter, r *http.Request) {
 
 	logger := log.GetCtxLogger(r.Context())
 
-	// Check file exists
+	// Check job dir exists
 	rootPath := filepath.Join(dataDir, jobID)
 	rootDir, err := os.OpenRoot(rootPath)
 	if err != nil {
-		logger.WithField("resp_status", http.StatusNotFound).Errorf("file not found: %s", err)
+		logger.WithField("resp_status", http.StatusNotFound).Errorf("job dir not found: %s", err)
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
 
+	// Check file exists
 	defer rootDir.Close()
 	filePath := filepath.Join(rootPath, fileName)
-
 	if _, err := rootDir.Stat(fileName); errors.Is(err, os.ErrNotExist) {
 		logger.WithField("resp_status", http.StatusNotFound).Errorf("file not found: %s", err)
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -371,6 +371,18 @@ func (s *APITestSuite) TestServeData() {
 	wd, _ := os.Getwd()
 	conf.SetEnv(s.T(), "FHIR_PAYLOAD_DIR", wd+"/shared_files/gzip_feature_test/")
 
+	// set up dir named "1" to simulate job id 1, then copy test ndjson files into it
+	err = os.MkdirAll(conf.GetEnv("FHIR_PAYLOAD_DIR")+"/1", 0755)
+	if err != nil {
+		s.T().FailNow()
+	}
+	srcFS := os.DirFS(conf.GetEnv("FHIR_PAYLOAD_DIR"))
+	err = os.CopyFS(conf.GetEnv("FHIR_PAYLOAD_DIR")+"/1", srcFS)
+	if err != nil {
+		fmt.Printf("Error copying directory: %v\n", err)
+		return
+	}
+
 	defer func() {
 		err = os.Chdir(origDir)
 		if err != nil {
@@ -381,26 +393,29 @@ func (s *APITestSuite) TestServeData() {
 		name         string
 		headers      []string
 		gzipExpected bool
+		jobID        string
 		fileName     string
 		validFile    bool
 		respStatus   int
 	}{
-		{"no-header-gzip-encoded", []string{""}, false, "test_gzip_encoded.ndjson", true, http.StatusOK},
-		{"yes-header-gzip-encoded", []string{"gzip"}, true, "test_gzip_encoded.ndjson", true, http.StatusOK},
-		{"yes-header-not-encoded", []string{"gzip"}, true, "test_no_encoding.ndjson", true, http.StatusOK},
-		{"bad file name", []string{""}, false, "not_a_real_file", false, http.StatusNotFound},
-		{"file doesn't exist", []string{"gzip"}, true, "foo.ndjson", false, http.StatusNotFound},
-		{"single byte file", []string{""}, false, "single_byte_file.bin", false, http.StatusInternalServerError},
-		{"no-header-corrupt-file", []string{""}, false, "corrupt_gz_file.ndjson", false, http.StatusInternalServerError}, //This file is kind of cool. has magic number, but otherwise arbitrary data.
+		{"no-header-gzip-encoded", []string{""}, false, "1", "test_gzip_encoded.ndjson", true, http.StatusOK},
+		{"yes-header-gzip-encoded", []string{"gzip"}, true, "1", "test_gzip_encoded.ndjson", true, http.StatusOK},
+		{"yes-header-not-encoded", []string{"gzip"}, true, "1", "test_no_encoding.ndjson", true, http.StatusOK},
+		{"bad file name", []string{""}, false, "1", "not_a_real_file", false, http.StatusNotFound},
+		{"bad job dir", []string{""}, false, "x", "test_gzip_encoded.ndjson", false, http.StatusNotFound},
+		{"file doesn't exist", []string{"gzip"}, true, "1", "foo.ndjson", false, http.StatusNotFound},
+		{"single byte file", []string{""}, false, "1", "single_byte_file.bin", false, http.StatusInternalServerError},
+		{"no-header-corrupt-file", []string{""}, false, "1", "corrupt_gz_file.ndjson", false, http.StatusInternalServerError}, //This file is kind of cool. has magic number, but otherwise arbitrary data.
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			defer s.SetupTest()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/data/%s", tt.fileName), nil)
+			req := httptest.NewRequest("GET", fmt.Sprintf("/data/%s/%s", tt.jobID, tt.fileName), nil)
 
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("fileName", tt.fileName)
+			rctx.URLParams.Add("jobID", tt.jobID)
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 			var useGZIP bool

--- a/bcda/api/v1/api_test.go
+++ b/bcda/api/v1/api_test.go
@@ -372,15 +372,14 @@ func (s *APITestSuite) TestServeData() {
 	conf.SetEnv(s.T(), "FHIR_PAYLOAD_DIR", wd+"/shared_files/gzip_feature_test/")
 
 	// set up dir named "1" to simulate job id 1, then copy test ndjson files into it
-	err = os.MkdirAll(conf.GetEnv("FHIR_PAYLOAD_DIR")+"/1", 0755)
-	if err != nil {
-		s.T().FailNow()
-	}
-	srcFS := os.DirFS(conf.GetEnv("FHIR_PAYLOAD_DIR"))
-	err = os.CopyFS(conf.GetEnv("FHIR_PAYLOAD_DIR")+"/1", srcFS)
-	if err != nil {
-		fmt.Printf("Error copying directory: %v\n", err)
-		return
+	jobDir := conf.GetEnv("FHIR_PAYLOAD_DIR") + "/1"
+	s.Require().NoError(os.MkdirAll(jobDir, 0755))
+	s.T().Cleanup(func() { os.RemoveAll(jobDir) })
+	fixtures := []string{"test_gzip_encoded.ndjson", "test_no_encoding.ndjson", "single_byte_file.bin", "corrupt_gz_file.ndjson"}
+	for _, name := range fixtures {
+		b, err := os.ReadFile(conf.GetEnv("FHIR_PAYLOAD_DIR") + "/" + name)
+		s.Require().NoError(err)
+		s.Require().NoError(os.WriteFile(jobDir+"/"+name, b, 0600))
 	}
 
 	defer func() {

--- a/bcdaworker/queueing/manager.go
+++ b/bcdaworker/queueing/manager.go
@@ -61,15 +61,15 @@ func validateJob(ctx context.Context, cfg ValidateJobConfig) (*models.Job, error
 
 	if goerrors.Is(err, worker.ErrParentJobCancelled) {
 		// ACK the job because we do not need to work on queue jobs associated with a cancelled parent job
-		cfg.Logger.Warnf("QJob %d associated with a cancelled parent Job %d. Removing job from queue.", cfg.Args.ID, cfg.JobID)
+		cfg.Logger.Warnf("QJob %d associated with a cancelled parent Job %d. Removing job from queue.", cfg.QJobID, cfg.JobID)
 		return nil, nil, true
 	} else if goerrors.Is(err, worker.ErrParentJobFailed) {
 		// ACK the job because we do not need to work on queue jobs associated with a failed parent job
-		cfg.Logger.Warnf("QJob %d associated with a failed parent Job %d. Removing job from queue.", cfg.Args.ID, cfg.JobID)
+		cfg.Logger.Warnf("QJob %d associated with a failed parent Job %d. Removing job from queue.", cfg.QJobID, cfg.JobID)
 		return nil, nil, true
 	} else if goerrors.Is(err, worker.ErrNoBasePathSet) {
 		// Data is corrupted, we cannot work on this job.
-		cfg.Logger.Warnf("QJob %d does not contain valid base path. Removing job from queue.", cfg.JobID)
+		cfg.Logger.Warnf("QJob %d does not contain valid base path. Removing job from queue.", cfg.QJobID)
 		return nil, nil, true
 	} else if goerrors.Is(err, worker.ErrParentJobNotFound) {
 		// Based on the current backoff delay (j.ErrorCount^4 + 3 seconds), this should've given

--- a/bcdaworker/queueing/manager.go
+++ b/bcdaworker/queueing/manager.go
@@ -89,7 +89,7 @@ func validateJob(ctx context.Context, cfg ValidateJobConfig) (*models.Job, error
 
 		return nil, errors.Wrap(repository.ErrJobNotFound, "could not retrieve job from database"), false
 	} else if goerrors.Is(err, worker.ErrQueJobProcessed) {
-		cfg.Logger.Warnf("QJob %d already processed for parent Job: %d. Checking completion status and removing job from queue.", cfg.Args.ID, cfg.JobID)
+		cfg.Logger.Warnf("QJob %d already processed for parent Job: %d. Checking completion status and removing job from queue.", cfg.QJobID, cfg.JobID)
 
 		u, err := safecast.ToUint(cfg.JobID)
 		if err != nil {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10243

## 🛠 Changes

Pretty minor logger updates to be a bit more helpful.  Slight adjustment to unit-test to verify function logic.

## ℹ️ Context

Part of investigating some issues with file download returning 404s lead me to notice some areas for improvement.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
