### PR TITLE
BCDA-10269: dd alert (sandbox health check)

### DIFF
--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -196,3 +196,12 @@ rds:
   notify_no_data: true
   no_data_timeframe_minutes: 10
   timeframe: "last_10m"
+
+# -----------------------------------------------------------------------------
+# Health Check Synthetic Tests
+# -----------------------------------------------------------------------------
+health_check:
+  enabled: false
+  url: ""
+  max_response_time_ms: 1000
+  validates_json_path: []

--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -208,6 +208,3 @@ health_check:
   validates_json_path: []
   tick_every: 300
   min_failure_duration: 600
-  min_location_failed: 2
-  locations:
-    - "aws:us-gov-west-1"

--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -41,6 +41,7 @@ shadow_mode: false
 # -----------------------------------------------------------------------------
 notifications:
   victorops: true
+  slack: true
   channels:
     - "@bcda-alerts"
 

--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -205,3 +205,8 @@ health_check:
   url: ""
   max_response_time_ms: 1000
   validates_json_path: []
+  tick_every: 1800
+  min_failure_duration: 3600
+  min_location_failed: 2
+  locations:
+    - "aws:us-gov-west-1"

--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -206,8 +206,8 @@ health_check:
   url: ""
   max_response_time_ms: 1000
   validates_json_path: []
-  tick_every: 1800
-  min_failure_duration: 3600
+  tick_every: 300
+  min_failure_duration: 600
   min_location_failed: 2
   locations:
     - "aws:us-gov-west-1"

--- a/ops/services/40-datadog-monitors/config/sandbox.yml
+++ b/ops/services/40-datadog-monitors/config/sandbox.yml
@@ -10,3 +10,13 @@ enabled:
   lambda: true
   s3: true
   rds: true
