### PR TITLE
BCDA-9638: smoke test rate limiting

### DIFF
--- a/bcda/service/config.go
+++ b/bcda/service/config.go
@@ -153,6 +153,8 @@ func (cfg *Config) IsSupportedACO(cmsID string) bool {
 	return false
 }
 
+var testACORegex = regexp.MustCompile(`^(TEST\d{3}|A999\d|A888\d|D999\d|E999\d|V994|T8882)$`)
+
 // IsTestACO determines if the specified CMS ID belongs to a test ACO.
 func (cfg *Config) IsTestACO(cmsID string) bool {
 	if cmsID == "" {
@@ -172,7 +174,6 @@ func (cfg *Config) IsTestACO(cmsID string) bool {
 			}
 		}
 	}
-	testACORegex := regexp.MustCompile(`^(TEST\d{3}|A999\d|A888\d|D999\d|E999\d|V994|T8882)$`)
 	return testACORegex.MatchString(cmsID)
 }
 

--- a/bcda/service/config.go
+++ b/bcda/service/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/CMSgov/bcda-app/conf"
@@ -150,6 +151,29 @@ func (cfg *Config) IsSupportedACO(cmsID string) bool {
 		}
 	}
 	return false
+}
+
+// IsTestACO determines if the specified CMS ID belongs to a test ACO.
+func (cfg *Config) IsTestACO(cmsID string) bool {
+	if cmsID == "" {
+		return false
+	}
+	if priorityACOPattern := conf.GetEnv("PRIORITY_ACO_REG_EX"); priorityACOPattern != "" {
+		if priorityACORegex, err := regexp.Compile(priorityACOPattern); err == nil {
+			if priorityACORegex.MatchString(cmsID) {
+				return true
+			}
+		}
+	}
+	if priorityACOIDs := conf.GetEnv("PRIORITY_ACO_IDS"); priorityACOIDs != "" {
+		for _, id := range strings.Split(priorityACOIDs, ",") {
+			if strings.TrimSpace(id) == cmsID {
+				return true
+			}
+		}
+	}
+	testACORegex := regexp.MustCompile(`^(TEST\d{3}|A999\d|A888\d|D999\d|E999\d|V994|T8882)$`)
+	return testACORegex.MatchString(cmsID)
 }
 
 // LookbackTime returns the timestamp that we should use as the lookback time associated with the ACO.

--- a/bcda/service/config_test.go
+++ b/bcda/service/config_test.go
@@ -380,8 +380,8 @@ func TestIsTestACO(t *testing.T) {
 		{"Real ACO C1234", "C1234", false, "", ""},
 		{"Real ACO D0005", "D0005", false, "", ""},
 		{"Real ACO GUIDE-0001", "GUIDE-0001", false, "", ""},
-		{"Priority ACO regex match", "A9996", true, "(^[A-Z]99([0-9]|9[0-9])$", ""},
-		{"Priority ACO list match", "E9994", true, "", "A9990,A9991,A9992,A9993,A9994,E9994,V994"},
+		{"Priority ACO regex match", "X9996", true, "^[A-Z]99([0-9]|9[0-9])$", ""},
+		{"Priority ACO list match", "X9994", true, "", "A9990,A9991,A9992,A9993,A9994,X9994,V994"},
 	}
 
 	for _, tt := range tests {

--- a/bcda/service/config_test.go
+++ b/bcda/service/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-app/bcda/constants"
+	"github.com/CMSgov/bcda-app/conf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -351,6 +352,43 @@ func TestSupportedACOs(t *testing.T) {
 		t.Run(tt.name, func(sub *testing.T) {
 			match := cfg.IsSupportedACO(tt.cmsID)
 			assert.Equal(sub, tt.isSupported, match)
+		})
+	}
+}
+
+func TestIsTestACO(t *testing.T) {
+	cfg := &Config{}
+
+	tests := []struct {
+		name        string
+		cmsID       string
+		isTestACO   bool
+		priorityEnv string
+		priorityIDs string
+	}{
+		{"Empty CMSID", "", false, "", ""},
+		{"Standard TEST ACO TEST001", "TEST001", true, "", ""},
+		{"Standard TEST ACO TEST994", "TEST994", true, "", ""},
+		{"Test ACO A9996", "A9996", true, "", ""},
+		{"Test ACO A9990", "A9990", true, "", ""},
+		{"Test ACO A8880", "A8880", true, "", ""},
+		{"Test ACO D9991", "D9991", true, "", ""},
+		{"Test ACO E9994", "E9994", true, "", ""},
+		{"Test ACO V994", "V994", true, "", ""},
+		{"Test ACO T8882", "T8882", true, "", ""},
+		{"Real ACO A1001", "A1001", false, "", ""},
+		{"Real ACO C1234", "C1234", false, "", ""},
+		{"Real ACO D0005", "D0005", false, "", ""},
+		{"Real ACO GUIDE-0001", "GUIDE-0001", false, "", ""},
+		{"Priority ACO regex match", "A9996", true, "(^[A-Z]99([0-9]|9[0-9])$", ""},
+		{"Priority ACO list match", "E9994", true, "", "A9990,A9991,A9992,A9993,A9994,E9994,V994"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(sub *testing.T) {
+			conf.SetEnv(sub, "PRIORITY_ACO_REG_EX", tt.priorityEnv)
+			conf.SetEnv(sub, "PRIORITY_ACO_IDS", tt.priorityIDs)
+			assert.Equal(sub, tt.isTestACO, cfg.IsTestACO(tt.cmsID))
 		})
 	}
 }

