### PR TITLE
BCDA-10337: disable sqs monitors in prod

### DIFF
--- a/ops/services/40-datadog-monitors/config/prod.yml
+++ b/ops/services/40-datadog-monitors/config/prod.yml
@@ -5,7 +5,7 @@ lambda:
 
 enabled:
   ecs: true
-  sqs: true
+  sqs: false
   sns: false
   lambda: true
   s3: true


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10337

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

- disable sqs monitors in prod

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without the team security engineer's approval:
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

SQS monitors in prod were setting off false victorops alerts -- they should be temporarily disabled and evaluated in a lower environment.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Already applied in prod