### PR TITLE
BCDA-10217: delete attr files after 14 days

### DIFF
--- a/ops/services/30-attribution-import/main.tf
+++ b/ops/services/30-attribution-import/main.tf
@@ -135,22 +135,26 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   bucket = module.attribution-import_file_bucket.id
 
   rule {
-    id     = "delete_after_14_days"
+    id     = "delete-after-14-days"
     status = "Enabled"
 
     filter {}
 
-    # Turn current objects into noncurrent versions (creates a delete marker)
     expiration {
       days = 14
     }
 
-    # Delete historical versions after 14 days
     noncurrent_version_expiration {
       noncurrent_days = 14
     }
+  }
 
-    # Clean up expired delete markers
+  rule {
+    id     = "cleanup-expired-delete-markers"
+    status = "Enabled"
+
+    filter {}
+
     expiration {
       expired_object_delete_marker = true
     }

--- a/ops/services/30-attribution-import/main.tf
+++ b/ops/services/30-attribution-import/main.tf
@@ -135,7 +135,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   bucket = module.attribution-import_file_bucket.id
 
   rule {
-    id     = "delete-after-14-days"
+    id     = "delete-old-files"
     status = "Enabled"
 
     filter {}

--- a/ops/services/30-attribution-import/main.tf
+++ b/ops/services/30-attribution-import/main.tf
@@ -135,13 +135,24 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   bucket = module.attribution-import_file_bucket.id
 
   rule {
-    id     = "delete-old-files"
+    id     = "delete_after_14_days"
     status = "Enabled"
 
     filter {}
 
+    # Turn current objects into noncurrent versions (creates a delete marker)
     expiration {
       days = 14
+    }
+
+    # Delete historical versions after 14 days
+    noncurrent_version_expiration {
+      noncurrent_days = 14
+    }
+
+    # Clean up expired delete markers
+    expiration {
+      expired_object_delete_marker = true
     }
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10217

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

- fix attribution-import file bucket policy to properly delete failed-to-process files after 14 days

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without the team security engineer's approval:
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

The previous policy to delete files did not account for bucket versioning. Now, after 14 days, files marked for deletion are deleted.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