--- a/bcda/web/middleware/ratelimit.go
+++ b/bcda/web/middleware/ratelimit.go
@@ -56,7 +56,7 @@ func (m RateLimitMiddleware) CheckConcurrentJobs(next http.Handler) http.Handler
 
 		acoID := uuid.Parse(ad.ACOID)
 
-		if shouldRateLimit(m.config.RateLimitConfig, ad.CMSID) {
+		if shouldRateLimit(m.config, ad.CMSID) {
 			pendingAndInProgressJobs, err := m.repository.GetJobs(ctx, acoID, models.JobStatusInProgress, models.JobStatusPending)
 			if err != nil {
 				ctx, _ = log.WriteErrorWithFields(
@@ -79,8 +79,11 @@ func (m RateLimitMiddleware) CheckConcurrentJobs(next http.Handler) http.Handler
 	})
 }
 
-func shouldRateLimit(config service.RateLimitConfig, cmsID string) bool {
-	if config.All || slices.Contains(config.ACOs, cmsID) {
+func shouldRateLimit(cfg *service.Config, cmsID string) bool {
+	if cfg != nil && cfg.IsTestACO(cmsID) {
+		return false
+	}
+	if cfg != nil && (cfg.RateLimitConfig.All || slices.Contains(cfg.RateLimitConfig.ACOs, cmsID)) {
 		return true
 	}
 	return false

--- a/bcda/web/middleware/ratelimit_test.go
+++ b/bcda/web/middleware/ratelimit_test.go
@@ -194,32 +194,3 @@ func (s *RateLimitMiddlewareTestSuite) TestShouldRateLimit() {
 		})
 	}
 }
-
-func TestShouldRateLimitStandalone(t *testing.T) {
-	cmsID := "MyFavoriteACO"
-	otherCMSID := "OtherCMSID"
-
-	tests := []struct {
-		name          string
-		cmsID         string
-		config        service.RateLimitConfig
-		expectedValue bool
-	}{
-		{"Apply rate limit for all requests", cmsID, service.RateLimitConfig{All: true, ACOs: []string{}}, true},
-		{"Apply rate limit for no requests", cmsID, service.RateLimitConfig{All: false, ACOs: []string{}}, false},
-		{"Apply rate limit for ACO in limit list", cmsID, service.RateLimitConfig{All: false, ACOs: []string{cmsID, otherCMSID}}, true},
-		{"Dont apply rate limit for ACO not in limit list", cmsID, service.RateLimitConfig{All: false, ACOs: []string{otherCMSID}}, false},
-		{"Bypass rate limit for test ACO A9996", "A9996", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
-		{"Bypass rate limit for test ACO TEST001", "TEST001", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
-		{"Bypass rate limit for test ACO A9990", "A9990", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
-		{"Bypass rate limit for test ACO TEST994", "TEST994", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(sub *testing.T) {
-			cfg := &service.Config{RateLimitConfig: tt.config}
-			actualValue := shouldRateLimit(cfg, tt.cmsID)
-			assert.Equal(sub, tt.expectedValue, actualValue, tt.name)
-		})
-	}
-}

--- a/bcda/web/middleware/ratelimit_test.go
+++ b/bcda/web/middleware/ratelimit_test.go
@@ -180,12 +180,46 @@ func (s *RateLimitMiddlewareTestSuite) TestShouldRateLimit() {
 		{"Apply rate limit for no requests", cmsID, service.RateLimitConfig{All: false, ACOs: []string{}}, false},
 		{"Apply rate limit for ACO in limit list", cmsID, service.RateLimitConfig{All: false, ACOs: []string{cmsID, otherCMSID}}, true},
 		{"Dont apply rate limit for ACO not in limit list", cmsID, service.RateLimitConfig{All: false, ACOs: []string{otherCMSID}}, false},
+		{"Bypass rate limit for test ACO A9996", "A9996", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+		{"Bypass rate limit for test ACO TEST001", "TEST001", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+		{"Bypass rate limit for test ACO A9990", "A9990", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+		{"Bypass rate limit for test ACO TEST994", "TEST994", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			actualValue := shouldRateLimit(tt.config, tt.cmsID)
+			cfg := &service.Config{RateLimitConfig: tt.config}
+			actualValue := shouldRateLimit(cfg, tt.cmsID)
 			assert.Equal(s.T(), tt.expectedValue, actualValue, tt.name)
+		})
+	}
+}
+
+func TestShouldRateLimitStandalone(t *testing.T) {
+	cmsID := "MyFavoriteACO"
+	otherCMSID := "OtherCMSID"
+
+	tests := []struct {
+		name          string
+		cmsID         string
+		config        service.RateLimitConfig
+		expectedValue bool
+	}{
+		{"Apply rate limit for all requests", cmsID, service.RateLimitConfig{All: true, ACOs: []string{}}, true},
+		{"Apply rate limit for no requests", cmsID, service.RateLimitConfig{All: false, ACOs: []string{}}, false},
+		{"Apply rate limit for ACO in limit list", cmsID, service.RateLimitConfig{All: false, ACOs: []string{cmsID, otherCMSID}}, true},
+		{"Dont apply rate limit for ACO not in limit list", cmsID, service.RateLimitConfig{All: false, ACOs: []string{otherCMSID}}, false},
+		{"Bypass rate limit for test ACO A9996", "A9996", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+		{"Bypass rate limit for test ACO TEST001", "TEST001", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+		{"Bypass rate limit for test ACO A9990", "A9990", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+		{"Bypass rate limit for test ACO TEST994", "TEST994", service.RateLimitConfig{All: true, ACOs: []string{}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(sub *testing.T) {
+			cfg := &service.Config{RateLimitConfig: tt.config}
+			actualValue := shouldRateLimit(cfg, tt.cmsID)
+			assert.Equal(sub, tt.expectedValue, actualValue, tt.name)
 		})
 	}
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9638

## 🛠 Changes

- Added `IsTestACO` helper to service config
- Updated `shouldRateLimit` to use `IsTestACO` and skip rate limiting for test ACOs
- Added unit tests

## ℹ️ Context

Because production configuration sets `rate_limit_config.all: true`, the rate-limiting middleware previously enforced concurrent job rate-limiting on all requests, including smoke test ACOs.
These changes bypass duplicate job rate-limiting checks, so smoke test runs without intermittent 429 failures.

## 🧪 Validation

Unit tests
