### PR TITLE
BCDA-10300: dd alerts

### DIFF
--- a/ops/services/40-datadog-monitors/config/dev.yml
+++ b/ops/services/40-datadog-monitors/config/dev.yml
@@ -5,3 +5,17 @@ enabled:
   lambda: true
   s3: true
   rds: true
+  synthetics: true
+
+notifications:
+  victorops: false
+  slack: true
+
+health_check:
+  enabled: true
+  url: "https://dev.bcda.cms.gov/_health"
+  max_response_time_ms: 1000
+  validates_json_path:
+    - database
+    - ssas
+    - ssas_introspect

--- a/ops/services/40-datadog-monitors/config/prod.yml
+++ b/ops/services/40-datadog-monitors/config/prod.yml
@@ -10,6 +10,16 @@ enabled:
   lambda: true
   s3: true
   rds: true
+  synthetics: true
+
+health_check:
+  enabled: true
+  url: "https://api.bcda.cms.gov/_health"
+  max_response_time_ms: 1000
+  validates_json_path:
+    - database
+    - ssas
+    - ssas_introspect
 
 static_site:
   enabled: true

--- a/ops/services/40-datadog-monitors/config/test.yml
+++ b/ops/services/40-datadog-monitors/config/test.yml
@@ -5,3 +5,17 @@ enabled:
   lambda: true
   s3: true
   rds: true
+  synthetics: true
+
+notifications:
+  victorops: false
+  slack: true
+
+health_check:
+  enabled: true
+  url: "https://test.bcda.cms.gov/_health"
+  max_response_time_ms: 1000
+  validates_json_path:
+    - database
+    - ssas
+    - ssas_introspect

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -81,7 +81,7 @@ locals {
 
         tick_every           = lookup(local.health_check_config, "tick_every", 1800)
         min_failure_duration = lookup(local.health_check_config, "min_failure_duration", 3600)
-        tags                 = ["service:bcda"]
+        tags                 = ["team:bcda", "service:bcda"]
       }
     ] : [],
     local.has_static_site ? [
@@ -117,7 +117,7 @@ locals {
 
         tick_every           = lookup(local.static_site_config, "tick_every", 300)
         min_failure_duration = lookup(local.static_site_config, "min_failure_duration", 600)
-        tags                 = ["service:bcda"]
+        tags                 = ["team:bcda", "service:bcda"]
       }
     ] : []
   )

--- a/ops/services/40-datadog-monitors/main.tf
+++ b/ops/services/40-datadog-monitors/main.tf
@@ -86,7 +86,7 @@ locals {
     ] : [],
     local.has_static_site ? [
       {
-        name    = "Static Site Prod Monitor"
+        name    = "Static Site Monitor"
         type    = "api"
         subtype = "http"
         status  = "live"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10300

## 🛠 Changes

- Added `team` tag for easy filtering in DD GUI
- Enabled API health check in production/test/dev
- Remove hardcoded environment from static site test
- Disable VictorOps webhook for dev and test (only Slack alerts)

## ℹ️ Context

We are adding additional synthetic alerts in DataDog for the production API

## 🧪 Validation

Ran `tofu plan` and validated output.
