### PR TITLE
Return after responding for an expired or archived job in RequireTokenJobMatch

### DIFF
--- a/bcda/auth/middleware.go
+++ b/bcda/auth/middleware.go
@@ -270,6 +270,7 @@ func (m AuthMiddleware) RequireTokenJobMatch(db *sql.DB) func(next http.Handler)
 					logrus.Fields{"resp_status": http.StatusNotFound},
 				)
 				rw.NotFound(log.NewStructuredLoggerEntry(log.Auth, ctx), w, http.StatusNotFound, responseutils.JobExpiredErr, "")
+				return
 			}
 
 			// ACO did not create the job

--- a/bcda/auth/middleware_test.go
+++ b/bcda/auth/middleware_test.go
@@ -479,7 +479,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchExpiredJob() {
 	archivedJob := models.Job{
 		ACOID:      uuid.Parse(constants.TestACOID),
 		RequestURL: constants.V1Path + constants.EOBExportPath,
-		Status:     models.JobStatusExpired,
+		Status:     models.JobStatusArchived,
 	}
 
 	postgrestest.CreateJobs(s.T(), s.db, &expiredJob)
@@ -506,14 +506,20 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchExpiredJob() {
 		{"Archive Job", archivedJobID, archivedJob.ACOID.String(), http.StatusNotFound},
 	}
 
+	// Sentinel handler so we can assert the request never reaches the
+	// downstream handler for an expired or archived job.
+	nextCalled := false
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { nextCalled = true })
+
 	p := auth.NewProvider(s.db)
 	am := auth.NewAuthMiddleware(p)
-	handler := am.RequireTokenJobMatch(s.db)(mockHandler)
+	handler := am.RequireTokenJobMatch(s.db)(sentinel)
 	server := s.CreateServer(p)
 	defer server.Close()
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
+			nextCalled = false
 			s.rr = httptest.NewRecorder()
 			rctx := chi.NewRouteContext()
 			rctx.URLParams.Add("jobID", tt.jobID)
@@ -527,6 +533,7 @@ func (s *MiddlewareTestSuite) TestRequireTokenJobMatchExpiredJob() {
 			req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
 			handler.ServeHTTP(s.rr, req)
 			assert.Equal(s.T(), tt.errCode, s.rr.Code)
+			assert.False(t, nextCalled, "downstream handler must not run for an expired or archived job")
 		})
 	}
 }


### PR DESCRIPTION
The expired/archived branch of `RequireTokenJobMatch` writes a 404 but is missing a `return`:

```go
if job.Status == models.JobStatusExpired || job.Status == models.JobStatusArchived {
    ctx, _ = log.WriteWarnWithFields(...)
    rw.NotFound(..., http.StatusNotFound, responseutils.JobExpiredErr, "")
}   // no return

// ACO did not create the job
if !strings.EqualFold(ad.ACOID, job.ACOID.String()) { ... return }
next.ServeHTTP(w, r)
```

Every other error branch in this function returns after responding (no-auth-data, job-not-found, ACO-mismatch). This one does not, so for a caller requesting their **own** expired/archived job the ACO check passes (same ACO) and `next.ServeHTTP` runs the real handler after the 404 was already written. The result is a "superfluous response.WriteHeader" condition, a corrupted response body (the JobExpiredErr OperationOutcome followed by the handler output), and the intended expired/archived denial is defeated.

This is not a cross-tenant issue (the ACO check still runs, so another ACO's expired job is still rejected), which is why it is a plain correctness fix. Impact is confined to a caller's own expired/archived jobs.

Fix: add the missing `return`.

I also strengthened `TestRequireTokenJobMatchExpiredJob`: its `archivedJob` fixture was created with `JobStatusExpired` (copy-paste), so the "Archive Job" case never exercised the archived branch, and it used a no-op handler so the fall-through was invisible (`httptest.ResponseRecorder.Code` locks on the first `WriteHeader`). It now sets `JobStatusArchived` and uses a sentinel handler, asserting the downstream handler is never reached.

Note: this middleware test needs a Postgres test database (`postgrestest.CreateJobs`), which I could not stand up locally, so I verified the change compiles (`go vet ./auth/`) and relied on CI to run the DB-backed suite. Happy to open a JIRA ticket if the team prefers.
