### PR TITLE
BCDA-10246: Fix test attribution workflow

### DIFF
--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   refresh_attribution:
     name: Refresh Attribution
-    runs-on: codebuild-bcda-app${{ contains(fromJSON('["dev"]'), matrix.env) && '-non-prod' || ''}}-${{github.run_id}}-${{github.run_attempt}} 
+    runs-on: codebuild-bcda-app-${{ contains(fromJSON('["prod", "sandbox"]'), matrix.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
     strategy:
       matrix:
         vars:

--- a/.github/workflows/refresh_test_attribution.yml
+++ b/.github/workflows/refresh_test_attribution.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   refresh_attribution:
     name: Refresh Attribution
-    runs-on: codebuild-bcda-app-${{ contains(fromJSON('["prod", "sandbox"]'), matrix.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-${{ contains(fromJSON('["prod", "sandbox"]'), matrix.vars.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
     strategy:
       matrix:
         vars:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10246

## 🛠 Changes

Update codebuild runner name.

## ℹ️ Context

Various tests were failing due to attribution files being out of date.  This ended up being caused by the automated workflow getting stuck in queued as there were no runners available because they were misnamed.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Successful run: https://github.com/CMSgov/bcda-app/actions/runs/28953195922
