### PR TITLE
BCDA-10138: header parsing

### DIFF
--- a/bcda/web/middleware/validation.go
+++ b/bcda/web/middleware/validation.go
@@ -356,15 +356,13 @@ func ValidateRequestHeaders(next http.Handler) http.Handler {
 		ctx := r.Context()
 		h := r.Header
 
-		acceptHeader := h.Get("Accept")
-		preferHeader := h.Get("Prefer")
-
 		rw, _ := getResponseWriterFromRequestPath(w, r)
 		if rw == nil {
 			return
 		}
 
-		if acceptHeader == "" {
+		acceptValues := parseHeaderValues(h, "Accept")
+		if len(acceptValues) == 0 {
 			ctx, _ = log.WriteWarnWithFields(
 				ctx,
 				fmt.Sprintf("%s: Accept header is required", responseutils.FormatErr),
@@ -372,17 +370,20 @@ func ValidateRequestHeaders(next http.Handler) http.Handler {
 			)
 			rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.FormatErr, "Accept header is required")
 			return
-		} else if acceptHeader != "application/fhir+json" {
+		}
+
+		if !hasHeaderToken(acceptValues, "application/fhir+json") {
 			ctx, _ = log.WriteWarnWithFields(
 				ctx,
-				fmt.Sprintf("%s: Application/fhir+json is the only supported response format", responseutils.FormatErr),
+				fmt.Sprintf("%s: application/fhir+json is the only supported response format", responseutils.FormatErr),
 				logrus.Fields{"resp_status": http.StatusBadRequest},
 			)
 			rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.FormatErr, "application/fhir+json is the only supported response format")
 			return
 		}
 
-		if preferHeader == "" {
+		preferValues := parseHeaderValues(h, "Prefer")
+		if len(preferValues) == 0 {
 			ctx, _ = log.WriteWarnWithFields(
 				ctx,
 				fmt.Sprintf("%s: Prefer header is required", responseutils.FormatErr),
@@ -390,7 +391,9 @@ func ValidateRequestHeaders(next http.Handler) http.Handler {
 			)
 			rw.OpOutcome(ctx, w, http.StatusBadRequest, responseutils.FormatErr, "Prefer header is required")
 			return
-		} else if preferHeader != "respond-async" {
+		}
+
+		if !hasHeaderToken(preferValues, "respond-async") {
 			ctx, _ = log.WriteWarnWithFields(
 				ctx,
 				fmt.Sprintf("%s: Only asynchronous responses are supported", responseutils.FormatErr),
@@ -402,6 +405,38 @@ func ValidateRequestHeaders(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// hasHeaderToken checks if targetToken exists within the parsed header values,
+// stripping optional parameters (anything after ';') and performing case-insensitive matching.
+func hasHeaderToken(values []string, targetToken string) bool {
+	for _, v := range values {
+		token, _, _ := strings.Cut(v, ";")
+		if strings.EqualFold(strings.TrimSpace(token), targetToken) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHeaderValues extracts all values from a header, handling both multi-line
+// header fields and comma-separated parameter lists within a single header value.
+// It returns a slice of trimmed tokens.
+func parseHeaderValues(h http.Header, headerName string) []string {
+	values := h.Values(headerName)
+	if len(values) == 0 {
+		return nil
+	}
+	results := make([]string, 0, len(values))
+	for _, rawValue := range values {
+		for _, part := range strings.Split(rawValue, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				results = append(results, trimmed)
+			}
+		}
+	}
+	return results
 }
 
 // validateSubqueryParameterList splits a comma-separated parameter value and validates each individual value

--- a/bcda/web/middleware/validation_test.go
+++ b/bcda/web/middleware/validation_test.go
@@ -123,20 +123,223 @@ func TestInvalidRequestURL(t *testing.T) {
 	}
 }
 
-func TestValidRequestHeaders(t *testing.T) {
-	ctx := context.Background()
-	ctx = log.NewStructuredLoggerEntry(logrus.New(), ctx)
-	req, err := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
-	assert.NoError(t, err)
+func TestParseHeaderValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    http.Header
+		headerName string
+		expected   []string
+	}{
+		{
+			name:       "singleValue",
+			headers:    http.Header{"Prefer": []string{constants.TestRespondAsync}},
+			headerName: "Prefer",
+			expected:   []string{constants.TestRespondAsync},
+		},
+		{
+			name:       "commaSeparatedValues",
+			headers:    http.Header{"Prefer": []string{constants.TestRespondAsync + ",handling=lenient"}},
+			headerName: "Prefer",
+			expected:   []string{constants.TestRespondAsync, "handling=lenient"},
+		},
+		{
+			name:       "whitespaceTrimmingAndEmptyTokens",
+			headers:    http.Header{"Prefer": []string{" " + constants.TestRespondAsync + " , , handling=lenient "}},
+			headerName: "Prefer",
+			expected:   []string{constants.TestRespondAsync, "handling=lenient"},
+		},
+		{
+			name:       "multiLineHeaders",
+			headers:    http.Header{"Prefer": []string{constants.TestRespondAsync, "handling=lenient"}},
+			headerName: "Prefer",
+			expected:   []string{constants.TestRespondAsync, "handling=lenient"},
+		},
+		{
+			name:       "missingHeader",
+			headers:    http.Header{},
+			headerName: "Prefer",
+			expected:   nil,
+		},
+	}
 
-	req = req.WithContext(ctx)
-	req.Header.Set("Accept", "application/fhir+json")
-	req.Header.Set("Prefer", constants.TestRespondAsync)
-
-	rr := httptest.NewRecorder()
-	ValidateRequestHeaders(noop).ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusOK, rr.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := parseHeaderValues(tt.headers, tt.headerName)
+			assert.Equal(t, tt.expected, results)
+		})
+	}
 }
+
+func TestHasHeaderToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		values      []string
+		targetToken string
+		expected    bool
+	}{
+		{
+			name:        "exactMatch",
+			values:      []string{"respond-async"},
+			targetToken: "respond-async",
+			expected:    true,
+		},
+		{
+			name:        "caseInsensitiveMatch",
+			values:      []string{"RESPOND-ASYNC"},
+			targetToken: "respond-async",
+			expected:    true,
+		},
+		{
+			name:        "withParameters",
+			values:      []string{"respond-async; wait=10"},
+			targetToken: "respond-async",
+			expected:    true,
+		},
+		{
+			name:        "mediaTypeWithParameters",
+			values:      []string{"application/fhir+json; charset=utf-8"},
+			targetToken: "application/fhir+json",
+			expected:    true,
+		},
+		{
+			name:        "multipleValuesMatch",
+			values:      []string{"handling=lenient", "respond-async"},
+			targetToken: "respond-async",
+			expected:    true,
+		},
+		{
+			name:        "noMatch",
+			values:      []string{"handling=lenient"},
+			targetToken: "respond-async",
+			expected:    false,
+		},
+		{
+			name:        "emptySlice",
+			values:      nil,
+			targetToken: "respond-async",
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasHeaderToken(tt.values, tt.targetToken))
+		})
+	}
+}
+
+func TestValidRequestHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupReq func() *http.Request
+	}{
+		{
+			name: "StandardHeaders",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json")
+				req.Header.Set("Prefer", constants.TestRespondAsync)
+				return req
+			},
+		},
+		{
+			name: "PreferCommaSeparatedDirectives",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json")
+				req.Header.Set("Prefer", constants.TestRespondAsync+",handling=lenient")
+				return req
+			},
+		},
+		{
+			name: "PreferWithParameters",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json")
+				req.Header.Set("Prefer", constants.TestRespondAsync+"; wait=10")
+				return req
+			},
+		},
+		{
+			name: "CaseInsensitiveHeaders",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "APPLICATION/FHIR+JSON")
+				req.Header.Set("Prefer", "RESPOND-ASYNC")
+				return req
+			},
+		},
+		{
+			name: "PreferReversedDirectives",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json")
+				req.Header.Set("Prefer", "handling=lenient, "+constants.TestRespondAsync)
+				return req
+			},
+		},
+		{
+			name: "PreferWhitespaceTolerance",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json")
+				req.Header.Set("Prefer", constants.TestRespondAsync+" , handling=lenient")
+				return req
+			},
+		},
+		{
+			name: "PreferMultiLineHeaders",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json")
+				req.Header.Add("Prefer", "handling=lenient")
+				req.Header.Add("Prefer", constants.TestRespondAsync)
+				return req
+			},
+		},
+		{
+			name: "AcceptCommaSeparatedMediaTypes",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json, application/json")
+				req.Header.Set("Prefer", constants.TestRespondAsync)
+				return req
+			},
+		},
+		{
+			name: "AcceptWithParameters",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Set("Accept", "application/fhir+json; charset=utf-8")
+				req.Header.Set("Prefer", constants.TestRespondAsync)
+				return req
+			},
+		},
+		{
+			name: "AcceptMultiLineHeaders",
+			setupReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/api/v1/Patient/$export", nil)
+				req.Header.Add("Accept", "application/json")
+				req.Header.Add("Accept", "application/fhir+json")
+				req.Header.Set("Prefer", constants.TestRespondAsync)
+				return req
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = log.NewStructuredLoggerEntry(logrus.New(), ctx)
+			req := tt.setupReq().WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			ValidateRequestHeaders(noop).ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
+}
+
 func TestInvalidRequestHeaders(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -146,8 +349,10 @@ func TestInvalidRequestHeaders(t *testing.T) {
 	}{
 		{"NoAcceptHeader", "", constants.TestRespondAsync, "Accept header is required"},
 		{"InvalidAcceptHeader", "invalid", constants.TestRespondAsync, "application/fhir+json is the only supported response format"},
+		{"UnsupportedAcceptHeader", "application/xml", constants.TestRespondAsync, "application/fhir+json is the only supported response format"},
 		{"NoPreferHeader", "application/fhir+json", "", "Prefer header is required"},
 		{"InvalidPreferHeader", "application/fhir+json", "invalid", "Only asynchronous responses are supported"},
+		{"PreferMissingRespondAsync", "application/fhir+json", "handling=lenient", "Only asynchronous responses are supported"},
 	}
 
 	for _, tt := range tests {
@@ -158,8 +363,12 @@ func TestInvalidRequestHeaders(t *testing.T) {
 			assert.NoError(t, err)
 
 			req = req.WithContext(ctx)
-			req.Header.Set("Accept", tt.acceptHeader)
-			req.Header.Set("Prefer", tt.preferHeader)
+			if tt.acceptHeader != "" {
+				req.Header.Set("Accept", tt.acceptHeader)
+			}
+			if tt.preferHeader != "" {
+				req.Header.Set("Prefer", tt.preferHeader)
+			}
 
 			rr := httptest.NewRecorder()
 			ValidateRequestHeaders(noop).ServeHTTP(rr, req)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10138

## 🛠 Changes

- Updated validator to properly parse `Prefer` and `Accept` headers.
  - It supports multi-line headers now.
  - Added case insensitivity to header parsing.
- Implemented `parseHeaderValues` helper to extract/trim/flatten header values (both multi-line and comma-separated).
- Implemented `hasHeaderToken` helper to strip optional header tokens.
- Minor log formatting and added unit tests.

## ℹ️ Context

Clients may send request headers using comma-separated lists, multi-line headers, or parameter metadata (such as `; charset=utf-8` or `; wait=10`). 

Previously, BCDA used exact string matching on single header lines (`h.Get()`), which caused valid HTTP requests containing additional directives, parameters, or uppercase characters to be rejected with `400 Bad Request`. The changes in this PR make BCDA's header validation robust and RFC-compliant while enforcing Bulk FHIR requirements (`application/fhir+json` and `respond-async`).

## 🧪 Validation

Added unit tests for newly implemented helpers. Updated existing validator tests to cover the new parsing logic.
