### PR TITLE
BCDA-10319: Fix error file download 404s

### DIFF
--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -391,6 +391,9 @@ func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.A
 	(*pr).BenesRetrievedPercent = benesRetrievedPercent
 	(*pr).BenesWithData = benesWithDataCount
 
+	// we create/append OpOutcomes into an error file whenever we either dont find data in BFD or there was some other error
+	// we compare total benes for the subjob to benesRetrievedCount as the latter accounts for both above situations.
+	// we need to then make sure that we are creating a job key for that error file to make sure that clients can download that file later on.
 	if benesRetrievedCount < len(jobArgs.BeneficiaryIDs) {
 		jobKeys = append(jobKeys, models.JobKey{JobID: id, QueJobID: &queJobID, FileName: fileUUID + "-error.ndjson", ResourceType: jobArgs.ResourceType})
 	}

--- a/bcdaworker/worker/worker.go
+++ b/bcdaworker/worker/worker.go
@@ -391,7 +391,7 @@ func writeBBDataToFile(ctx context.Context, r repository.Repository, bb client.A
 	(*pr).BenesRetrievedPercent = benesRetrievedPercent
 	(*pr).BenesWithData = benesWithDataCount
 
-	if errorCount > 0 {
+	if benesRetrievedCount < len(jobArgs.BeneficiaryIDs) {
 		jobKeys = append(jobKeys, models.JobKey{JobID: id, QueJobID: &queJobID, FileName: fileUUID + "-error.ndjson", ResourceType: jobArgs.ResourceType})
 	}
 	return jobKeys, nil

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -451,22 +451,29 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {
 	defer conf.SetEnv(s.T(), "EXPORT_FAIL_PCT", origFailPct)
 	conf.SetEnv(s.T(), "EXPORT_FAIL_PCT", "100")
 
-	bbc := client.MockBlueButtonClient{}
-	bbc.On("GetPatientByMbi", mock.AnythingOfType("string")).Return("", &bcdaErrs.RequestedBeneficiaryNotFoundError{Msg: "patient identifier not found for MBI"})
-
-	badMBIs := []string{"ab000000001", "ab000000002"}
+	mbis := []string{"a1000000001", "a1000000002", "a1000000008", "a1000000009"}
 	var cclfBeneficiaryIDs []string
-	for i := 0; i < len(badMBIs); i++ {
-		mbi := badMBIs[i]
+	for i := 0; i < len(mbis); i++ {
+		mbi := mbis[i]
 		cclfBeneficiary := models.CCLFBeneficiary{FileID: s.cclfFile.ID, MBI: mbi, BlueButtonID: ""}
 		postgrestest.CreateCCLFBeneficiary(s.T(), s.db, &cclfBeneficiary)
 		cclfBeneficiaryIDs = append(cclfBeneficiaryIDs, strconv.FormatUint(uint64(cclfBeneficiary.ID), 10))
 	}
 
+	bbc := client.MockBlueButtonClient{}
+	// good mbis (return found bene)
+	bbc.On("GetPatientByMbi", "a1000000001").Return(bbc.GetData("Patient", "a1000000001"))
+	bbc.On("GetPatientByMbi", "a1000000002").Return(bbc.GetData("Patient", "a1000000002"))
+	// bad mbis (return not found)
+	bbc.On("GetPatientByMbi", "a1000000008").Return("", &bcdaErrs.RequestedBeneficiaryNotFoundError{Msg: "patient identifier not found for MBI"})
+	bbc.On("GetPatientByMbi", "a1000000009").Return("", &bcdaErrs.RequestedBeneficiaryNotFoundError{Msg: "patient identifier not found for MBI"})
+
 	jobArgs := worker_types.JobEnqueueArgs{ID: s.jobID, ResourceType: "ExplanationOfBenefit", BeneficiaryIDs: cclfBeneficiaryIDs, TransactionTime: time.Now(), ACOID: s.testACO.UUID.String()}
 	jobKeys, err := writeBBDataToFile(s.logctx, s.r, &bbc, *s.testACO.CMSID, testUtils.CryptoRandInt63(), jobArgs, s.tempDir)
-	assert.Len(s.T(), jobKeys, 1)
+
+	assert.Len(s.T(), jobKeys, 2)
 	assert.Equal(s.T(), jobKeys[0].FileName, "blank.ndjson")
+	assert.Contains(s.T(), "-error.ndjson", jobKeys[1].FileName)
 	assert.Nil(s.T(), err)
 
 	files, err := os.ReadDir(s.tempDir)

--- a/bcdaworker/worker/worker_test.go
+++ b/bcdaworker/worker/worker_test.go
@@ -473,7 +473,7 @@ func (s *WorkerTestSuite) TestWriteEOBDataToFile_BlueButtonIDNotFound() {
 
 	assert.Len(s.T(), jobKeys, 2)
 	assert.Equal(s.T(), jobKeys[0].FileName, "blank.ndjson")
-	assert.Contains(s.T(), "-error.ndjson", jobKeys[1].FileName)
+	assert.Contains(s.T(), jobKeys[1].FileName, "-error.ndjson")
 	assert.Nil(s.T(), err)
 
 	files, err := os.ReadDir(s.tempDir)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10319

## 🛠 Changes

Fix bug where certain issues from the response of finding a bene in BFD would not create an error file job key record.

## ℹ️ Context

Incident on 8-3-26 involving clients reporting that they were getting 404s when trying to download error files.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and testing.