+  synthetics: true
+
+health_check:
+  enabled: true
+  url: "https://sandbox.bcda.cms.gov/_health"
+  max_response_time_ms: 1000
+  validates_json_path:
+    - database
+    - ssas
+    - ssas_introspect

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -103,7 +103,7 @@ module "datadog_synthetics" {
 # Common Monitors
 
 module "common_datadog_monitors" {
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=6ded520857376f46bb317dca898e5df6a9ecc93b"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=14ce90093bd0487d62bcb155b871b42bf7650f74"
 
   app              = "bcda"
   env              = local.env

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -52,7 +52,7 @@ module "platform" {
 
 module "datadog_synthetics" {
   count  = local.has_health_check ? 1 : 0
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=main"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=14ce90093bd0487d62bcb155b871b42bf7650f74"
 
   app = "bcda"
   env = local.env

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -27,10 +27,16 @@ locals {
     local.defaults.notifications.channels,
     local._env_channels != null ? local._env_channels : []
   ))
+
+  health_check_config = merge(
+    lookup(local.defaults, "health_check", {}),
+    lookup(local.env_config, "health_check", {})
+  )
+  has_health_check = try(local.health_check_config.enabled, false) && length(try(local.health_check_config.validates_json_path, [])) > 0
 }
 
 # Use platform module to derive datadog keys via ssm_root_map
-# Can be replaced with direct data lookups 
+# Can be replaced with direct data lookups
 module "platform" {
   source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=6ded520857376f46bb317dca898e5df6a9ecc93b"
   providers = { aws = aws, aws.secondary = aws.secondary }
@@ -42,14 +48,65 @@ module "platform" {
   ssm_root_map = { datadog = "/bcda/${local.env}/datadog/cicd/" }
 }
 
-###################
-# Common Monitors #
-###################
+# Synthetics Tests
+
+module "datadog_synthetics" {
+  count  = local.has_health_check ? 1 : 0
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=main"
+
+  app = "bcda"
+  env = local.env
+
+  tests = {
+    health_check = {
+      name    = "Health Check"
+      type    = "api"
+      subtype = "http"
+      status  = "live"
+
+      request_definition = {
+        method = "GET"
+        url    = local.health_check_config.url
+      }
+
+      assertions = concat(
+        [
+          {
+            type     = "responseTime"
+            operator = "lessThan"
+            target   = tostring(lookup(local.health_check_config, "max_response_time_ms", 1000))
+          },
+          {
+            type     = "statusCode"
+            operator = "is"
+            target   = "200"
+          }
+        ],
+        [
+          for field in try(local.health_check_config.validates_json_path, []) : {
+            type     = "body"
+            operator = "validatesJSONPath"
+            targetjsonpath = {
+              jsonpath    = "$.${field}"
+              operator    = "contains"
+              targetvalue = "ok"
+            }
+          }
+        ]
+      )
+
+      tick_every = 1800
+    }
+  }
+}
+
+# Common Monitors
 
 module "common_datadog_monitors" {
   source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=6ded520857376f46bb317dca898e5df6a9ecc93b"
 
-  app            = "bcda"
-  env            = local.env
-  monitor_config = local.monitor_config
+  app              = "bcda"
+  env              = local.env
+  monitor_config   = local.monitor_config
+  synthetics_tests = local.has_health_check ? module.datadog_synthetics[0].synthetics_tests : []
 }

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -98,8 +98,6 @@ module "datadog_synthetics" {
 
       tick_every           = lookup(local.health_check_config, "tick_every", 1800)
       min_failure_duration = lookup(local.health_check_config, "min_failure_duration", 3600)
-      min_location_failed  = lookup(local.health_check_config, "min_location_failed", 2)
-      locations            = lookup(local.health_check_config, "locations", null)
     }
   ]
 }

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -54,9 +54,10 @@ module "datadog_synthetics" {
   count  = local.has_health_check ? 1 : 0
   source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=ea161d6a00e729690a495d30c4d57d0d2990d0a6"
 
-  app    = "bcda"
-  env    = local.env
-  notify = module.common_datadog_monitors.notify
+  app                  = "bcda"
+  env                  = local.env
+  notify               = module.common_datadog_monitors.notify
+  min_failure_duration = lookup(local.health_check_config, "min_failure_duration", 0)
 
   tests = [
     {

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -38,7 +38,7 @@ locals {
 # Use platform module to derive datadog keys via ssm_root_map
 # Can be replaced with direct data lookups
 module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=6ded520857376f46bb317dca898e5df6a9ecc93b"
+  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=ea161d6a00e729690a495d30c4d57d0d2990d0a6"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app          = "bcda"
@@ -52,7 +52,7 @@ module "platform" {
 
 module "datadog_synthetics" {
   count  = local.has_health_check ? 1 : 0
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=6d0df984bf9bb54b721ae5af329765c6a0e80a43"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=ea161d6a00e729690a495d30c4d57d0d2990d0a6"
 
   app    = "bcda"
   env    = local.env
@@ -105,7 +105,7 @@ module "datadog_synthetics" {
 # Common Monitors
 
 module "common_datadog_monitors" {
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=6d0df984bf9bb54b721ae5af329765c6a0e80a43"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=ea161d6a00e729690a495d30c4d57d0d2990d0a6"
 
   app            = "bcda"
   env            = local.env

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -52,13 +52,14 @@ module "platform" {
 
 module "datadog_synthetics" {
   count  = local.has_health_check ? 1 : 0
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=14ce90093bd0487d62bcb155b871b42bf7650f74"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_synthetics?ref=6d0df984bf9bb54b721ae5af329765c6a0e80a43"
 
-  app = "bcda"
-  env = local.env
+  app    = "bcda"
+  env    = local.env
+  notify = module.common_datadog_monitors.notify
 
-  tests = {
-    health_check = {
+  tests = [
+    {
       name    = "Health Check"
       type    = "api"
       subtype = "http"
@@ -95,18 +96,20 @@ module "datadog_synthetics" {
         ]
       )
 
-      tick_every = 1800
+      tick_every           = lookup(local.health_check_config, "tick_every", 1800)
+      min_failure_duration = lookup(local.health_check_config, "min_failure_duration", 3600)
+      min_location_failed  = lookup(local.health_check_config, "min_location_failed", 2)
+      locations            = lookup(local.health_check_config, "locations", null)
     }
-  }
+  ]
 }
 
 # Common Monitors
 
 module "common_datadog_monitors" {
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=14ce90093bd0487d62bcb155b871b42bf7650f74"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=6d0df984bf9bb54b721ae5af329765c6a0e80a43"
 
-  app              = "bcda"
-  env              = local.env
-  monitor_config   = local.monitor_config
-  synthetics_tests = local.has_health_check ? module.datadog_synthetics[0].synthetics_tests : []
+  app            = "bcda"
+  env            = local.env
+  monitor_config = local.monitor_config
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10269

## 🛠 Changes

- Add YAML-driven health check for sandbox environment
- Updated sandbox main.tf to parse YAML inputs and construct response time, status code, and `validatesJSONPath` assertions
- Use `common_datadog_monitors` to dispatch alerts

## ℹ️ Context

This work backports the health check synthetic test into OpenTofu using CDAP's shared `datadog_synthetics` and `datadog_monitors` helper modules.
