### PR TITLE
BCDA-10309: datadog dashboard and alert adjustments

### DIFF
--- a/bcda/bcdacli/cli.go
+++ b/bcda/bcdacli/cli.go
@@ -97,7 +97,8 @@ func setUpApp() *cli.App {
 				fmt.Fprintf(app.Writer, "%s\n", "Starting bcda...")
 
 				err := profiler.Start(
-					profiler.WithService("BCDA"),
+					profiler.WithTags("application:bcda"),
+					profiler.WithService("api"),
 					profiler.WithEnv(os.Getenv("ENV")),
 					profiler.WithVersion(constants.Version),
 				)

--- a/bcdaworker/cli/cli.go
+++ b/bcdaworker/cli/cli.go
@@ -76,7 +76,8 @@ func startWorker() {
 	logger.Info("Starting bcdaworker...")
 
 	err := profiler.Start(
-		profiler.WithService("BCDA"),
+		profiler.WithTags("application:bcda"),
+		profiler.WithService("worker"),
 		profiler.WithEnv(os.Getenv("ENV")),
 		profiler.WithVersion(constants.Version),
 	)

--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -206,7 +206,7 @@ health_check:
   url: ""
   max_response_time_ms: 1000
   validates_json_path: []
-  tick_every: 300
+  tick_every: 150
   min_failure_duration: 600
 
 # -----------------------------------------------------------------------------

--- a/ops/services/40-datadog-monitors/config/defaults.yml
+++ b/ops/services/40-datadog-monitors/config/defaults.yml
@@ -206,7 +206,7 @@ health_check:
   url: ""
   max_response_time_ms: 1000
   validates_json_path: []
-  tick_every: 150
+  tick_every: 180
   min_failure_duration: 600
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10309

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- update health check monitor tick rate from 5 min > 3 min
- update APM tags to match pattern specified by CDAP (e.g. application:bcda, service:worker)

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without the team security engineer's approval:
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

For the health check, the current configuration is tickrate: 5 min, failure time: 10 min. This _seems_ to trigger relatively easily, with alerts (which sent on-call pages) off-and-on every once in a while that are immediately resolved.
There are a few ways to approach solving this:
- adding a retry function: it seems this is not currently supported by the CDAP synthetics module
- increasing the failure time: it's already set to a pretty conservative 10 minutes
- increasing the max response time: the max response time was the cause of many of the intermittent "failures" but 1s also seems reasonable for this check
- increasing the number of ticks: the chose solution, increasing from every 5 minutes to every 3 minutes; the intent here is that, like a retry function, we'll moderately increase the number of checks, filter out false failures, increasing the number of "failures" before alert without increasing the time required to trigger an alert 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Validated APM changes in datadog dashboard

<details>
<summary>tf plan in prod</summary>

```

OpenTofu will perform the following actions:

  # module.datadog_synthetics[0].datadog_synthetics_test.this["Health Check"] will be updated in-place
  ~ resource "datadog_synthetics_test" "this" {
        id               = "f82-hvy-rbz"
        name             = "bcda-prod-Health Check"
        tags             = [
            "application:bcda",
            "environment:prod",
            "managed-by:tofu",
            "shadow-mode:false",
            "team:bcda",
            "service:bcda",
        ]
        # (10 unchanged attributes hidden)

      ~ options_list {
          ~ tick_every                        = 300 -> 180
            # (19 unchanged attributes hidden)
        }

        # (6 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```

</details>