### PR TITLE
Temporarily disable default datadog lambda monitoring

### DIFF
--- a/ops/services/40-datadog-monitors/config/prod.yml
+++ b/ops/services/40-datadog-monitors/config/prod.yml
@@ -7,7 +7,7 @@ enabled:
   ecs: true
   sqs: false
   sns: false
-  lambda: true
+  lambda: false
   s3: true
   rds: true
   synthetics: true


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

- disable default monitors for lambdas (lambda throttling, lambda error rate, lambda duration)

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without the team security engineer's approval:
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

Default lambda monitors are triggering on-call alerts because they have no data. These monitors should be disabled in prod while they are investigated and properly configured in a lower environment first.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

<details>
<summary>TF Plan in prod</summary>

```

OpenTofu will perform the following actions:

  # module.common_datadog_monitors.datadog_monitor.lambda_duration[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "datadog_monitor" "lambda_duration" {
      - draft_status         = "published" -> null
      - evaluation_delay     = 0 -> null
      - id                   = "604050" -> null
      - include_tags         = true -> null
      - message              = "Lambda function {{functionname.name}} p99 duration is approaching its timeout threshold. {{#is_alert}}@webhook-victorops-bcda-critical{{/is_alert}}{{#is_warning}}@webhook-victorops-bcda-warning{{/is_warning}}{{#is_recovery}}@webhook-victorops-bcda-recovery{{/is_recovery}}{{#is_no_data}}@webhook-victorops-bcda-critical{{/is_no_data}} @webhook-slack-bcda" -> null
      - name                 = "[PROD] [bcda] Lambda — Duration Near Timeout" -> null
      - new_group_delay      = 0 -> null
      - new_host_delay       = 300 -> null
      - no_data_timeframe    = 10 -> null
      - notify_audit         = false -> null
      - notify_by            = [] -> null
      - notify_no_data       = true -> null
      - query                = "avg(last_10m):avg:aws.lambda.duration.p99{application:bcda,environment:prod} by {functionname} > 900000" -> null
      - renotify_interval    = 0 -> null
      - renotify_occurrences = 0 -> null
      - require_full_window  = true -> null
      - restricted_roles     = [] -> null
      - tags                 = [
          - "application:bcda",
          - "environment:prod",
          - "managed-by:tofu",
          - "shadow-mode:false",
        ] -> null
      - timeout_h            = 0 -> null
      - type                 = "metric alert" -> null

      - monitor_thresholds {
          - critical = "900000" -> null
          - warning  = "675000" -> null
        }
    }

  # module.common_datadog_monitors.datadog_monitor.lambda_error_rate[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "datadog_monitor" "lambda_error_rate" {
      - draft_status         = "published" -> null
      - evaluation_delay     = 0 -> null
      - id                   = "604045" -> null
      - include_tags         = true -> null
      - message              = "Lambda function {{functionname.name}} has a high error rate. {{#is_alert}}@webhook-victorops-bcda-critical{{/is_alert}}{{#is_warning}}@webhook-victorops-bcda-warning{{/is_warning}}{{#is_recovery}}@webhook-victorops-bcda-recovery{{/is_recovery}}{{#is_no_data}}@webhook-victorops-bcda-critical{{/is_no_data}} @webhook-slack-bcda" -> null
      - name                 = "[PROD] [bcda] Lambda — Error Rate High" -> null
      - new_group_delay      = 0 -> null
      - new_host_delay       = 300 -> null
      - notify_audit         = false -> null
      - notify_by            = [] -> null
      - notify_no_data       = false -> null
      - query                = "sum(last_10m):(sum:aws.lambda.errors{application:bcda,environment:prod} by {functionname} / sum:aws.lambda.invocations{application:bcda,environment:prod} by {functionname}) * 100 > 1" -> null
      - renotify_interval    = 0 -> null
      - renotify_occurrences = 0 -> null
      - require_full_window  = true -> null
      - restricted_roles     = [] -> null
      - tags                 = [
          - "application:bcda",
          - "environment:prod",
          - "managed-by:tofu",
          - "shadow-mode:false",
        ] -> null
      - timeout_h            = 0 -> null
      - type                 = "metric alert" -> null

      - monitor_thresholds {
          - critical = "1" -> null
          - warning  = "0" -> null
        }
    }

  # module.common_datadog_monitors.datadog_monitor.lambda_throttles[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "datadog_monitor" "lambda_throttles" {
      - draft_status         = "published" -> null
      - evaluation_delay     = 0 -> null
      - id                   = "604053" -> null
      - include_tags         = true -> null
      - message              = "Lambda function {{functionname.name}} is being throttled. {{#is_alert}}@webhook-victorops-bcda-critical{{/is_alert}}{{#is_warning}}@webhook-victorops-bcda-warning{{/is_warning}}{{#is_recovery}}@webhook-victorops-bcda-recovery{{/is_recovery}}{{#is_no_data}}@webhook-victorops-bcda-critical{{/is_no_data}} @webhook-slack-bcda" -> null
      - name                 = "[PROD] [bcda] Lambda — Throttles High" -> null
      - new_group_delay      = 0 -> null
      - new_host_delay       = 300 -> null
      - no_data_timeframe    = 10 -> null
      - notify_audit         = false -> null
      - notify_by            = [] -> null
      - notify_no_data       = true -> null
      - query                = "sum(last_10m):sum:aws.lambda.throttles{application:bcda,environment:prod} by {functionname} > 10" -> null
      - renotify_interval    = 0 -> null
      - renotify_occurrences = 0 -> null
      - require_full_window  = true -> null
      - restricted_roles     = [] -> null
      - tags                 = [
          - "application:bcda",
          - "environment:prod",
          - "managed-by:tofu",
          - "shadow-mode:false",
        ] -> null
      - timeout_h            = 0 -> null
      - type                 = "metric alert" -> null

      - monitor_thresholds {
          - critical = "10" -> null
          - warning  = "7" -> null
        }
    }

Plan: 0 to add, 0 to change, 3 to destroy.

```

</details>