### PR TITLE
BCDA-10209: Remove datadog profiling for now

### DIFF
--- a/bcda/lambda/attribution-import/main.go
+++ b/bcda/lambda/attribution-import/main.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/dd-trace-go/v2/profiler"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,9 +15,7 @@ import (
 
 	bcdaaws "github.com/CMSgov/bcda-app/bcda/aws"
 	"github.com/CMSgov/bcda-app/bcda/cclf"
-	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
-	"github.com/CMSgov/bcda-app/log"
 	"github.com/CMSgov/bcda-app/optout"
 
 	"github.com/CMSgov/bcda-app/conf"
@@ -29,16 +26,6 @@ import (
 )
 
 func main() {
-	err := profiler.Start(
-		profiler.WithService("BCDA Attribution Import"),
-		profiler.WithEnv(conf.GetEnv("ENV")),
-		profiler.WithVersion(constants.Version),
-	)
-	if err != nil {
-		log.API.Warn(err)
-	}
-	defer profiler.Stop()
-
 	lambda.Start(attributionImportHandler)
 }
 

--- a/bcda/lambda/optout/main.go
+++ b/bcda/lambda/optout/main.go
@@ -8,18 +8,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/dd-trace-go/v2/profiler"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/sirupsen/logrus"
 
 	bcdaaws "github.com/CMSgov/bcda-app/bcda/aws"
-	"github.com/CMSgov/bcda-app/bcda/constants"
 	"github.com/CMSgov/bcda-app/bcda/database"
 	"github.com/CMSgov/bcda-app/bcda/models/postgres"
 	"github.com/CMSgov/bcda-app/bcda/suppression"
 	"github.com/CMSgov/bcda-app/bcda/utils"
-	"github.com/CMSgov/bcda-app/log"
 	"github.com/CMSgov/bcda-app/optout"
 
 	"github.com/CMSgov/bcda-app/conf"
@@ -32,16 +29,6 @@ import (
 )
 
 func main() {
-	err := profiler.Start(
-		profiler.WithService("BCDA Bene Prefs"),
-		profiler.WithEnv(conf.GetEnv("ENV")),
-		profiler.WithVersion(constants.Version),
-	)
-	if err != nil {
-		log.API.Warn(err)
-	}
-	defer profiler.Stop()
-
 	lambda.Start(optOutImportHandler)
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10209

## 🛠 Changes

Remove datadog profiling.

## ℹ️ Context

These were added wholesale throughout our services.  Lambdas apparently require a different and more custom set up.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
